### PR TITLE
Print models in a better way

### DIFF
--- a/grisette-core/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
@@ -33,7 +33,7 @@ import Generics.Deriving
 -- | Extracts all the symbolic variables that are transitively contained in the given value.
 --
 -- >>> gextractSymbolics ("a" :: SymBool) :: SymbolSet
--- SymbolSet {unSymbolSet = fromList [a :: Bool]}
+-- SymbolSet {a :: Bool}
 --
 -- >>> :{
 --   sort $ HashSet.toList $ unSymbolSet $

--- a/grisette-symir/src/Grisette/IR/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim.hs
@@ -19,6 +19,7 @@ module Grisette.IR.SymPrim
     SymbolSet (..),
     Model (..),
     TypedSymbol (..),
+    showUntyped,
     withSymbolSupported,
     SomeTypedSymbol (..),
     someTypedSymbol,

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
@@ -22,6 +22,7 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
     TernaryOp (..),
     TypedSymbol (..),
     SomeTypedSymbol (..),
+    showUntyped,
     withSymbolSupported,
     someTypedSymbol,
     Term (..),

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
@@ -41,9 +41,23 @@ import Type.Reflection
 import Unsafe.Coerce
 
 newtype SymbolSet = SymbolSet {unSymbolSet :: S.HashSet SomeTypedSymbol}
-  deriving (Eq, Show, Generic, Hashable, Semigroup, Monoid)
+  deriving (Eq, Generic, Hashable, Semigroup, Monoid)
 
-newtype Model = Model {unModel :: M.HashMap SomeTypedSymbol ModelValue} deriving (Show, Eq, Generic, Hashable)
+instance Show SymbolSet where
+  showsPrec prec (SymbolSet s) = showParen (prec >= 10) $ \x -> "SymbolSet {" ++ go0 (S.toList s) ++ "}" ++ x
+    where
+      go0 [] = ""
+      go0 [x] = show x
+      go0 (x : xs) = show x ++ ", " ++ go0 xs
+
+newtype Model = Model {unModel :: M.HashMap SomeTypedSymbol ModelValue} deriving (Eq, Generic, Hashable)
+
+instance Show Model where
+  showsPrec prec (Model m) = showParen (prec >= 10) $ \x -> "Model {" ++ go0 (M.toList m) ++ "}" ++ x
+    where
+      go0 [] = ""
+      go0 [(SomeTypedSymbol _ s, v)] = showUntyped s ++ " -> " ++ show v
+      go0 ((SomeTypedSymbol _ s, v) : xs) = showUntyped s ++ " -> " ++ show v ++ ", " ++ go0 xs
 
 equation :: TypedSymbol a -> Model -> Maybe (Term Bool)
 equation tsym m = withSymbolSupported tsym $


### PR DESCRIPTION
This pull request improves the printing of models and symbol sets.

A model will now be printed as

```haskell
Model {a -> 1 :: Integer, b -> False :: Bool}
```

A symbol set will now be printed as

```haskell
SymbolSet {a :: Integer, b :: Bool}
```
