### PR TITLE
Introduce model construction using ModelRep

### DIFF
--- a/grisette-core/src/Grisette/Core/Data/Class/ModelOps.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/ModelOps.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -5,6 +6,7 @@
 module Grisette.Core.Data.Class.ModelOps
   ( ModelOps (..),
     SymbolSetOps (..),
+    ModelRep (..),
   )
 where
 
@@ -32,3 +34,6 @@ class
   extendTo :: symbolSet -> model -> model
   exact :: symbolSet -> model -> model
   exact s = restrictTo s . extendTo s
+
+class ModelOps model symbolSet typedSymbol => ModelRep rep model symbolSet (typedSymbol :: * -> *) where
+  buildModel :: rep -> model

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
@@ -37,6 +37,7 @@ import Data.Function (on)
 import Data.Hashable
 import Data.Interned
 import Data.Kind
+import Data.String
 import Data.Typeable (Proxy (..), cast)
 import GHC.Generics
 import GHC.TypeNats
@@ -173,6 +174,9 @@ instance NFData (TypedSymbol t) where
   rnf (SimpleSymbol str) = rnf str
   rnf (IndexedSymbol str i) = rnf str `seq` rnf i
   rnf (WithInfo s info) = rnf s `seq` rnf info
+
+instance SupportedPrim t => IsString (TypedSymbol t) where
+  fromString = SimpleSymbol
 
 withSymbolSupported :: TypedSymbol t -> (SupportedPrim t => a) -> a
 withSymbolSupported (SimpleSymbol _) a = a

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
@@ -12,6 +12,7 @@
 module Grisette.IR.SymPrim.Data.Prim.Model
   ( SymbolSet (..),
     Model (..),
+    ModelValuePair (..),
     equation,
     evaluateTerm,
   )
@@ -176,3 +177,190 @@ evaluateSomeTerm fillDefault (Model ma) = gomemo
 evaluateTerm :: forall a. (SupportedPrim a) => Bool -> Model -> Term a -> Term a
 evaluateTerm fillDefault m t = case evaluateSomeTerm fillDefault m $ SomeTerm t of
   SomeTerm (t1 :: Term b) -> unsafeCoerce @(Term b) @(Term a) t1
+
+data ModelValuePair t = (TypedSymbol t) ::= t deriving (Show)
+
+instance ModelRep (ModelValuePair t) Model SymbolSet TypedSymbol where
+  buildModel (sym ::= val) = insertValue sym val emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2
+      ) =
+      insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3
+      ) =
+      insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c,
+      ModelValuePair d
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3,
+      sym4 ::= val4
+      ) =
+      insertValue sym4 val4
+        . insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c,
+      ModelValuePair d,
+      ModelValuePair e
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3,
+      sym4 ::= val4,
+      sym5 ::= val5
+      ) =
+      insertValue sym5 val5
+        . insertValue sym4 val4
+        . insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c,
+      ModelValuePair d,
+      ModelValuePair e,
+      ModelValuePair f
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3,
+      sym4 ::= val4,
+      sym5 ::= val5,
+      sym6 ::= val6
+      ) =
+      insertValue sym6 val6
+        . insertValue sym5 val5
+        . insertValue sym4 val4
+        . insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c,
+      ModelValuePair d,
+      ModelValuePair e,
+      ModelValuePair f,
+      ModelValuePair g
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3,
+      sym4 ::= val4,
+      sym5 ::= val5,
+      sym6 ::= val6,
+      sym7 ::= val7
+      ) =
+      insertValue sym7 val7
+        . insertValue sym6 val6
+        . insertValue sym5 val5
+        . insertValue sym4 val4
+        . insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel
+
+instance
+  ModelRep
+    ( ModelValuePair a,
+      ModelValuePair b,
+      ModelValuePair c,
+      ModelValuePair d,
+      ModelValuePair e,
+      ModelValuePair f,
+      ModelValuePair g,
+      ModelValuePair h
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( sym1 ::= val1,
+      sym2 ::= val2,
+      sym3 ::= val3,
+      sym4 ::= val4,
+      sym5 ::= val5,
+      sym6 ::= val6,
+      sym7 ::= val7,
+      sym8 ::= val8
+      ) =
+      insertValue sym8 val8
+        . insertValue sym7 val7
+        . insertValue sym6 val6
+        . insertValue sym5 val5
+        . insertValue sym4 val4
+        . insertValue sym3 val3
+        . insertValue sym2 val2
+        . insertValue sym1 val1
+        $ emptyModel

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -22,6 +22,7 @@ module Grisette.IR.SymPrim.Data.SymPrim
     SymIntN,
     symSize,
     symsSize,
+    ModelSymPair (..),
   )
 where
 
@@ -44,6 +45,7 @@ import Grisette.Core.Data.Class.Function
 import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Integer
 import Grisette.Core.Data.Class.Mergeable
+import Grisette.Core.Data.Class.ModelOps
 import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
@@ -399,3 +401,198 @@ symsSize = termsSize . fmap underlyingTerm
 
 symSize :: Sym a -> Int
 symSize = termSize . underlyingTerm
+
+data ModelSymPair t = (Sym t) := t deriving (Show)
+
+instance ModelRep (ModelSymPair t) Model SymbolSet TypedSymbol where
+  buildModel (Sym (SymbTerm _ sym) := val) = insertValue sym val emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c,
+      ModelSymPair d
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3,
+      Sym (SymbTerm _ sym4) := val4
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        . insertValue sym4 val4
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c,
+      ModelSymPair d,
+      ModelSymPair e
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3,
+      Sym (SymbTerm _ sym4) := val4,
+      Sym (SymbTerm _ sym5) := val5
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        . insertValue sym4 val4
+        . insertValue sym5 val5
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c,
+      ModelSymPair d,
+      ModelSymPair e,
+      ModelSymPair f
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3,
+      Sym (SymbTerm _ sym4) := val4,
+      Sym (SymbTerm _ sym5) := val5,
+      Sym (SymbTerm _ sym6) := val6
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        . insertValue sym4 val4
+        . insertValue sym5 val5
+        . insertValue sym6 val6
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c,
+      ModelSymPair d,
+      ModelSymPair e,
+      ModelSymPair f,
+      ModelSymPair g
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3,
+      Sym (SymbTerm _ sym4) := val4,
+      Sym (SymbTerm _ sym5) := val5,
+      Sym (SymbTerm _ sym6) := val6,
+      Sym (SymbTerm _ sym7) := val7
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        . insertValue sym4 val4
+        . insertValue sym5 val5
+        . insertValue sym6 val6
+        . insertValue sym7 val7
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance
+  ModelRep
+    ( ModelSymPair a,
+      ModelSymPair b,
+      ModelSymPair c,
+      ModelSymPair d,
+      ModelSymPair e,
+      ModelSymPair f,
+      ModelSymPair g,
+      ModelSymPair h
+    )
+    Model
+    SymbolSet
+    TypedSymbol
+  where
+  buildModel
+    ( Sym (SymbTerm _ sym1) := val1,
+      Sym (SymbTerm _ sym2) := val2,
+      Sym (SymbTerm _ sym3) := val3,
+      Sym (SymbTerm _ sym4) := val4,
+      Sym (SymbTerm _ sym5) := val5,
+      Sym (SymbTerm _ sym6) := val6,
+      Sym (SymbTerm _ sym7) := val7,
+      Sym (SymbTerm _ sym8) := val8
+      ) =
+      insertValue sym1 val1
+        . insertValue sym2 val2
+        . insertValue sym3 val3
+        . insertValue sym4 val4
+        . insertValue sym5 val5
+        . insertValue sym6 val6
+        . insertValue sym7 val7
+        . insertValue sym8 val8
+        $ emptyModel
+  buildModel _ = error "buildModel: should only use symbolic constants"

--- a/grisette-symir/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
+++ b/grisette-symir/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
@@ -25,6 +25,8 @@ modelTests =
       dsymbol :: TypedSymbol Bool = SimpleSymbol "d"
       esymbol :: TypedSymbol (WordN 4) = SimpleSymbol "e"
       fsymbol :: TypedSymbol (IntN 4) = SimpleSymbol "f"
+      gsymbol :: TypedSymbol (WordN 16) = SimpleSymbol "g"
+      hsymbol :: TypedSymbol (IntN 16) = SimpleSymbol "h"
       m1 = emptyModel
       m2 = insertValue asymbol 1 m1
       m3 = insertValue bsymbol True m2
@@ -134,5 +136,116 @@ modelTests =
             evaluateTerm False m3 (pevalITETerm (ssymbTerm "z") (ssymbTerm "x") (pevalAddNumTerm (concTerm 1) (ssymbTerm "y")) :: Term Integer)
               @=? pevalITETerm (ssymbTerm "z") (ssymbTerm "x") (pevalAddNumTerm (concTerm 1) (ssymbTerm "y"))
             evaluateTerm True m3 (pevalITETerm (ssymbTerm "z") (ssymbTerm "x") (pevalAddNumTerm (concTerm 1) (ssymbTerm "y")) :: Term Integer)
-              @=? concTerm 1
+              @=? concTerm 1,
+          testCase "construction from ModelValuePair" $ do
+            buildModel (asymbol ::= 1) @=? Model (M.singleton (someTypedSymbol asymbol) (toModelValue (1 :: Integer)))
+            buildModel (asymbol ::= 1, bsymbol ::= True)
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True)
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer))
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2,
+                dsymbol ::= False
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                      (someTypedSymbol dsymbol, toModelValue False)
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2,
+                dsymbol ::= False,
+                esymbol ::= 3
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                      (someTypedSymbol dsymbol, toModelValue False),
+                      (someTypedSymbol esymbol, toModelValue (3 :: WordN 4))
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2,
+                dsymbol ::= False,
+                esymbol ::= 3,
+                fsymbol ::= 4
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                      (someTypedSymbol dsymbol, toModelValue False),
+                      (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                      (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4))
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2,
+                dsymbol ::= False,
+                esymbol ::= 3,
+                fsymbol ::= 4,
+                gsymbol ::= 5
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                      (someTypedSymbol dsymbol, toModelValue False),
+                      (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                      (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4)),
+                      (someTypedSymbol gsymbol, toModelValue (5 :: WordN 16))
+                    ]
+                )
+            buildModel
+              ( asymbol ::= 1,
+                bsymbol ::= True,
+                csymbol ::= 2,
+                dsymbol ::= False,
+                esymbol ::= 3,
+                fsymbol ::= 4,
+                gsymbol ::= 5,
+                hsymbol ::= 6
+              )
+              @=? Model
+                ( M.fromList
+                    [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                      (someTypedSymbol bsymbol, toModelValue True),
+                      (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                      (someTypedSymbol dsymbol, toModelValue False),
+                      (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                      (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4)),
+                      (someTypedSymbol gsymbol, toModelValue (5 :: WordN 16)),
+                      (someTypedSymbol hsymbol, toModelValue (6 :: IntN 16))
+                    ]
+                )
         ]

--- a/grisette-symir/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/grisette-symir/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -10,6 +10,7 @@ module Grisette.IR.SymPrim.Data.SymPrimTests where
 
 import Control.Monad.Except
 import Data.Bits
+import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
 import Data.Int
 import Data.Proxy
@@ -33,6 +34,7 @@ import Grisette.IR.SymPrim.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import Grisette.IR.SymPrim.Data.Prim.Model
+import Grisette.IR.SymPrim.Data.Prim.ModelValue
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
@@ -408,5 +410,134 @@ symPrimTests =
             symSize (ites (ssymb "a" :: Sym Bool) (ssymb "b") (ssymb "c") :: Sym Integer) @=? 4,
           testCase "symsSize" $ do
             symsSize [ssymb "a" :: Sym Integer, ssymb "a" + ssymb "a"] @=? 2
-        ]
+        ],
+      let asymbol :: TypedSymbol Integer = "a"
+          bsymbol :: TypedSymbol Bool = "b"
+          csymbol :: TypedSymbol Integer = "c"
+          dsymbol :: TypedSymbol Bool = "d"
+          esymbol :: TypedSymbol (WordN 4) = "e"
+          fsymbol :: TypedSymbol (IntN 4) = "f"
+          gsymbol :: TypedSymbol (WordN 16) = "g"
+          hsymbol :: TypedSymbol (IntN 16) = "h"
+          a :: Sym Integer = ssymb "a"
+          b :: Sym Bool = "b"
+          c :: Sym Integer = "c"
+          d :: Sym Bool = "d"
+          e :: Sym (WordN 4) = "e"
+          f :: Sym (IntN 4) = "f"
+          g :: Sym (WordN 16) = "g"
+          h :: Sym (IntN 16) = "h"
+       in testCase
+            "construting Model from ModelSymPair"
+            $ do
+              buildModel (a := 1) @=? Model (M.singleton (someTypedSymbol asymbol) (toModelValue (1 :: Integer)))
+              buildModel (a := 1, b := True)
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True)
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer))
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2,
+                  d := False
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                        (someTypedSymbol dsymbol, toModelValue False)
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2,
+                  d := False,
+                  e := 3
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                        (someTypedSymbol dsymbol, toModelValue False),
+                        (someTypedSymbol esymbol, toModelValue (3 :: WordN 4))
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2,
+                  d := False,
+                  e := 3,
+                  f := 4
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                        (someTypedSymbol dsymbol, toModelValue False),
+                        (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                        (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4))
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2,
+                  d := False,
+                  e := 3,
+                  f := 4,
+                  g := 5
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                        (someTypedSymbol dsymbol, toModelValue False),
+                        (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                        (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4)),
+                        (someTypedSymbol gsymbol, toModelValue (5 :: WordN 16))
+                      ]
+                  )
+              buildModel
+                ( a := 1,
+                  b := True,
+                  c := 2,
+                  d := False,
+                  e := 3,
+                  f := 4,
+                  g := 5,
+                  h := 6
+                )
+                @=? Model
+                  ( M.fromList
+                      [ (someTypedSymbol asymbol, toModelValue (1 :: Integer)),
+                        (someTypedSymbol bsymbol, toModelValue True),
+                        (someTypedSymbol csymbol, toModelValue (2 :: Integer)),
+                        (someTypedSymbol dsymbol, toModelValue False),
+                        (someTypedSymbol esymbol, toModelValue (3 :: WordN 4)),
+                        (someTypedSymbol fsymbol, toModelValue (4 :: IntN 4)),
+                        (someTypedSymbol gsymbol, toModelValue (5 :: WordN 16)),
+                        (someTypedSymbol hsymbol, toModelValue (6 :: IntN 16))
+                      ]
+                  )
     ]


### PR DESCRIPTION
This pull request introduces a convenient interface for constructing a model using `ModelRep`.

We will now be able to construct a model using the `buildModel` function with a tuple

```haskell
>>> buildModel ("a" := True, "b" := (1 :: Integer)) :: Model
Model {unModel = fromList [(b :: Integer,1 :: Integer),(a :: Bool,True :: Bool)]}
```
