### PR TITLE
More powerful CEGIS interface

### DIFF
--- a/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
+++ b/grisette-backend-sbv/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
@@ -19,6 +19,7 @@ import qualified Data.SBV.Control as SBVC
 import Grisette.Backend.SBV.Data.SMT.Config
 import Grisette.Backend.SBV.Data.SMT.Lowering
 import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.CEGISSolver
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.ModelOps
@@ -45,7 +46,7 @@ solveTermWith config term = SBV.runSMTWith (sbvConfig config) $ do
         return (m, Right $ parseModel config md m)
       _ -> return (m, Left r)
 
-instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.Model where
+instance Solver (GrisetteSMTConfig n) SymBool SBVC.CheckSatResult PM.Model where
   solveFormula config (Sym t) = snd <$> solveTermWith config t
   solveFormulaMulti config n s@(Sym t)
     | n > 0 = SBV.runSMTWith (sbvConfig config) $ do
@@ -89,6 +90,8 @@ instance Solver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.M
                 return $ md : rmmd
         | otherwise = return [md]
   solveFormulaAll = undefined
+
+instance CEGISSolver (GrisetteSMTConfig n) SymBool SymbolSet SBVC.CheckSatResult PM.Model where
   cegisFormulas ::
     forall forallArg.
     (GExtractSymbolics SymbolSet forallArg, GEvaluateSym PM.Model forallArg) =>

--- a/grisette-backend-sbv/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
+++ b/grisette-backend-sbv/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
@@ -33,7 +33,7 @@ import Test.Tasty.HUnit
 
 testCegis :: (HasCallStack, ExtractSymbolics a, EvaluateSym a, Show a) => GrisetteSMTConfig i -> Bool -> a -> [SymBool] -> Assertion
 testCegis config shouldSuccess a bs = do
-  x <- cegisFallable' config (a, ssymb "internal" :: SymInteger) return (runExceptT $ buildFormula bs)
+  x <- cegisExceptVC config (a, ssymb "internal" :: SymInteger) return (runExceptT $ buildFormula bs)
   case x of
     Left _ -> shouldSuccess @=? False
     Right (_, m) -> do

--- a/grisette-backend-sbv/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
+++ b/grisette-backend-sbv/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
@@ -14,6 +14,7 @@ import Grisette.Backend.SBV.Data.SMT.Solving ()
 import Grisette.Core.Control.Exception
 import Grisette.Core.Data.Class.BitVector
 import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.CEGISSolver
 import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics

--- a/grisette-core/grisette-core.cabal
+++ b/grisette-core/grisette-core.cabal
@@ -48,6 +48,7 @@ library
       Grisette.Core.Control.Monad.UnionMBase
       Grisette.Core.Data.Class.BitVector
       Grisette.Core.Data.Class.Bool
+      Grisette.Core.Data.Class.CEGISSolver
       Grisette.Core.Data.Class.Error
       Grisette.Core.Data.Class.Evaluate
       Grisette.Core.Data.Class.ExtractSymbolics

--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -185,12 +185,16 @@ module Grisette.Core
 
     -- * Solver interface
     Solver (..),
+    UnionWithExcept (..),
+    solveExcept,
+    solveMultiExcept,
     CEGISSolver (..),
-    ExtractUnionEither (..),
-    solveFallable,
-    solveMultiFallable,
-    cegisFallable,
-    cegisFallable',
+    CEGISCondition (..),
+    cegisPostCond,
+    cegisExcept,
+    cegisExceptVC,
+    cegisExceptGenInputs,
+    cegisExceptVCGenInputs,
 
     -- * Memoization
     htmemo,

--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -185,6 +185,7 @@ module Grisette.Core
 
     -- * Solver interface
     Solver (..),
+    CEGISSolver (..),
     ExtractUnionEither (..),
     solveFallable,
     solveMultiFallable,
@@ -227,6 +228,7 @@ import Grisette.Core.Control.Monad.Union
 import Grisette.Core.Control.Monad.UnionMBase
 import Grisette.Core.Data.Class.BitVector
 import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.CEGISSolver
 import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics

--- a/grisette-core/src/Grisette/Core/Control/Monad/CBMCExcept.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/CBMCExcept.hs
@@ -39,6 +39,7 @@ import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Solver
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Language.Haskell.TH.Syntax (Lift)
@@ -412,3 +413,9 @@ instance
   ToSym (CBMCExceptT e1 m1 a) (CBMCExceptT e2 m2 b)
   where
   toSym (CBMCExceptT v) = CBMCExceptT $ toSym v
+
+instance
+  (Monad u, GUnionLike bool u, GMergeable bool e, GMergeable bool v) =>
+  UnionWithExcept (CBMCExceptT e u v) u e v
+  where
+  extractUnionExcept = merge . fmap runCBMCEither . runCBMCExceptT

--- a/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
@@ -415,8 +415,8 @@ instance (SymBoolOp bool, IsConcrete k, GMergeable bool t) => GSimpleMergeable b
           r
           (HML.keys l)
 
-instance ExtractUnionEither (UnionMBase bool (Either e v)) (UnionMBase bool) e v where
-  extractUnionEither = id
+instance UnionWithExcept (UnionMBase bool (Either e v)) (UnionMBase bool) e v where
+  extractUnionExcept = id
 
-instance SymBoolOp bool => ExtractUnionEither (UnionMBase bool (CBMCEither e v)) (UnionMBase bool) e v where
-  extractUnionEither = fmap runCBMCEither
+instance SymBoolOp bool => UnionWithExcept (UnionMBase bool (CBMCEither e v)) (UnionMBase bool) e v where
+  extractUnionExcept = fmap runCBMCEither

--- a/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Grisette.Core.Data.Class.CEGISSolver
+  ( CEGISSolver (..),
+    cegisFallable,
+    cegisFallable',
+  )
+where
+
+import Grisette.Core.Control.Exception
+import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.Evaluate
+import Grisette.Core.Data.Class.ExtractSymbolics
+import Grisette.Core.Data.Class.PrimWrapper
+import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Solver
+
+class
+  (SymBoolOp bool, GEvaluateSym model bool) =>
+  CEGISSolver config bool symbolSet failure model
+    | config -> bool symbolSet failure model
+  where
+  cegisFormula ::
+    (GEvaluateSym model forallArg, GExtractSymbolics symbolSet forallArg) =>
+    config ->
+    forallArg ->
+    bool ->
+    IO (Either failure ([forallArg], model))
+  cegisFormula config forallArg = cegisFormulas config forallArg (conc False)
+  cegisFormulas ::
+    (GEvaluateSym model forallArg, GExtractSymbolics symbolSet forallArg) =>
+    config ->
+    forallArg ->
+    bool ->
+    bool ->
+    IO (Either failure ([forallArg], model))
+
+cegisFallable ::
+  ( ExtractUnionEither t u e v,
+    GUnionPrjOp bool u,
+    Functor u,
+    SymBoolOp bool,
+    GEvaluateSym model forallArgs,
+    GExtractSymbolics symbolSet forallArgs,
+    CEGISSolver config bool symbolSet failure model
+  ) =>
+  config ->
+  forallArgs ->
+  (Either e v -> (bool, bool)) ->
+  t ->
+  IO (Either failure ([forallArgs], model))
+cegisFallable config args f v = uncurry (cegisFormulas config args) (getSingle $ f <$> extractUnionEither v)
+
+cegisFallable' ::
+  ( ExtractUnionEither t u e v,
+    GUnionPrjOp bool u,
+    Monad u,
+    SymBoolOp bool,
+    GEvaluateSym model forallArgs,
+    GExtractSymbolics symbolSet forallArgs,
+    CEGISSolver config bool symbolSet failure model
+  ) =>
+  config ->
+  forallArgs ->
+  (Either e v -> u (Either VerificationConditions ())) ->
+  t ->
+  IO (Either failure ([forallArgs], model))
+cegisFallable' config args f v =
+  uncurry
+    (cegisFormulas config args)
+    ( getSingle $
+        ( \case
+            Left AssumptionViolation -> (conc True, conc False)
+            Left AssertionViolation -> (conc False, conc True)
+            _ -> (conc False, conc False)
+        )
+          <$> (extractUnionEither v >>= f)
+    )

--- a/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -1,40 +1,133 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Grisette.Core.Data.Class.CEGISSolver
   ( CEGISSolver (..),
+    CEGISFormulas (..),
+    cegisPostOnly,
+    cegisPrePost,
+    cegisFormulas,
     cegisFallable,
     cegisFallable',
+    cegisFallableGenForalls,
+    cegisFallableGenForalls',
   )
 where
 
+import GHC.Generics
+import Generics.Deriving
 import Grisette.Core.Control.Exception
 import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
+import Grisette.Core.Data.Class.GenSym
+import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solver
+
+data CEGISFormulas bool = CEGISFormulas bool bool deriving (Generic)
+
+cegisPostOnly :: SymBoolOp bool => bool -> CEGISFormulas bool
+cegisPostOnly = CEGISFormulas (conc True)
+
+cegisPrePost :: SymBoolOp bool => bool -> bool -> CEGISFormulas bool
+cegisPrePost = CEGISFormulas
+
+deriving via (Default (CEGISFormulas bool)) instance SymBoolOp bool => GMergeable bool (CEGISFormulas bool)
+
+deriving via (Default (CEGISFormulas bool)) instance SymBoolOp bool => GSimpleMergeable bool (CEGISFormulas bool)
 
 class
   (SymBoolOp bool, GEvaluateSym model bool) =>
   CEGISSolver config bool symbolSet failure model
     | config -> bool symbolSet failure model
   where
-  cegisFormula ::
-    (GEvaluateSym model forallArg, GExtractSymbolics symbolSet forallArg) =>
+  cegisFormulasGenForalls ::
+    (GEvaluateSym model inputs, GExtractSymbolics symbolSet inputs, GenSymSimple spec inputs) =>
     config ->
-    forallArg ->
-    bool ->
-    IO (Either failure ([forallArg], model))
-  cegisFormula config forallArg = cegisFormulas config forallArg (conc False)
-  cegisFormulas ::
-    (GEvaluateSym model forallArg, GExtractSymbolics symbolSet forallArg) =>
-    config ->
-    forallArg ->
-    bool ->
-    bool ->
-    IO (Either failure ([forallArg], model))
+    [spec] ->
+    [inputs] ->
+    (inputs -> CEGISFormulas bool) ->
+    IO (Either failure ([inputs], model))
+
+cegisFormulas ::
+  ( CEGISSolver config bool symbolSet failure model,
+    GEvaluateSym model forallArg,
+    GExtractSymbolics symbolSet forallArg
+  ) =>
+  config ->
+  forallArg ->
+  CEGISFormulas bool ->
+  IO (Either failure ([forallArg], model))
+cegisFormulas config forallArg formula = do
+  r <-
+    cegisFormulasGenForalls
+      config
+      [IdGen forallArg]
+      []
+      (\(_ :: IdGen forallArg) -> formula)
+  case r of
+    Left f -> return $ Left f
+    Right (cexes, mo) -> return $ Right (runIdGen <$> cexes, mo)
+
+cegisFallableGenForalls ::
+  ( CEGISSolver config bool symbolSet failure model,
+    GEvaluateSym model inputs,
+    GExtractSymbolics symbolSet inputs,
+    GenSymSimple spec inputs,
+    ExtractUnionEither t u e v,
+    GUnionPrjOp bool u,
+    Monad u,
+    SymBoolOp bool
+  ) =>
+  config ->
+  [spec] ->
+  [inputs] ->
+  (Either e v -> CEGISFormulas bool) ->
+  (inputs -> t) ->
+  IO (Either failure ([inputs], model))
+cegisFallableGenForalls config inputGen cexes interpretFunc f =
+  cegisFormulasGenForalls config inputGen cexes (getSingle . (interpretFunc <$>) . extractUnionEither . f)
+
+cegisFallableGenForalls' ::
+  ( CEGISSolver config bool symbolSet failure model,
+    GEvaluateSym model inputs,
+    GExtractSymbolics symbolSet inputs,
+    GenSymSimple spec inputs,
+    ExtractUnionEither t u e v,
+    GUnionPrjOp bool u,
+    Monad u,
+    SymBoolOp bool
+  ) =>
+  config ->
+  [spec] ->
+  [inputs] ->
+  (Either e v -> u (Either VerificationConditions ())) ->
+  (inputs -> t) ->
+  IO (Either failure ([inputs], model))
+cegisFallableGenForalls' config inputGen cexes interpretFunc f =
+  cegisFormulasGenForalls
+    config
+    inputGen
+    cexes
+    ( \v ->
+        getSingle
+          ( ( \case
+                Left AssumptionViolation -> cegisPrePost (conc False) (conc True)
+                Left AssertionViolation -> cegisPostOnly (conc False)
+                _ -> cegisPostOnly (conc True)
+            )
+              <$> (extractUnionEither (f v) >>= interpretFunc)
+          )
+    )
 
 cegisFallable ::
   ( ExtractUnionEither t u e v,
@@ -47,10 +140,10 @@ cegisFallable ::
   ) =>
   config ->
   forallArgs ->
-  (Either e v -> (bool, bool)) ->
+  (Either e v -> CEGISFormulas bool) ->
   t ->
   IO (Either failure ([forallArgs], model))
-cegisFallable config args f v = uncurry (cegisFormulas config args) (getSingle $ f <$> extractUnionEither v)
+cegisFallable config args f v = cegisFormulas config args $ getSingle $ f <$> extractUnionEither v
 
 cegisFallable' ::
   ( ExtractUnionEither t u e v,
@@ -67,13 +160,22 @@ cegisFallable' ::
   t ->
   IO (Either failure ([forallArgs], model))
 cegisFallable' config args f v =
-  uncurry
-    (cegisFormulas config args)
-    ( getSingle $
-        ( \case
-            Left AssumptionViolation -> (conc True, conc False)
-            Left AssertionViolation -> (conc False, conc True)
-            _ -> (conc False, conc False)
-        )
-          <$> (extractUnionEither v >>= f)
-    )
+  cegisFormulas config args $
+    getSingle $
+      ( \case
+          Left AssumptionViolation -> cegisPrePost (conc False) (conc True)
+          Left AssertionViolation -> cegisPostOnly (conc False)
+          _ -> cegisPostOnly (conc True)
+      )
+        <$> (extractUnionEither v >>= f)
+
+newtype IdGen x = IdGen {runIdGen :: x}
+
+instance GEvaluateSym model x => GEvaluateSym model (IdGen x) where
+  gevaluateSym fillDefault model (IdGen v) = IdGen (gevaluateSym fillDefault model v)
+
+instance GExtractSymbolics set x => GExtractSymbolics set (IdGen x) where
+  gextractSymbolics (IdGen v) = gextractSymbolics v
+
+instance GenSymSimple (IdGen x) (IdGen x) where
+  simpleFresh = return

--- a/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
@@ -15,9 +15,9 @@
 
 module Grisette.Core.Data.Class.Solver
   ( Solver (..),
-    ExtractUnionEither (..),
-    solveFallable,
-    solveMultiFallable,
+    UnionWithExcept (..),
+    solveExcept,
+    solveMultiExcept,
   )
 where
 
@@ -51,14 +51,14 @@ class
   solveFormulaMulti :: config -> Int -> bool -> IO [model]
   solveFormulaAll :: config -> Int -> bool -> IO [model]
 
-class ExtractUnionEither t u e v | t -> u e v where
-  extractUnionEither :: t -> u (Either e v)
+class UnionWithExcept t u e v | t -> u e v where
+  extractUnionExcept :: t -> u (Either e v)
 
-instance ExtractUnionEither (ExceptT e u v) u e v where
-  extractUnionEither = runExceptT
+instance UnionWithExcept (ExceptT e u v) u e v where
+  extractUnionExcept = runExceptT
 
-solveFallable ::
-  ( ExtractUnionEither t u e v,
+solveExcept ::
+  ( UnionWithExcept t u e v,
     GUnionPrjOp bool u,
     Functor u,
     SymBoolOp bool,
@@ -68,10 +68,10 @@ solveFallable ::
   (Either e v -> bool) ->
   t ->
   IO (Either failure model)
-solveFallable config f v = solveFormula config (getSingle $ f <$> extractUnionEither v)
+solveExcept config f v = solveFormula config (getSingle $ f <$> extractUnionExcept v)
 
-solveMultiFallable ::
-  ( ExtractUnionEither t u e v,
+solveMultiExcept ::
+  ( UnionWithExcept t u e v,
     GUnionPrjOp bool u,
     Functor u,
     SymBoolOp bool,
@@ -82,4 +82,4 @@ solveMultiFallable ::
   (Either e v -> bool) ->
   t ->
   IO [model]
-solveMultiFallable config n f v = solveFormulaMulti config n (getSingle $ f <$> extractUnionEither v)
+solveMultiExcept config n f v = solveFormulaMulti config n (getSingle $ f <$> extractUnionExcept v)

--- a/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
@@ -51,7 +51,6 @@ class
   solveFormulaMulti :: config -> Int -> bool -> IO [model]
   solveFormulaAll :: config -> Int -> bool -> IO [model]
 
-
 class ExtractUnionEither t u e v | t -> u e v where
   extractUnionEither :: t -> u (Either e v)
 


### PR DESCRIPTION
This pull request introduces a more powerful CEGIS interface.

Example usage:

```haskell
cegisGenInputs
  (UnboundedReasoning z3)              -- the solver configuration 
  [SimpleListSpec x () | x <- [1..2]]  -- the specifications to generate inputs
  [[1 :: SymInteger]]                  -- initial counterexamples
  (\case                               -- the function to generate cegis formulas
    [x] -> cegisPostOnly $ abs x >~ "a" + 10            -- we want abs x >~ "a" + 10
    [x,y] -> cegisPostOnly $ abs x + abs y >~ "b" + 20) -- we want abs x + abs y >~ "b" + 20
```

The result would be

```haskell
Right ([[1I],[0I]],Model {b -> -21 :: Integer, a -> -11 :: Integer})
```

Showing that the solver get the the result `{a = -11, b = -21}` with two counterexamples `[1]`, `[0]`.
