### PR TITLE
Rename getSingle to simpleMerge

### DIFF
--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -77,7 +77,7 @@ module Grisette.Core
     -- withUnionGSimpleMergeable,
     -- withUnionGSimpleMergeableU,
     GMonadUnion,
-    getSingle,
+    simpleMerge,
     {-
     mrgReturnWithStrategy,
     mrgBindWithStrategy,

--- a/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
@@ -204,7 +204,7 @@ instance SymBoolOp bool => GUnionLike bool (UnionMBase bool) where
   {-# INLINE unionIf #-}
 
 instance (SymBoolOp bool, GSEq bool a) => GSEq bool (UnionMBase bool a) where
-  x `gsymeq` y = getSingle $ do
+  x `gsymeq` y = simpleMerge $ do
     x1 <- x
     y1 <- y
     mrgSingle $ x1 `gsymeq` y1
@@ -217,19 +217,19 @@ liftToGMonadUnion u = go (underlyingUnion u)
     go (If _ _ c t f) = mrgIf c (go t) (go f)
 
 instance (SymBoolOp bool, GSOrd bool a) => GSOrd bool (UnionMBase bool a) where
-  x `gsymle` y = getSingle $ do
+  x `gsymle` y = simpleMerge $ do
     x1 <- x
     y1 <- y
     mrgSingle $ x1 `gsymle` y1
-  x `gsymlt` y = getSingle $ do
+  x `gsymlt` y = simpleMerge $ do
     x1 <- x
     y1 <- y
     mrgSingle $ x1 `gsymlt` y1
-  x `gsymge` y = getSingle $ do
+  x `gsymge` y = simpleMerge $ do
     x1 <- x
     y1 <- y
     mrgSingle $ x1 `gsymge` y1
-  x `gsymgt` y = getSingle $ do
+  x `gsymgt` y = simpleMerge $ do
     x1 <- x
     y1 <- y
     mrgSingle $ x1 `gsymgt` y1

--- a/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -82,7 +82,7 @@ cegisExceptMultiInputs ::
   (inputs -> t) ->
   IO (Either failure ([inputs], model))
 cegisExceptMultiInputs config cexes interpretFunc f =
-  cegisMultiInputs config cexes (getSingle . (interpretFunc <$>) . extractUnionExcept . f)
+  cegisMultiInputs config cexes (simpleMerge . (interpretFunc <$>) . extractUnionExcept . f)
 
 cegisExceptVCMultiInputs ::
   ( CEGISSolver config bool symbolSet failure model,
@@ -103,7 +103,7 @@ cegisExceptVCMultiInputs config cexes interpretFunc f =
     config
     cexes
     ( \v ->
-        getSingle
+        simpleMerge
           ( ( \case
                 Left AssumptionViolation -> cegisPrePost (conc False) (conc True)
                 Left AssertionViolation -> cegisPostCond (conc False)
@@ -127,7 +127,7 @@ cegisExcept ::
   (Either e v -> CEGISCondition bool) ->
   t ->
   IO (Either failure ([forallArgs], model))
-cegisExcept config args f v = cegis config args $ getSingle $ f <$> extractUnionExcept v
+cegisExcept config args f v = cegis config args $ simpleMerge $ f <$> extractUnionExcept v
 
 cegisExceptVC ::
   ( UnionWithExcept t u e v,
@@ -145,7 +145,7 @@ cegisExceptVC ::
   IO (Either failure ([forallArgs], model))
 cegisExceptVC config args f v =
   cegis config args $
-    getSingle $
+    simpleMerge $
       ( \case
           Left AssumptionViolation -> cegisPrePost (conc False) (conc True)
           Left AssertionViolation -> cegisPostCond (conc False)

--- a/grisette-core/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -23,7 +23,7 @@ module Grisette.Core.Data.Class.SimpleMergeable
     GUnionPrjOp (..),
     pattern SingleU,
     pattern IfU,
-    getSingle,
+    simpleMerge,
     (#~),
   )
 where
@@ -604,20 +604,20 @@ pattern IfU c t f <-
   where
     IfU c t f = unionIf c t f
 
--- | Extract the value from a union-like monad if the value has a simply mergeable type.
+-- | Merge the simply mergeable values in a union, and extract the merged value.
 --
--- 'unionIf' will not merge the results.
--- 'getSingle' will merge it and extract the single value.
+-- In the following example, 'unionIf' will not merge the results, and
+-- 'simpleMerge' will merge it and extract the single merged value.
 --
 -- >>> unionIf (ssymb "a") (return $ ssymb "b") (return $ ssymb "c") :: UnionM SymBool
 -- UAny (If a (Single b) (Single c))
--- >>> getSingle $ (unionIf (ssymb "a") (return $ ssymb "b") (return $ ssymb "c") :: UnionM SymBool)
+-- >>> simpleMerge $ (unionIf (ssymb "a") (return $ ssymb "b") (return $ ssymb "c") :: UnionM SymBool)
 -- (ite a b c)
-getSingle :: forall bool u a. (GSimpleMergeable bool a, GUnionLike bool u, GUnionPrjOp bool u) => u a -> a
-getSingle u = case merge u of
+simpleMerge :: forall bool u a. (GSimpleMergeable bool a, GUnionLike bool u, GUnionPrjOp bool u) => u a -> a
+simpleMerge u = case merge u of
   SingleU x -> x
   _ -> error "Should not happen"
-{-# INLINE getSingle #-}
+{-# INLINE simpleMerge #-}
 
 -- | Helper for applying functions on 'GUnionPrjOp' and 'GSimpleMergeable'.
 --
@@ -629,7 +629,7 @@ getSingle u = case merge u of
   f ->
   u (Arg f) ->
   Ret f
-(#~) f u = getSingle $ fmap (f #) u
+(#~) f u = simpleMerge $ fmap (f #) u
 {-# INLINE (#~) #-}
 
 infixl 9 #~

--- a/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/Solver.hs
@@ -61,7 +61,7 @@ solveExcept ::
   (Either e v -> bool) ->
   t ->
   IO (Either failure model)
-solveExcept config f v = solveFormula config (getSingle $ f <$> extractUnionExcept v)
+solveExcept config f v = solveFormula config (simpleMerge $ f <$> extractUnionExcept v)
 
 solveMultiExcept ::
   ( UnionWithExcept t u e v,
@@ -75,4 +75,4 @@ solveMultiExcept ::
   (Either e v -> bool) ->
   t ->
   IO [model]
-solveMultiExcept config n f v = solveFormulaMulti config n (getSingle $ f <$> extractUnionExcept v)
+solveMultiExcept config n f v = solveFormulaMulti config n (simpleMerge $ f <$> extractUnionExcept v)

--- a/grisette-core/test/Grisette/Core/Data/Class/UnionLikeTests.hs
+++ b/grisette-core/test/Grisette/Core/Data/Class/UnionLikeTests.hs
@@ -21,8 +21,8 @@ unionLikeTests :: TestTree
 unionLikeTests =
   testGroup
     "UnionLikeTests"
-    [ testCase "getSingle" $
-        getSingle (unionIf (SSBool "a") (single $ SSBool "b") (single $ SSBool "c") :: UnionMBase SBool SBool)
+    [ testCase "simpleMerge" $
+        simpleMerge (unionIf (SSBool "a") (single $ SSBool "b") (single $ SSBool "c") :: UnionMBase SBool SBool)
           @=? ITE (SSBool "a") (SSBool "b") (SSBool "c"),
       testGroup
         "UnionLike"


### PR DESCRIPTION
This pull request renames the `getSingle` API to `simpleMerge` to reflect the fact that a `simpleMerge` merges the simply-mergeable values in a union container.