### PR TITLE
Add GSubstituteSym instance for UnionMBase

### DIFF
--- a/grisette-core/grisette-core.cabal
+++ b/grisette-core/grisette-core.cabal
@@ -86,6 +86,7 @@ library
       Grisette.TestUtils.SBool
       Grisette.TestUtils.SEq
       Grisette.TestUtils.SOrd
+      Grisette.TestUtils.Substitute
       Grisette.TestUtils.ToCon
       Grisette.TestUtils.ToSym
   other-modules:
@@ -126,6 +127,7 @@ test-suite spec
       Grisette.Core.Data.Class.SEqTests
       Grisette.Core.Data.Class.SimpleMergeableTests
       Grisette.Core.Data.Class.SOrdTests
+      Grisette.Core.Data.Class.SubstituteSymTests
       Grisette.Core.Data.Class.ToConTests
       Grisette.Core.Data.Class.ToSymTests
       Grisette.Core.Data.Class.UnionLikeTests

--- a/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
+++ b/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs
@@ -46,6 +46,7 @@ import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solver
+import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Core.Data.UnionBase
@@ -269,6 +270,17 @@ instance (SymBoolOp bool, GMergeable bool a, GEvaluateSym model a, GEvaluateSym 
       go (If _ _ cond t f) =
         mrgIf
           (gevaluateSym fillDefault model cond)
+          (go t)
+          (go f)
+
+instance (SymBoolOp bool, GMergeable bool a, GSubstituteSym ts s a, GSubstituteSym ts s bool) => GSubstituteSym ts s (UnionMBase bool a) where
+  gsubstituteSym sym val x = go $ underlyingUnion x
+    where
+      go :: UnionBase bool a -> UnionMBase bool a
+      go (Single v) = mrgSingle $ gsubstituteSym sym val v
+      go (If _ _ cond t f) =
+        mrgIf
+          (gsubstituteSym sym val cond)
           (go t)
           (go f)
 

--- a/grisette-core/src/Grisette/TestUtils/SBool.hs
+++ b/grisette-core/src/Grisette/TestUtils/SBool.hs
@@ -19,6 +19,7 @@ import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Lib.Control.Monad
@@ -154,8 +155,6 @@ data Symbol where
   ISymbol :: String -> Int -> Symbol
   IISymbol :: (Typeable a, Show a, Eq a, Hashable a) => String -> Int -> a -> Symbol
 
--- deriving (Generic, Show, Eq, Hashable)
-
 instance Show Symbol where
   show (SSymbol s) = "SSymbol " ++ s
   show (ISSymbol s info) = "ISSymbol " ++ s ++ " " ++ show info
@@ -222,3 +221,25 @@ instance GGenSym SBool SBool SBool
 
 instance GenSymSimple SBool SBool where
   simpleFresh _ = simpleFresh ()
+
+data TSymbol a where
+  TSymbol :: Symbol -> TSymbol a
+
+data TSBool a where
+  TSBool :: SBool -> TSBool Bool
+
+instance GSubstituteSymSymbol TSymbol TSBool
+
+instance GSubstituteSym TSymbol TSBool SBool where
+  gsubstituteSym (TSymbol s) (TSBool t) v = go s v
+    where
+      go s (CBool v) = CBool v
+      go s (SSBool sym) = if s == SSymbol sym then t else SSBool sym
+      go s (ISSBool sym info) = if s == ISSymbol sym info then t else ISSBool sym info
+      go s (ISBool sym i) = if s == ISymbol sym i then t else ISBool sym i
+      go s (IISBool sym i info) = if s == IISymbol sym i info then t else IISBool sym i info
+      go s (Or l r) = Or (go s l) (go s r)
+      go s (And l r) = And (go s l) (go s r)
+      go s (Not v) = Not (go s v)
+      go s (Equal l r) = Equal (go s l) (go s r)
+      go s (ITE c l r) = ITE (go s c) (go s l) (go s r)

--- a/grisette-core/src/Grisette/TestUtils/Substitute.hs
+++ b/grisette-core/src/Grisette/TestUtils/Substitute.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Grisette.TestUtils.Substitute (concreteGSubstituteSymOkProp) where
+
+import qualified Data.HashMap.Strict as M
+import GHC.Stack
+import Grisette.Core.Data.Class.Substitute
+import Grisette.TestUtils.Assertions
+import Grisette.TestUtils.SBool
+
+concreteGSubstituteSymOkProp :: (HasCallStack, GSubstituteSym TSymbol TSBool a, Show a, Eq a) => a -> Assertion
+concreteGSubstituteSymOkProp x = gsubstituteSym (TSymbol $ SSymbol "a") (TSBool $ SSBool "b") x @=? x

--- a/grisette-core/test/Grisette/Core/Control/Monad/UnionMBaseTests.hs
+++ b/grisette-core/test/Grisette/Core/Control/Monad/UnionMBaseTests.hs
@@ -19,6 +19,7 @@ import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.PrimWrapper
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Core.Data.UnionBase
@@ -419,6 +420,41 @@ unionMBaseTests =
           @=? (mrgSingle $ Right $ CBool False :: UnionMBase SBool (Either SBool SBool))
         gevaluateSym False model1 (mrgIf (SSBool "a") (mrgSingle $ Left (SSBool "b")) (mrgSingle $ Right (SSBool "c")))
           @=? (mrgSingle $ Left $ CBool False :: UnionMBase SBool (Either SBool SBool)),
+      testCase "SubstituteSym" $ do
+        let asym = TSymbol $ SSymbol "a"
+        let a = SSBool "a"
+        let b = SSBool "b"
+        let c = SSBool "c"
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgSingle $ Left a :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgSingle (Left b)
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgSingle $ Left c :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgSingle (Left c)
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgSingle $ Right a :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgSingle (Right b)
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgSingle $ Right c :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgSingle (Right c)
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgIf a (mrgSingle $ Left a) (mrgSingle $ Right c) :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgIf b (mrgSingle $ Left b) (mrgSingle $ Right c)
+        gsubstituteSym
+          asym
+          (TSBool b)
+          (mrgIf c (mrgSingle $ Left c) (mrgSingle $ Right a) :: UnionMBase SBool (Either SBool SBool))
+          @=? mrgIf c (mrgSingle $ Left c) (mrgSingle $ Right b),
       testCase "ExtractSymbolic" $ do
         gextractSymbolics (mrgSingle $ SSBool "a" :: UnionMBase SBool SBool)
           @=? S.singleton (SSymbol "a")

--- a/grisette-core/test/Grisette/Core/Data/Class/SubstituteSymTests.hs
+++ b/grisette-core/test/Grisette/Core/Data/Class/SubstituteSymTests.hs
@@ -1,0 +1,327 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Grisette.Core.Data.Class.SubstituteSymTests where
+
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Trans.Maybe
+import qualified Control.Monad.Writer.Lazy as WriterLazy
+import qualified Control.Monad.Writer.Strict as WriterStrict
+import qualified Data.ByteString as B
+import Data.Functor.Sum
+import qualified Data.HashMap.Strict as M
+import Data.Int
+import Data.Word
+import Grisette.Core.Data.Class.Substitute
+import Grisette.TestUtils.SBool
+import Grisette.TestUtils.Substitute
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
+
+gsubstituteSymTests :: TestTree
+gsubstituteSymTests =
+  testGroup
+    "GSubstituteSymTests"
+    [ testGroup
+        "GSubstituteSym for common types"
+        [ testCase "SBool" $ do
+            let asym = TSymbol $ SSymbol "a"
+            let a = SSBool "a"
+            let b = SSBool "b"
+            let c = SSBool "c"
+            gsubstituteSym asym (TSBool b) a @?= b
+            gsubstituteSym asym (TSBool b) c @?= c
+            gsubstituteSym asym (TSBool b) (Or a c) @?= Or b c,
+          testProperty "Bool" (ioProperty . concreteGSubstituteSymOkProp @Bool),
+          testProperty "Integer" (ioProperty . concreteGSubstituteSymOkProp @Integer),
+          testProperty "Char" (ioProperty . concreteGSubstituteSymOkProp @Char),
+          testProperty "Int" (ioProperty . concreteGSubstituteSymOkProp @Int),
+          testProperty "Int8" (ioProperty . concreteGSubstituteSymOkProp @Int8),
+          testProperty "Int16" (ioProperty . concreteGSubstituteSymOkProp @Int16),
+          testProperty "Int32" (ioProperty . concreteGSubstituteSymOkProp @Int32),
+          testProperty "Int64" (ioProperty . concreteGSubstituteSymOkProp @Int64),
+          testProperty "Word" (ioProperty . concreteGSubstituteSymOkProp @Word),
+          testProperty "Word8" (ioProperty . concreteGSubstituteSymOkProp @Word8),
+          testProperty "Word16" (ioProperty . concreteGSubstituteSymOkProp @Word16),
+          testProperty "Word32" (ioProperty . concreteGSubstituteSymOkProp @Word32),
+          testProperty "Word64" (ioProperty . concreteGSubstituteSymOkProp @Word64),
+          testGroup
+            "List"
+            [ testProperty "[Integer]" (ioProperty . concreteGSubstituteSymOkProp @[Integer]),
+              testCase "[SBool]" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) [a, c] @?= [b, c]
+            ],
+          testGroup
+            "Maybe"
+            [ testProperty "Maybe Integer" (ioProperty . concreteGSubstituteSymOkProp @(Maybe Integer)),
+              testCase "Maybe SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (Just a) @?= Just b
+                gsubstituteSym asym (TSBool b) (Just c) @?= Just c
+                gsubstituteSym asym (TSBool b) (Nothing :: Maybe SBool) @?= Nothing
+            ],
+          testGroup
+            "Either"
+            [ testProperty "Either Integer Integer" (ioProperty . concreteGSubstituteSymOkProp @(Either Integer Integer)),
+              testCase "Either SBool SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (Left a :: Either SBool SBool) @?= Left b
+                gsubstituteSym asym (TSBool b) (Left c :: Either SBool SBool) @?= Left c
+                gsubstituteSym asym (TSBool b) (Right a :: Either SBool SBool) @?= Right a
+                gsubstituteSym asym (TSBool b) (Right c :: Either SBool SBool) @?= Right c
+            ],
+          testGroup
+            "MaybeT"
+            [ testProperty "MaybeT Maybe Integer" (ioProperty . concreteGSubstituteSymOkProp @(MaybeT Maybe Integer) . MaybeT),
+              testCase "MaybeT Maybe SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (MaybeT Nothing :: MaybeT Maybe SBool) @?= MaybeT Nothing
+                gsubstituteSym asym (TSBool b) (MaybeT (Just Nothing) :: MaybeT Maybe SBool) @?= MaybeT (Just Nothing)
+                gsubstituteSym asym (TSBool b) (MaybeT (Just (Just a))) @?= MaybeT (Just (Just b))
+                gsubstituteSym asym (TSBool b) (MaybeT (Just (Just c))) @?= MaybeT (Just (Just c))
+            ],
+          testGroup
+            "ExceptT"
+            [ testProperty "ExceptT Maybe Integer" (ioProperty . concreteGSubstituteSymOkProp @(ExceptT Integer Maybe Integer) . ExceptT),
+              testCase "ExceptT SBool Maybe SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (ExceptT Nothing :: ExceptT SBool Maybe SBool) @?= ExceptT Nothing
+                gsubstituteSym asym (TSBool b) (ExceptT $ Just $ Left "a" :: ExceptT SBool Maybe SBool) @?= ExceptT (Just $ Left "b")
+                gsubstituteSym asym (TSBool b) (ExceptT $ Just $ Left "c" :: ExceptT SBool Maybe SBool) @?= ExceptT (Just $ Left "c")
+                gsubstituteSym asym (TSBool b) (ExceptT $ Just $ Right "a" :: ExceptT SBool Maybe SBool) @?= ExceptT (Just $ Right "b")
+                gsubstituteSym asym (TSBool b) (ExceptT $ Just $ Right "c" :: ExceptT SBool Maybe SBool) @?= ExceptT (Just $ Right "c")
+            ],
+          testProperty "()" (ioProperty . concreteGSubstituteSymOkProp @()),
+          testGroup
+            "(,)"
+            [ testProperty "(Integer, Integer)" (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer)),
+              testCase "(SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c) @?= (b, c)
+            ],
+          testGroup
+            "(,,)"
+            [ testProperty
+                "(Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a) @?= (b, c, b)
+            ],
+          testGroup
+            "(,,,)"
+            [ testProperty
+                "(Integer, Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a, c) @?= (b, c, b, c)
+            ],
+          testGroup
+            "(,,,,)"
+            [ testProperty
+                "(Integer, Integer, Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a, c, a) @?= (b, c, b, c, b)
+            ],
+          testGroup
+            "(,,,,,)"
+            [ testProperty
+                "(Integer, Integer, Integer, Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer, Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool, SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a, c, a, c) @?= (b, c, b, c, b, c)
+            ],
+          testGroup
+            "(,,,,,,)"
+            [ testProperty
+                "(Integer, Integer, Integer, Integer, Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer, Integer, Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool, SBool, SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a, c, a, c, a) @?= (b, c, b, c, b, c, b)
+            ],
+          testGroup
+            "(,,,,,,,)"
+            [ testProperty
+                "(Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)"
+                (ioProperty . concreteGSubstituteSymOkProp @(Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)),
+              testCase "(SBool, SBool, SBool, SBool, SBool, SBool, SBool, SBool)" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (a, c, a, c, a, c, a, c) @?= (b, c, b, c, b, c, b, c)
+            ],
+          testProperty "ByteString" (ioProperty . concreteGSubstituteSymOkProp @B.ByteString . B.pack),
+          testGroup
+            "Sum"
+            [ testProperty
+                "Sum Maybe Maybe Integer"
+                ( ioProperty
+                    . concreteGSubstituteSymOkProp @(Sum Maybe Maybe Integer)
+                    . ( \case
+                          Left x -> InL x
+                          Right x -> InL x
+                      )
+                ),
+              testCase
+                "Sum Maybe Maybe SBool"
+                ( do
+                    let asym = TSymbol $ SSymbol "a"
+                    let a = SSBool "a"
+                    let b = SSBool "b"
+                    let c = SSBool "c"
+                    gsubstituteSym asym (TSBool b) (InL Nothing :: Sum Maybe Maybe SBool) @?= InL Nothing
+                    gsubstituteSym asym (TSBool b) (InL (Just a) :: Sum Maybe Maybe SBool) @?= InL (Just b)
+                    gsubstituteSym asym (TSBool b) (InL (Just c) :: Sum Maybe Maybe SBool) @?= InL (Just c)
+                    gsubstituteSym asym (TSBool b) (InR Nothing :: Sum Maybe Maybe SBool) @?= InR Nothing
+                    gsubstituteSym asym (TSBool b) (InR (Just a) :: Sum Maybe Maybe SBool) @?= InR (Just b)
+                    gsubstituteSym asym (TSBool b) (InR (Just c) :: Sum Maybe Maybe SBool) @?= InR (Just c)
+                )
+            ],
+          testGroup
+            "WriterT"
+            [ testGroup
+                "Lazy"
+                [ testProperty
+                    "WriterT Integer (Either Integer) Integer"
+                    ( ioProperty
+                        . concreteGSubstituteSymOkProp
+                          @(WriterLazy.WriterT Integer (Either Integer) Integer)
+                        . WriterLazy.WriterT
+                    ),
+                  testCase "WriterT SBool (Either SBool) SBool" $ do
+                    let asym = TSymbol $ SSymbol "a"
+                    let a = SSBool "a"
+                    let b = SSBool "b"
+                    let c = SSBool "c"
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterLazy.WriterT (Left a) :: WriterLazy.WriterT SBool (Either SBool) SBool)
+                      @?= WriterLazy.WriterT (Left b)
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterLazy.WriterT (Left c) :: WriterLazy.WriterT SBool (Either SBool) SBool)
+                      @?= WriterLazy.WriterT (Left c)
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterLazy.WriterT (Right (a, a)) :: WriterLazy.WriterT SBool (Either SBool) SBool)
+                      @?= WriterLazy.WriterT (Right (b, b))
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterLazy.WriterT (Right (c, c)) :: WriterLazy.WriterT SBool (Either SBool) SBool)
+                      @?= WriterLazy.WriterT (Right (c, c))
+                ],
+              testGroup
+                "Strict"
+                [ testProperty
+                    "WriterT Integer (Either Integer) Integer"
+                    ( ioProperty
+                        . concreteGSubstituteSymOkProp
+                          @(WriterStrict.WriterT Integer (Either Integer) Integer)
+                        . WriterStrict.WriterT
+                    ),
+                  testCase "WriterT SBool (Either SBool) SBool" $ do
+                    let asym = TSymbol $ SSymbol "a"
+                    let a = SSBool "a"
+                    let b = SSBool "b"
+                    let c = SSBool "c"
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterStrict.WriterT (Left a) :: WriterStrict.WriterT SBool (Either SBool) SBool)
+                      @?= WriterStrict.WriterT (Left b)
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterStrict.WriterT (Left c) :: WriterStrict.WriterT SBool (Either SBool) SBool)
+                      @?= WriterStrict.WriterT (Left c)
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterStrict.WriterT (Right (a, a)) :: WriterStrict.WriterT SBool (Either SBool) SBool)
+                      @?= WriterStrict.WriterT (Right (b, b))
+                    gsubstituteSym
+                      asym
+                      (TSBool b)
+                      (WriterStrict.WriterT (Right (c, c)) :: WriterStrict.WriterT SBool (Either SBool) SBool)
+                      @?= WriterStrict.WriterT (Right (c, c))
+                ]
+            ],
+          testGroup
+            "Identity"
+            [ testProperty
+                "Identity Integer"
+                (ioProperty . concreteGSubstituteSymOkProp @(Identity Integer)),
+              testCase "Identity SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (Identity a) @?= Identity b
+                gsubstituteSym asym (TSBool b) (Identity c) @?= Identity c
+            ],
+          testGroup
+            "IdentityT"
+            [ testProperty
+                "IdentityT (Either Integer) Integer"
+                (ioProperty . concreteGSubstituteSymOkProp @(IdentityT (Either Integer) Integer) . IdentityT),
+              testCase "IdentityT (Either SBool) SBool" $ do
+                let asym = TSymbol $ SSymbol "a"
+                let a = SSBool "a"
+                let b = SSBool "b"
+                let c = SSBool "c"
+                gsubstituteSym asym (TSBool b) (IdentityT (Left a) :: IdentityT (Either SBool) SBool) @?= IdentityT (Left b)
+                gsubstituteSym asym (TSBool b) (IdentityT (Left c) :: IdentityT (Either SBool) SBool) @?= IdentityT (Left c)
+                gsubstituteSym asym (TSBool b) (IdentityT (Right a) :: IdentityT (Either SBool) SBool) @?= IdentityT (Right b)
+                gsubstituteSym asym (TSBool b) (IdentityT (Right c) :: IdentityT (Either SBool) SBool) @?= IdentityT (Right c)
+            ]
+        ]
+    ]


### PR DESCRIPTION
This pull request adds the missing `GSubstituteSym` instance for `UnionMBase` container.