### PR TITLE
Making the type of fresh less specific to improve error messages

### DIFF
--- a/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs-boot
+++ b/grisette-core/src/Grisette/Core/Control/Monad/UnionMBase.hs-boot
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Grisette.Core.Control.Monad.UnionMBase (UnionMBase (..)) where
+
+import Data.IORef
+import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.Mergeable
+import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.UnionBase
+
+data UnionMBase bool a where
+  -- | 'UnionMBase' with no 'Mergeable' knowledge.
+  UAny ::
+    -- | (Possibly) cached merging result.
+    IORef (Either (UnionBase bool a) (UnionMBase bool a)) ->
+    -- | Original 'UnionBase'.
+    UnionBase bool a ->
+    UnionMBase bool a
+  -- | 'UnionMBase' with 'Mergeable' knowledge.
+  UMrg ::
+    -- | Cached merging strategy.
+    GMergingStrategy bool a ->
+    -- | Merged UnionBase
+    UnionBase bool a ->
+    UnionMBase bool a
+
+instance SymBoolOp bool => GUnionLike bool (UnionMBase bool)
+
+instance (SymBoolOp bool) => Functor (UnionMBase bool)
+
+instance (SymBoolOp bool) => Applicative (UnionMBase bool)
+
+instance (SymBoolOp bool) => Monad (UnionMBase bool)

--- a/grisette-symir/src/Grisette/IR/SymPrim/Data/Class/GenSym.hs
+++ b/grisette-symir/src/Grisette/IR/SymPrim/Data/Class/GenSym.hs
@@ -24,17 +24,18 @@ import Data.Proxy
 import GHC.Generics
 import Grisette.Core.Data.Class.GenSym
 import Grisette.IR.SymPrim.Control.Monad.Union
+import Grisette.IR.SymPrim.Control.Monad.UnionM
 import Grisette.IR.SymPrim.Data.Class.Mergeable
 import Grisette.IR.SymPrim.Data.Class.SimpleMergeable
 import Grisette.IR.SymPrim.Data.SymPrim
 
 -- | 'gchooseFresh' specialized with 'SymBool'
-chooseFresh :: (Mergeable a, MonadFresh m, MonadUnion u) => [a] -> m (u a)
+chooseFresh :: (Mergeable a, MonadFresh m) => [a] -> m (UnionM a)
 chooseFresh = gchooseFresh
 {-# INLINE chooseFresh #-}
 
 -- | 'gchoose' specialized with 'SymBool'
-choose :: (Mergeable a, MonadUnion u) => [a] -> FreshIdent -> u a
+choose :: (Mergeable a) => [a] -> FreshIdent -> UnionM a
 choose = gchoose
 {-# INLINE choose #-}
 
@@ -49,11 +50,11 @@ chooseSimple = gchooseSimple (Proxy @SymBool)
 {-# INLINE chooseSimple #-}
 
 -- | 'gchooseUnionFresh' specialized with 'SymBool'
-chooseUnionFresh :: (Mergeable a, MonadFresh m, MonadUnion u) => [u a] -> m (u a)
+chooseUnionFresh :: (Mergeable a, MonadFresh m) => [UnionM a] -> m (UnionM a)
 chooseUnionFresh = gchooseUnionFresh
 {-# INLINE chooseUnionFresh #-}
 
 -- | 'gchooseUnion' specialized with 'SymBool'
-chooseUnion :: (Mergeable a, MonadUnion u) => [u a] -> FreshIdent -> u a
+chooseUnion :: (Mergeable a) => [UnionM a] -> FreshIdent -> UnionM a
 chooseUnion = gchooseUnion
 {-# INLINE chooseUnion #-}


### PR DESCRIPTION
This pull request makes the type of `fresh` function less specific. This could improve the error messages when `fresh` is used without an `UnionM`.

Before:
```haskell
ghci> runFresh (fresh ()) "a" :: SymInteger

<interactive>:2:11: error:
    • No instance for (GenSym bool0 () Integer)
        arising from a use of ‘fresh’
    • In the first argument of ‘runFresh’, namely ‘(fresh ())’
      In the expression: runFresh (fresh ()) "a" :: SymInteger
      In an equation for ‘it’: it = runFresh (fresh ()) "a" :: SymInteger
```

After:
```haskell
ghci> runFresh (fresh ()) "a" :: SymInteger

<interactive>:3:1: error:
    • Couldn't match type: UnionMBase bool0 a0
                     with: Sym Integer
      Expected: SymInteger
        Actual: UnionMBase bool0 a0
    • In the expression: runFresh (fresh ()) "a" :: SymInteger
      In an equation for ‘it’: it = runFresh (fresh ()) "a" :: SymInteger
```