### PR TITLE
Introduce substitution API

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install OS Packages
+      uses: mstksg/get-package@v1
+      with:
+        apt-get: libncurses5
+
     - name: 'Set up HLint'
       uses: haskell/actions/hlint-setup@v2
 

--- a/grisette-core/grisette-core.cabal
+++ b/grisette-core/grisette-core.cabal
@@ -49,6 +49,7 @@ library
       Grisette.Core.Data.Class.SimpleMergeable
       Grisette.Core.Data.Class.Solver
       Grisette.Core.Data.Class.SOrd
+      Grisette.Core.Data.Class.Substitute
       Grisette.Core.Data.Class.ToCon
       Grisette.Core.Data.Class.ToSym
       Grisette.Core.Data.FileLocation

--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -179,6 +179,9 @@ module Grisette.Core
     evaluateSymToCon,
     ToCon (..),
     ToSym (..),
+    SubstituteSym (..),
+    SubstituteSym' (..),
+    SubstituteSymSymbol (..),
 
     -- * Solver interface
     Solver (..),
@@ -236,6 +239,7 @@ import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solver
+import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Core.Data.FileLocation

--- a/grisette-core/src/Grisette/Core/Data/Class/Substitute.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/Substitute.hs
@@ -1,0 +1,222 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Grisette.Core.Data.Class.Substitute
+  ( SubstituteSymSymbol (..),
+    SubstituteSym (..),
+    SubstituteSym' (..),
+  )
+where
+
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Trans.Maybe
+import qualified Control.Monad.Writer.Lazy as WriterLazy
+import qualified Control.Monad.Writer.Strict as WriterStrict
+import qualified Data.ByteString as B
+import Data.Functor.Sum
+import Data.Int
+import Data.Word
+import Generics.Deriving
+import Generics.Deriving.Instances ()
+
+class SubstituteSymSymbol (typedSymbol :: * -> *) (sym :: * -> *) | sym -> typedSymbol
+
+class SubstituteSymSymbol typedSymbol sym => SubstituteSym typedSymbol sym a | sym -> typedSymbol where
+  substituteSym :: typedSymbol b -> sym b -> a -> a
+
+class SubstituteSym' typedSymbol sym a | sym -> typedSymbol where
+  substituteSym' :: typedSymbol b -> sym b -> a c -> a c
+
+instance
+  ( Generic a,
+    SubstituteSymSymbol typedSymbol sym,
+    SubstituteSym' typedSymbol sym (Rep a)
+  ) =>
+  SubstituteSym typedSymbol sym (Default a)
+  where
+  substituteSym sym val = Default . to . substituteSym' sym val . from . unDefault
+
+instance SubstituteSymSymbol typedSymbol sym => SubstituteSym' typedSymbol sym U1 where
+  substituteSym' _ _ = id
+
+instance SubstituteSym typedSymbol sym c => SubstituteSym' typedSymbol sym (K1 i c) where
+  substituteSym' sym val (K1 v) = K1 $ substituteSym sym val v
+
+instance SubstituteSym' typedSymbol sym a => SubstituteSym' typedSymbol sym (M1 i c a) where
+  substituteSym' sym val (M1 v) = M1 $ substituteSym' sym val v
+
+instance (SubstituteSym' typedSymbol sym a, SubstituteSym' typedSymbol sym b) => SubstituteSym' typedSymbol sym (a :+: b) where
+  substituteSym' sym val (L1 l) = L1 $ substituteSym' sym val l
+  substituteSym' sym val (R1 r) = R1 $ substituteSym' sym val r
+
+instance (SubstituteSym' typedSymbol sym a, SubstituteSym' typedSymbol sym b) => SubstituteSym' typedSymbol sym (a :*: b) where
+  substituteSym' sym val (a :*: b) = substituteSym' sym val a :*: substituteSym' sym val b
+
+#define CONCRETE_SUBSTITUTESYM(type) \
+instance SubstituteSymSymbol typedSymbol sym => SubstituteSym typedSymbol sym type where \
+  substituteSym _ _ = id
+
+CONCRETE_SUBSTITUTESYM (Bool)
+CONCRETE_SUBSTITUTESYM (Integer)
+CONCRETE_SUBSTITUTESYM (Char)
+CONCRETE_SUBSTITUTESYM (Int)
+CONCRETE_SUBSTITUTESYM (Int8)
+CONCRETE_SUBSTITUTESYM (Int16)
+CONCRETE_SUBSTITUTESYM (Int32)
+CONCRETE_SUBSTITUTESYM (Int64)
+CONCRETE_SUBSTITUTESYM (Word)
+CONCRETE_SUBSTITUTESYM (Word8)
+CONCRETE_SUBSTITUTESYM (Word16)
+CONCRETE_SUBSTITUTESYM (Word32)
+CONCRETE_SUBSTITUTESYM (Word64)
+CONCRETE_SUBSTITUTESYM (B.ByteString)
+
+instance SubstituteSymSymbol typedSymbol sym => SubstituteSym typedSymbol sym () where
+  substituteSym _ _ = id
+
+-- Either
+deriving via
+  (Default (Either a b))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b
+    ) =>
+    SubstituteSym typedSymbol sym (Either a b)
+
+-- Maybe
+deriving via (Default (Maybe a)) instance (SubstituteSym typedSymbol sym a) => SubstituteSym typedSymbol sym (Maybe a)
+
+-- List
+deriving via (Default [a]) instance (SubstituteSym typedSymbol sym a) => SubstituteSym typedSymbol sym [a]
+
+-- (,)
+deriving via
+  (Default (a, b))
+  instance
+    (SubstituteSym typedSymbol sym a, SubstituteSym typedSymbol sym b) =>
+    SubstituteSym typedSymbol sym (a, b)
+
+-- (,,)
+deriving via
+  (Default (a, b, c))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c
+    ) =>
+    SubstituteSym typedSymbol sym (a, b, c)
+
+-- (,,,)
+deriving via
+  (Default (a, b, c, d))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c,
+      SubstituteSym typedSymbol sym d
+    ) =>
+    SubstituteSym typedSymbol sym (a, b, c, d)
+
+-- (,,,,)
+deriving via
+  (Default (a, b, c, d, e))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c,
+      SubstituteSym typedSymbol sym d,
+      SubstituteSym typedSymbol sym e
+    ) =>
+    SubstituteSym typedSymbol sym (a, b, c, d, e)
+
+-- (,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c,
+      SubstituteSym typedSymbol sym d,
+      SubstituteSym typedSymbol sym e,
+      SubstituteSym typedSymbol sym f
+    ) =>
+    SubstituteSym typedSymbol sym (a, b, c, d, e, f)
+
+-- (,,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f, g))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c,
+      SubstituteSym typedSymbol sym d,
+      SubstituteSym typedSymbol sym e,
+      SubstituteSym typedSymbol sym f,
+      SubstituteSym typedSymbol sym g
+    ) =>
+    SubstituteSym typedSymbol sym (a, b, c, d, e, f, g)
+
+-- (,,,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f, g, h))
+  instance
+    ( SubstituteSym typedSymbol sym a,
+      SubstituteSym typedSymbol sym b,
+      SubstituteSym typedSymbol sym c,
+      SubstituteSym typedSymbol sym d,
+      SubstituteSym typedSymbol sym e,
+      SubstituteSym typedSymbol sym f,
+      SubstituteSym typedSymbol sym g,
+      SubstituteSym typedSymbol sym h
+    ) =>
+    SubstituteSym typedSymbol sym ((,,,,,,,) a b c d e f g h)
+
+-- MaybeT
+instance
+  (SubstituteSymSymbol typedSymbol sym, SubstituteSym typedSymbol sym (m (Maybe a))) =>
+  SubstituteSym typedSymbol sym (MaybeT m a)
+  where
+  substituteSym sym val (MaybeT v) = MaybeT $ substituteSym sym val v
+
+-- ExceptT
+instance
+  (SubstituteSymSymbol typedSymbol sym, SubstituteSym typedSymbol sym (m (Either e a))) =>
+  SubstituteSym typedSymbol sym (ExceptT e m a)
+  where
+  substituteSym sym val (ExceptT v) = ExceptT $ substituteSym sym val v
+
+-- Sum
+deriving via
+  (Default (Sum f g a))
+  instance
+    (SubstituteSym typedSymbol sym (f a), SubstituteSym typedSymbol sym (g a)) =>
+    SubstituteSym typedSymbol sym (Sum f g a)
+
+-- WriterT
+instance
+  (SubstituteSymSymbol typedSymbol sym, SubstituteSym typedSymbol sym (m (a, s))) =>
+  SubstituteSym typedSymbol sym (WriterLazy.WriterT s m a)
+  where
+  substituteSym sym val (WriterLazy.WriterT v) = WriterLazy.WriterT $ substituteSym sym val v
+
+instance
+  (SubstituteSymSymbol typedSymbol sym, SubstituteSym typedSymbol sym (m (a, s))) =>
+  SubstituteSym typedSymbol sym (WriterStrict.WriterT s m a)
+  where
+  substituteSym sym val (WriterStrict.WriterT v) = WriterStrict.WriterT $ substituteSym sym val v
+
+-- Identity
+instance SubstituteSym typedSymbol sym a => SubstituteSym typedSymbol sym (Identity a) where
+  substituteSym sym val (Identity a) = Identity $ substituteSym sym val a
+
+-- IdentityT
+instance SubstituteSym typedSymbol sym (m a) => SubstituteSym typedSymbol sym (IdentityT m a) where
+  substituteSym sym val (IdentityT a) = IdentityT $ substituteSym sym val a

--- a/grisette-symir/grisette-symir.cabal
+++ b/grisette-symir/grisette-symir.cabal
@@ -36,10 +36,10 @@ library
       Grisette.IR.SymPrim.Data.IntBitwidth
       Grisette.IR.SymPrim.Data.Prim.Helpers
       Grisette.IR.SymPrim.Data.Prim.InternedTerm.Caches
-      Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst
       Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
       Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm
       Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+      Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
       Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
       Grisette.IR.SymPrim.Data.Prim.Model
       Grisette.IR.SymPrim.Data.Prim.ModelValue

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/GeneralFuncSubst.hs-boot
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/GeneralFuncSubst.hs-boot
@@ -1,7 +1,0 @@
-{-# LANGUAGE RankNTypes #-}
-
-module Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst (generalFuncSubst) where
-
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-
-generalFuncSubst :: forall a b. (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term a -> Term b -> Term b

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
@@ -45,8 +45,8 @@ import Grisette.Core.Data.Class.BitVector
 import Grisette.Core.Data.Class.Function
 import Grisette.IR.SymPrim.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Caches
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
 import Grisette.IR.SymPrim.Data.Prim.ModelValue
 import Grisette.IR.SymPrim.Data.Prim.Utils
@@ -849,4 +849,4 @@ instance (SupportedPrim a, SupportedPrim b) => SupportedPrim (a --> b) where
 instance (SupportedPrim a, SupportedPrim b) => Function (a --> b) where
   type Arg (a --> b) = Term a
   type Ret (a --> b) = Term b
-  (GeneralFunc arg tm) # v = generalFuncSubst arg v tm
+  (GeneralFunc arg tm) # v = substTerm arg v tm

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst (generalFuncSubst) where
+module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution (substTerm) where
 
 import Grisette.Core.Data.MemoUtils
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
@@ -20,8 +20,8 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFunc
 import Type.Reflection
 import Unsafe.Coerce
 
-generalFuncSubst :: forall a b. (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term a -> Term b -> Term b
-generalFuncSubst sym term = gov
+substTerm :: forall a b. (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term a -> Term b -> Term b
+substTerm sym term = gov
   where
     gov :: (SupportedPrim x) => Term x -> Term x
     gov b = case go (SomeTerm b) of

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs-boot
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs-boot
@@ -1,0 +1,7 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution (substTerm) where
+
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+
+substTerm :: forall a b. (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term a -> Term b -> Term b

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -49,10 +49,12 @@ import Grisette.Core.Data.Class.ModelOps
 import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.IR.SymPrim.Data.BV
 import Grisette.IR.SymPrim.Data.IntBitwidth
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
@@ -596,3 +598,12 @@ instance
         . insertValue sym8 val8
         $ emptyModel
   buildModel _ = error "buildModel: should only use symbolic constants"
+
+instance SubstituteSym TypedSymbol Sym (Sym a) where
+  substituteSym sym (Sym val) (Sym x) =
+    introSupportedPrimConstraint val $
+      introSupportedPrimConstraint x $
+        Sym $
+          generalFuncSubst sym val x
+
+instance SubstituteSymSymbol TypedSymbol Sym

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -54,9 +54,9 @@ import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.IR.SymPrim.Data.BV
 import Grisette.IR.SymPrim.Data.IntBitwidth
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.GeneralFuncSubst
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
 import Grisette.IR.SymPrim.Data.Prim.Model
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
@@ -604,6 +604,6 @@ instance SubstituteSym TypedSymbol Sym (Sym a) where
     introSupportedPrimConstraint val $
       introSupportedPrimConstraint x $
         Sym $
-          generalFuncSubst sym val x
+          substTerm sym val x
 
 instance SubstituteSymSymbol TypedSymbol Sym


### PR DESCRIPTION
This pull request introduces the substitution API, allowing the substitution of symbolic constants in a value.

For example,

```haskell
GHCi> substituteSym "a" ("b" :: SymInteger) (Just "a" :: Maybe SymInteger)
Just b
```