### PR TITLE
Make the model argument the last in ModelOps

### DIFF
--- a/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Lowering.hs
+++ b/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Lowering.hs
@@ -756,7 +756,7 @@ parseModel _ (SBVI.SMTModel _ _ assoc uifuncs) mp = foldr gouifuncs (foldr goass
     goassoc :: (String, SBVI.CV) -> PM.Model -> PM.Model
     goassoc (name, cv) m = case findStringToSymbol name mp of
       Just s@(TermSymbol (_ :: R.TypeRep t) _) ->
-        insertValue m s (resolveSingle (R.typeRep @t) cv)
+        insertValue s (resolveSingle (R.typeRep @t) cv) m
       Nothing -> error "Bad"
     resolveSingle :: R.TypeRep a -> SBVI.CV -> a
     resolveSingle t (SBVI.CV SBVI.KBool (SBVI.CInteger n)) =
@@ -874,8 +874,8 @@ parseModel _ (SBVI.SMTModel _ _ assoc uifuncs) mp = foldr gouifuncs (foldr goass
     gouifuncs :: (String, (SBVI.SBVType, ([([SBVI.CV], SBVI.CV)], SBVI.CV))) -> PM.Model -> PM.Model
     gouifuncs (name, (SBVI.SBVType _, l)) m = case findStringToSymbol name mp of
       Just s@(TermSymbol (_ :: R.TypeRep t) _) -> case R.typeRep @t of
-        t@(TFunType a r) -> R.withTypeable t $ insertValue m s $ goutfuncResolve a r l
-        t@(GFunType a r) -> R.withTypeable t $ insertValue m s $ gougfuncResolve 0 a r l
+        t@(TFunType a r) -> R.withTypeable t $ insertValue s (goutfuncResolve a r l) m
+        t@(GFunType a r) -> R.withTypeable t $ insertValue s (gougfuncResolve 0 a r l) m
         _ -> error "Bad"
       Nothing -> error "Bad"
 

--- a/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
+++ b/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
@@ -66,7 +66,7 @@ instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.M
       next md origm = do
         let newtm =
               S.foldl'
-                (\acc v -> pevalOrTerm acc (pevalNotTerm (fromJust $ equation md v)))
+                (\acc v -> pevalOrTerm acc (pevalNotTerm (fromJust $ equation v md)))
                 (concTerm False)
                 (unSymbolSet allSymbols)
         let (lowered, newm) = lowerSinglePrim' config newtm origm
@@ -109,7 +109,7 @@ instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.M
             md <- SBVC.getModel
             return $ Right $ parseModel config md newm
           _ -> return $ Left r
-        loop ((`exceptFor` forallSymbols) <$> mr) [] newm
+        loop (exceptFor forallSymbols <$> mr) [] newm
     where
       forallSymbols :: SymbolSet
       forallSymbols = extractSymbolics foralls
@@ -121,7 +121,7 @@ instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.M
         r <- solveFormula config evaluated
         return $ do
           m <- r
-          let newm = exact m forallSymbols
+          let newm = exact forallSymbols m
           return (evaluateSym False newm foralls, newm)
       guess :: Model -> SymBiMap -> Query (SymBiMap, Either SBVC.CheckSatResult PM.Model)
       guess candidate origm = do
@@ -133,7 +133,7 @@ instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.M
           SBVC.Sat -> do
             md <- SBVC.getModel
             let model = parseModel config md newm
-            return (newm, Right $ exceptFor model forallSymbols)
+            return (newm, Right $ exceptFor forallSymbols model)
           _ -> return (newm, Left r)
       loop ::
         Either SBVC.CheckSatResult PM.Model ->

--- a/grisette-core/src/Grisette/Core/Data/Class/Evaluate.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/Evaluate.hs
@@ -40,7 +40,7 @@ import Grisette.Core.Data.Class.ToCon
 class EvaluateSym model a where
   -- | Evaluate a symbolic variable with some model, possibly fill in values for the missing variables.
   --
-  -- >>> let model = insertValue emptyModel (termSymbol (Proxy @Integer) (SimpleSymbol "a")) (1 :: Integer) :: Model
+  -- >>> let model = insertValue (termSymbol (Proxy @Integer) (SimpleSymbol "a")) (1 :: Integer) emptyModel :: Model
   -- >>> evaluateSym False model ([ssymb "a", ssymb "b"] :: [SymInteger])
   -- [1I,b]
   -- >>> evaluateSym True model ([ssymb "a", ssymb "b"] :: [SymInteger])
@@ -72,7 +72,7 @@ instance (EvaluateSym' model a, EvaluateSym' model b) => EvaluateSym' model (a :
 -- | Evaluate a symbolic variable with some model, fill in values for the missing variables,
 -- and transform to concrete ones
 --
--- >>> let model = insertValue emptyModel (termSymbol (Proxy @Integer) (SimpleSymbol "a")) (1 :: Integer) :: Model
+-- >>> let model = insertValue (termSymbol (Proxy @Integer) (SimpleSymbol "a")) (1 :: Integer) emptyModel :: Model
 -- >>> evaluateSymToCon model ([ssymb "a", ssymb "b"] :: [SymInteger]) :: [Integer]
 -- [1,0]
 evaluateSymToCon :: (ToCon a b, EvaluateSym model a) => model -> a -> b

--- a/grisette-core/src/Grisette/Core/Data/Class/ModelOps.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/ModelOps.hs
@@ -21,10 +21,10 @@ class Monoid symbolSet => SymbolSetOps symbolSet symbol | symbolSet -> symbol wh
 
 class SymbolSetOps symbolSet symbol => ModelOps model symbolSet symbol | model -> symbolSet symbol where
   emptyModel :: model
-  valueOf :: forall t. (Typeable t) => model -> symbol -> Maybe t
-  insertValue :: (Eq a, Show a, Hashable a, Typeable a) => model -> symbol -> a -> model
-  exceptFor :: model -> symbolSet -> model
-  restrictTo :: model -> symbolSet -> model
-  extendTo :: model -> symbolSet -> model
-  exact :: model -> symbolSet -> model
-  exact m s = restrictTo (extendTo m s) s
+  valueOf :: forall t. (Typeable t) => symbol -> model -> Maybe t
+  insertValue :: (Eq a, Show a, Hashable a, Typeable a) => symbol -> a -> model -> model
+  exceptFor :: symbolSet -> model -> model
+  restrictTo :: symbolSet -> model -> model
+  extendTo :: symbolSet -> model -> model
+  exact :: symbolSet -> model -> model
+  exact s = restrictTo s . extendTo s

--- a/grisette-symir/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
+++ b/grisette-symir/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
@@ -26,8 +26,8 @@ modelTests =
       esymbol = TermSymbol (typeRep @(WordN 4)) $ SimpleSymbol "e"
       fsymbol = TermSymbol (typeRep @(IntN 4)) $ SimpleSymbol "f"
       m1 = emptyModel
-      m2 = insertValue m1 asymbol (1 :: Integer)
-      m3 = insertValue m2 bsymbol True
+      m2 = insertValue asymbol (1 :: Integer) m1
+      m3 = insertValue bsymbol True m2
    in testGroup
         "ModelTests"
         [ testCase "empty model is really empty" $ do
@@ -41,22 +41,22 @@ modelTests =
                     ]
                 ),
           testCase "equation" $ do
-            equation m3 asymbol @=? Just (pevalEqvTerm (ssymbTerm "a") (concTerm 1 :: Term Integer))
-            equation m3 bsymbol @=? Just (pevalEqvTerm (ssymbTerm "b") (concTerm True))
-            equation m3 csymbol @=? Nothing,
+            equation asymbol m3 @=? Just (pevalEqvTerm (ssymbTerm "a") (concTerm 1 :: Term Integer))
+            equation bsymbol m3 @=? Just (pevalEqvTerm (ssymbTerm "b") (concTerm True))
+            equation csymbol m3 @=? Nothing,
           testCase "valueOf" $ do
-            valueOf m3 asymbol @=? Just (1 :: Integer)
-            valueOf m3 bsymbol @=? Just True
-            valueOf m3 csymbol @=? (Nothing :: Maybe Integer),
+            valueOf asymbol m3 @=? Just (1 :: Integer)
+            valueOf bsymbol m3 @=? Just True
+            valueOf csymbol m3 @=? (Nothing :: Maybe Integer),
           testCase "exceptFor" $ do
-            exceptFor m3 (SymbolSet $ S.fromList [asymbol])
+            exceptFor (SymbolSet $ S.fromList [asymbol]) m3
               @=? Model
                 ( M.fromList
                     [ (bsymbol, toModelValue True)
                     ]
                 ),
           testCase "restrictTo" $ do
-            restrictTo m3 (SymbolSet $ S.fromList [asymbol])
+            restrictTo (SymbolSet $ S.fromList [asymbol]) m3
               @=? Model
                 ( M.fromList
                     [ (asymbol, toModelValue (1 :: Integer))
@@ -64,7 +64,6 @@ modelTests =
                 ),
           testCase "extendTo" $ do
             extendTo
-              m3
               ( SymbolSet $
                   S.fromList
                     [ csymbol,
@@ -73,6 +72,7 @@ modelTests =
                       fsymbol
                     ]
               )
+              m3
               @=? Model
                 ( M.fromList
                     [ (asymbol, toModelValue (1 :: Integer)),
@@ -85,13 +85,13 @@ modelTests =
                 ),
           testCase "exact" $ do
             exact
-              m3
               ( SymbolSet $
                   S.fromList
                     [ asymbol,
                       csymbol
                     ]
               )
+              m3
               @=? Model
                 ( M.fromList
                     [ (asymbol, toModelValue (1 :: Integer)),

--- a/grisette-symir/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/grisette-symir/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -101,8 +101,8 @@ symPrimTests =
             ],
           testCase "EvaluateSym" $ do
             let m1 = emptyModel :: Model
-            let m2 = insertValue m1 (TermSymbol (typeRep @Integer) (SimpleSymbol "a")) (1 :: Integer)
-            let m3 = insertValue m2 (TermSymbol (typeRep @Bool) (SimpleSymbol "b")) True
+            let m2 = insertValue (TermSymbol (typeRep @Integer) (SimpleSymbol "a")) (1 :: Integer) m1
+            let m3 = insertValue (TermSymbol (typeRep @Bool) (SimpleSymbol "b")) True m2
             evaluateSym False m3 (ites ("c" :: Sym Bool) "a" ("a" + "a" :: Sym Integer))
               @=? ites ("c" :: Sym Bool) 1 2
             evaluateSym True m3 (ites ("c" :: Sym Bool) "a" ("a" + "a" :: Sym Integer)) @=? 2,


### PR DESCRIPTION
This pull requestion changes the interfaces defined in `ModelOps`.

The `model` argument is now always the last argument. This aligns to the mapping interfaces in Haskell, and make it easier to chain the functions.