### PR TITLE
Introduce onUnion combinator

### DIFF
--- a/grisette-core/src/Grisette/Core.hs
+++ b/grisette-core/src/Grisette/Core.hs
@@ -78,6 +78,10 @@ module Grisette.Core
     -- withUnionGSimpleMergeableU,
     GMonadUnion,
     simpleMerge,
+    onUnion,
+    onUnion2,
+    onUnion3,
+    onUnion4,
     {-
     mrgReturnWithStrategy,
     mrgBindWithStrategy,

--- a/grisette-core/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/grisette-core/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -24,6 +24,10 @@ module Grisette.Core.Data.Class.SimpleMergeable
     pattern SingleU,
     pattern IfU,
     simpleMerge,
+    onUnion,
+    onUnion2,
+    onUnion3,
+    onUnion4,
     (#~),
   )
 where
@@ -618,6 +622,42 @@ simpleMerge u = case merge u of
   SingleU x -> x
   _ -> error "Should not happen"
 {-# INLINE simpleMerge #-}
+
+-- | Lift a function to work on union values.
+--
+-- >>> sumU = onUnion sum
+-- >>> sumU (unionIf "cond" (return ["a"]) (return ["b","c"]) :: UnionM [SymInteger])
+-- (ite cond a (+ b c))
+onUnion ::
+  forall bool u a r.
+  (GSimpleMergeable bool r, GUnionLike bool u, GUnionPrjOp bool u, Monad u) =>
+  (a -> r) ->
+  (u a -> r)
+onUnion f = simpleMerge . fmap f
+
+-- | Lift a function to work on union values.
+onUnion2 ::
+  forall bool u a b r.
+  (GSimpleMergeable bool r, GUnionLike bool u, GUnionPrjOp bool u, Monad u) =>
+  (a -> b -> r) ->
+  (u a -> u b -> r)
+onUnion2 f ua ub = simpleMerge $ f <$> ua <*> ub
+
+-- | Lift a function to work on union values.
+onUnion3 ::
+  forall bool u a b c r.
+  (GSimpleMergeable bool r, GUnionLike bool u, GUnionPrjOp bool u, Monad u) =>
+  (a -> b -> c -> r) ->
+  (u a -> u b -> u c -> r)
+onUnion3 f ua ub uc = simpleMerge $ f <$> ua <*> ub <*> uc
+
+-- | Lift a function to work on union values.
+onUnion4 ::
+  forall bool u a b c d r.
+  (GSimpleMergeable bool r, GUnionLike bool u, GUnionPrjOp bool u, Monad u) =>
+  (a -> b -> c -> d -> r) ->
+  (u a -> u b -> u c -> u d -> r)
+onUnion4 f ua ub uc ud = simpleMerge $ f <$> ua <*> ub <*> uc <*> ud
 
 -- | Helper for applying functions on 'GUnionPrjOp' and 'GSimpleMergeable'.
 --

--- a/grisette-core/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
+++ b/grisette-core/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Grisette.Core.Data.Class.SimpleMergeableTests where
@@ -331,5 +332,21 @@ simpleMergeableTests =
             runIdentityT i3 @=? mrgSingle (ITE (SSBool "c") (SSBool "a") (SSBool "b"))
             runIdentityT i31 @=? mrgSingle (ITE (SSBool "c") (SSBool "a") (SSBool "b"))
             runIdentityT i3u1 @=? mrgSingle (ITE (SSBool "c") (SSBool "a") (SSBool "b"))
+        ],
+      testGroup
+        "Combinators"
+        [ testCase "simpleMerge" $ do
+            simpleMerge
+              (unionIf "a" (return "b") (return "c") :: UnionMBase SBool SBool)
+              @=? ITE (SSBool "a") (SSBool "b") (SSBool "c"),
+          testCase "onUnion" $ do
+            let symAll = foldl (&&~) (CBool True)
+            let symAllU = onUnion symAll
+            symAllU (unionIf "cond" (return ["a"]) (return ["b", "c"]) :: UnionMBase SBool [SBool])
+              @=? ITE "cond" "a" ("b" &&~ "c"),
+          testCase "(#~)" $ do
+            let symAll = foldl (&&~) (CBool True)
+            symAll #~ (unionIf "cond" (return ["a"]) (return ["b", "c"]) :: UnionMBase SBool [SBool])
+              @=? ITE "cond" "a" ("b" &&~ "c")
         ]
     ]


### PR DESCRIPTION
This pull request introduces `onUnion` combinator for lifting functions.

Example:

```haskell
>>> sumU = onUnion sum
>>> sumU (unionIf "cond" (return ["a"]) (return ["b","c"]) :: UnionM [SymInteger])
(ite cond a (+ b c))
```