### PR TITLE
New cegis api

### DIFF
--- a/pizza-backend-sbv/package.yaml
+++ b/pizza-backend-sbv/package.yaml
@@ -20,6 +20,7 @@ dependencies:
 - sbv >= 8.11
 - template-haskell >= 2.16
 - deepseq >= 1.4.4
+- generic-deriving >= 1.14.1
 
 flags: {
   fast: {

--- a/pizza-backend-sbv/pizza-backend-sbv.cabal
+++ b/pizza-backend-sbv/pizza-backend-sbv.cabal
@@ -42,6 +42,7 @@ library
   build-depends:
       base >4.14 && <5
     , deepseq >=1.4.4
+    , generic-deriving >=1.14.1
     , hashable >=1.3
     , mtl >=2.2.2
     , pizza-core ==0.1.0.0
@@ -69,6 +70,7 @@ test-suite spec
   build-depends:
       base >4.14 && <5
     , deepseq >=1.4.4
+    , generic-deriving >=1.14.1
     , hashable >=1.3
     , mtl >=2.2.2
     , pizza-backend-sbv

--- a/pizza-backend-sbv/src/Pizza/Backend/SBV/Data/SMT/Solving.hs
+++ b/pizza-backend-sbv/src/Pizza/Backend/SBV/Data/SMT/Solving.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/pizza-core/src/Pizza/Core/Data/Class/Solver.hs
+++ b/pizza-core/src/Pizza/Core/Data/Class/Solver.hs
@@ -72,7 +72,7 @@ class
     r <-
       cegisFormulasVarInputs
         config
-        (\x -> if x == 0 then Just (IdGen foralls) else Nothing)
+        [IdGen foralls]
         []
         (\(_ :: IdGen forallArg) -> (assumption, assertion))
     case r of
@@ -82,7 +82,7 @@ class
     forall inputs spec.
     (ExtractSymbolics symbolSet inputs, EvaluateSym model inputs, GenSymSimple spec inputs) =>
     config ->
-    (Int -> Maybe spec) ->
+    [spec] ->
     [inputs] ->
     (inputs -> bool) ->
     IO (Either failure ([inputs], model))
@@ -90,7 +90,7 @@ class
   cegisFormulasVarInputs ::
     (EvaluateSym model inputs, ExtractSymbolics symbolSet inputs, GenSymSimple spec inputs) =>
     config ->
-    (Int -> Maybe spec) ->
+    [spec] ->
     [inputs] ->
     (inputs -> (bool, bool)) ->
     IO (Either failure ([inputs], model))
@@ -155,7 +155,7 @@ cegisFallableVarInputs ::
     SymBoolOp bool
   ) =>
   config ->
-  (Int -> Maybe spec) ->
+  [spec] ->
   [inputs] ->
   (Either e v -> (bool, bool)) ->
   (inputs -> t) ->
@@ -174,7 +174,7 @@ cegisFallableVarInputs' ::
     SymBoolOp bool
   ) =>
   config ->
-  (Int -> Maybe spec) ->
+  [spec] ->
   [inputs] ->
   (Either e v -> u (Either VerificationConditions ())) ->
   (inputs -> t) ->


### PR DESCRIPTION
This pull request introduces new CEGIS API that allows variable inputs.

Example usage:

```haskell
cegisFormulaVarInputs
  (UnboundedReasoning z3)             -- the solver configuration 
  [SimpleListSpec x () | x <- [1..2]] -- the specifications to generate inputs
  [[10 :: SymInteger]]                -- initial counterexamples
  (\case                              -- the function to generate the condition for assertion violations
    [x] -> abs x <=~ "a" + 10            -- when abs x <=~ "a" + 10, then crash
    [x,y] -> abs x + abs y <=~ "b" + 20) -- when abs x + abs y <=~ "b" + 20, then crash
```

The result would be
```haskell
Right ([[0I]],Model (fromList [(b :: Integer,-21 :: Integer),(a :: Integer,-11 :: Integer)]))
```

Showing that the solver get the the result `{a = -11, b = -21}` with one counterexample `[0]`.


