### PR TITLE
Drop UAny merging result cache

### DIFF
--- a/src/Grisette/Core/Control/Monad/UnionM.hs-boot
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs-boot
@@ -13,8 +13,6 @@ import Grisette.Core.Data.Union
 data UnionM a where
   -- | 'UnionM' with no 'Mergeable' knowledge.
   UAny ::
-    -- | (Possibly) cached merging result.
-    IORef (Either (Union a) (UnionM a)) ->
     -- | Original 'Union'.
     Union a ->
     UnionM a


### PR DESCRIPTION
This pull request drops the merging result cache for `UAny`.

This merging result cache aimed to make multiple `merge` call on the same `UAny` faster. It turns out that this does not help much in real-world scenarios, but introduces segmentation faults.

We decided not to fix the bug, but totally drop the cache.