### PR TITLE
Shorten the API name for symbolic generation

### DIFF
--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -132,20 +132,20 @@ module Grisette.Core
     -- * Symbolic Generation
 
     -- ** Symbolic Generation Context
-    GenSymIndex (..),
-    GenSymIdent,
-    pattern GenSymIdent,
+    FreshIndex (..),
+    FreshIdent,
+    pattern FreshIdent,
     name,
     nameWithInfo,
     FileLocation (..),
     nameWithLoc,
 
     -- ** Symbolic Generation Monad
-    MonadGenSymFresh (..),
-    GenSymFresh,
-    GenSymFreshT,
-    runGenSymFresh,
-    runGenSymFreshT,
+    MonadFresh (..),
+    Fresh,
+    FreshT,
+    runFresh,
+    runFreshT,
 
     -- ** Symbolic Generation Class
     GGenSym (..),
@@ -154,9 +154,9 @@ module Grisette.Core
     genSymSimple,
 
     -- ** Symbolic Generation Class Derivation
-    derivedNoSpecGGenSymFresh,
-    derivedNoSpecGenSymSimpleFresh,
-    derivedSameShapeGenSymSimpleFresh,
+    derivedNoSpecGFresh,
+    derivedNoSpecSimpleFresh,
+    derivedSameShapeSimpleFresh,
 
     -- ** Symbolic choice
     gchooseFresh,

--- a/grisette-core/src/Grisette/Core/Control/Monad/CBMCExcept.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/CBMCExcept.hs
@@ -72,13 +72,13 @@ instance
   ) =>
   GenSymSimple (CBMCEither a b) (CBMCEither a b)
   where
-  genSymSimpleFresh = derivedSameShapeGenSymSimpleFresh
+  simpleFresh = derivedSameShapeSimpleFresh
 
 instance
   (SymBoolOp bool, GenSymSimple () bool, GGenSym bool () a, GMergeable bool a, GGenSym bool () b, GMergeable bool b) =>
   GGenSym bool () (CBMCEither a b)
   where
-  ggenSymFresh = derivedNoSpecGGenSymFresh
+  gfresh = derivedNoSpecGFresh
 
 deriving newtype instance (SymBoolOp bool, GSOrd bool a, GSOrd bool b) => GSOrd bool (CBMCEither a b)
 
@@ -330,8 +330,8 @@ instance
   ) =>
   GGenSym bool spec (CBMCExceptT a m b)
   where
-  ggenSymFresh v = do
-    x <- ggenSymFresh v
+  gfresh v = do
+    x <- gfresh v
     return $ merge . fmap CBMCExceptT $ x
 
 instance
@@ -340,7 +340,7 @@ instance
   ) =>
   GenSymSimple spec (CBMCExceptT a m b)
   where
-  genSymSimpleFresh v = CBMCExceptT <$> genSymSimpleFresh v
+  simpleFresh v = CBMCExceptT <$> simpleFresh v
 
 instance
   {-# OVERLAPPING #-}
@@ -348,7 +348,7 @@ instance
   ) =>
   GenSymSimple (CBMCExceptT e m a) (CBMCExceptT e m a)
   where
-  genSymSimpleFresh (CBMCExceptT v) = CBMCExceptT <$> genSymSimpleFresh v
+  simpleFresh (CBMCExceptT v) = CBMCExceptT <$> simpleFresh v
 
 instance
   {-# OVERLAPPING #-}

--- a/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
@@ -367,18 +367,18 @@ instance (SymBoolOp bool) => Traversable (UnionMBase bool) where
 instance (SymBoolOp bool, GGenSym bool spec a, GMergeable bool a) => GGenSym bool spec (UnionMBase bool a)
 
 instance (SymBoolOp bool, GGenSym bool spec a) => GenSymSimple spec (UnionMBase bool a) where
-  genSymSimpleFresh spec = do
-    res <- ggenSymFresh spec
+  simpleFresh spec = do
+    res <- gfresh spec
     if not (isMerged res) then error "Not merged" else return res
 
 instance
   (SymBoolOp bool, GGenSym bool a a, GenSymSimple () bool, GMergeable bool a) =>
   GGenSym bool (UnionMBase bool a) a
   where
-  ggenSymFresh spec = go (underlyingUnion $ merge spec)
+  gfresh spec = go (underlyingUnion $ merge spec)
     where
-      go (Single x) = ggenSymFresh x
-      go (If _ _ _ t f) = mrgIf <$> genSymSimpleFresh () <*> go t <*> go f
+      go (Single x) = gfresh x
+      go (If _ _ _ t f) = mrgIf <$> simpleFresh () <*> go t <*> go f
 
 -- Concrete Key HashMaps
 

--- a/grisette-core/src/Grisette/Core/Data/FileLocation.hs
+++ b/grisette-core/src/Grisette/Core/Data/FileLocation.hs
@@ -46,7 +46,7 @@ parseFileLocation str =
 -- a:<interactive>:...
 --
 -- The uniqueness is ensured for the call to 'nameWithLoc' at different location.
-nameWithLoc :: String -> SpliceQ GenSymIdent
+nameWithLoc :: String -> SpliceQ FreshIdent
 nameWithLoc s = [||nameWithInfo s (parseFileLocation $$(liftSplice $ unsafeTExpCoerce __LOCATION__))||]
 
 -- | Generate simply-named symbolic variables. The file location will be attached to identifier.

--- a/grisette-core/src/Grisette/TestUtils/SBool.hs
+++ b/grisette-core/src/Grisette/TestUtils/SBool.hs
@@ -211,14 +211,14 @@ instance ToSym SBool SBool where
 instance GGenSym SBool () SBool
 
 instance GenSymSimple () SBool where
-  genSymSimpleFresh _ = do
-    ident <- getGenSymIdent
-    GenSymIndex i <- nextGenSymIndex
+  simpleFresh _ = do
+    ident <- getFreshIdent
+    FreshIndex i <- nextFreshIndex
     case ident of
-      GenSymIdent s -> return $ ISBool s i
-      GenSymIdentWithInfo s info -> return $ IISBool s i info
+      FreshIdent s -> return $ ISBool s i
+      FreshIdentWithInfo s info -> return $ IISBool s i info
 
 instance GGenSym SBool SBool SBool
 
 instance GenSymSimple SBool SBool where
-  genSymSimpleFresh _ = genSymSimpleFresh ()
+  simpleFresh _ = simpleFresh ()

--- a/grisette-core/test/Grisette/Core/Data/Class/GenSymTests.hs
+++ b/grisette-core/test/Grisette/Core/Data/Class/GenSymTests.hs
@@ -753,19 +753,19 @@ genSymTests =
       testGroup
         "gchoose*"
         [ testCase "gchooseFresh" $ do
-            (runGenSymFresh (gchooseFresh [1, 2, 3]) "a" :: UnionMBase SBool Int)
+            (runFresh (gchooseFresh [1, 2, 3]) "a" :: UnionMBase SBool Int)
               @=? mrgIf (ISBool "a" 0) (mrgSingle 1) (mrgIf (ISBool "a" 1) (mrgSingle 2) (mrgSingle 3)),
           testCase "gchoose" $ do
             (gchoose [1, 2, 3] "a" :: UnionMBase SBool Int)
               @=? mrgIf (ISBool "a" 0) (mrgSingle 1) (mrgIf (ISBool "a" 1) (mrgSingle 2) (mrgSingle 3)),
           testCase "gchooseSimpleFresh" $ do
-            (runGenSymFresh (gchooseSimpleFresh (Proxy @SBool) ["x", "y", "z"]) "a" :: SBool)
+            (runFresh (gchooseSimpleFresh (Proxy @SBool) ["x", "y", "z"]) "a" :: SBool)
               @=? ites (ISBool "a" 0) (SSBool "x") (ites (ISBool "a" 1) (SSBool "y") (SSBool "z")),
           testCase "gchooseSimple" $ do
             (gchooseSimple (Proxy @SBool) ["x", "y", "z"] "a" :: SBool)
               @=? ites (ISBool "a" 0) (SSBool "x") (ites (ISBool "a" 1) (SSBool "y") (SSBool "z")),
           testCase "gchooseUnionFresh" $ do
-            ( runGenSymFresh
+            ( runFresh
                 (gchooseUnionFresh [mrgIf (SSBool "x") 1 2, mrgIf (SSBool "x") 2 3, mrgIf (SSBool "x") 3 4])
                 "a" ::
                 UnionMBase SBool Int

--- a/grisette-symir/src/Grisette/IR/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim.hs
@@ -79,7 +79,7 @@ module Grisette.IR.SymPrim
     SubstituteSym,
     substituteSym,
     GenSym,
-    genSymFresh,
+    fresh,
     genSym,
     chooseFresh,
     chooseSimpleFresh,

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Class/GenSym.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Class/GenSym.hs
@@ -4,7 +4,7 @@
 
 module Grisette.IR.SymPrim.Data.Class.GenSym
   ( GenSym,
-    genSymFresh,
+    fresh,
     genSym,
     chooseFresh,
     chooseSimpleFresh,
@@ -25,34 +25,34 @@ import Grisette.IR.SymPrim.Data.SymPrim
 
 type GenSym spec a = GGenSym SymBool spec a
 
-genSymFresh :: (GenSym spec a, MonadGenSymFresh m, MonadUnion u) => spec -> m (u a)
-genSymFresh = ggenSymFresh
-{-# INLINE genSymFresh #-}
+fresh :: (GenSym spec a, MonadFresh m, MonadUnion u) => spec -> m (u a)
+fresh = gfresh
+{-# INLINE fresh #-}
 
-genSym :: (GenSym spec a, MonadUnion u) => spec -> GenSymIdent -> u a
+genSym :: (GenSym spec a, MonadUnion u) => spec -> FreshIdent -> u a
 genSym = ggenSym
 {-# INLINE genSym #-}
 
-chooseFresh :: (Mergeable a, MonadGenSymFresh m, MonadUnion u) => [a] -> m (u a)
+chooseFresh :: (Mergeable a, MonadFresh m, MonadUnion u) => [a] -> m (u a)
 chooseFresh = gchooseFresh
 {-# INLINE chooseFresh #-}
 
-choose :: (Mergeable a, MonadUnion u) => [a] -> GenSymIdent -> u a
+choose :: (Mergeable a, MonadUnion u) => [a] -> FreshIdent -> u a
 choose = gchoose
 {-# INLINE choose #-}
 
-chooseSimpleFresh :: (SimpleMergeable a, MonadGenSymFresh m) => [a] -> m a
+chooseSimpleFresh :: (SimpleMergeable a, MonadFresh m) => [a] -> m a
 chooseSimpleFresh = gchooseSimpleFresh (Proxy @SymBool)
 {-# INLINE chooseSimpleFresh #-}
 
-chooseSimple :: (SimpleMergeable a) => [a] -> GenSymIdent -> a
+chooseSimple :: (SimpleMergeable a) => [a] -> FreshIdent -> a
 chooseSimple = gchooseSimple (Proxy @SymBool)
 {-# INLINE chooseSimple #-}
 
-chooseUnionFresh :: (Mergeable a, MonadGenSymFresh m, MonadUnion u) => [u a] -> m (u a)
+chooseUnionFresh :: (Mergeable a, MonadFresh m, MonadUnion u) => [u a] -> m (u a)
 chooseUnionFresh = gchooseUnionFresh
 {-# INLINE chooseUnionFresh #-}
 
-chooseUnion :: (Mergeable a, MonadUnion u) => [u a] -> GenSymIdent -> u a
+chooseUnion :: (Mergeable a, MonadUnion u) => [u a] -> FreshIdent -> u a
 chooseUnion = gchooseUnion
 {-# INLINE chooseUnion #-}

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -126,20 +126,20 @@ instance (SupportedPrim a) => GExtractSymbolics SymbolSet (Sym a) where
   gextractSymbolics (Sym t) = SymbolSet $ extractSymbolicsTerm t
 
 instance (SymBoolOp (Sym Bool), SupportedPrim a) => GGenSym (Sym Bool) () (Sym a) where
-  ggenSymFresh _ = mrgReturn <$> genSymSimpleFresh ()
+  gfresh _ = mrgReturn <$> simpleFresh ()
 
 instance (SymBoolOp (Sym Bool), SupportedPrim a) => GenSymSimple () (Sym a) where
-  genSymSimpleFresh _ = do
-    ident <- getGenSymIdent
-    GenSymIndex i <- nextGenSymIndex
+  simpleFresh _ = do
+    ident <- getFreshIdent
+    FreshIndex i <- nextFreshIndex
     case ident of
-      GenSymIdent s -> return $ isymb s i
-      GenSymIdentWithInfo s info -> return $ iinfosymb s i info
+      FreshIdent s -> return $ isymb s i
+      FreshIdentWithInfo s info -> return $ iinfosymb s i info
 
 instance (SymBoolOp (Sym Bool), SupportedPrim a) => GGenSym (Sym Bool) (Sym a) (Sym a)
 
 instance (SymBoolOp (Sym Bool), SupportedPrim a) => GenSymSimple (Sym a) (Sym a) where
-  genSymSimpleFresh _ = genSymSimpleFresh ()
+  simpleFresh _ = simpleFresh ()
 
 instance (SupportedPrim a) => Show (Sym a) where
   show (Sym t) = pformat t


### PR DESCRIPTION
This pull request simplifies some APIs for symbolic generation, e.g., `genSymFresh` becomes `fresh`.