### PR TITLE
Remove libncurses5 dependency for hlint

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -13,11 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install OS Packages
-      uses: mstksg/get-package@v1
-      with:
-        apt-get: libncurses5
-
     - name: 'Set up HLint'
       uses: haskell/actions/hlint-setup@v2
 


### PR DESCRIPTION
As haskell/actions/hlint-setup has upgraded to hlint 3.5, the libncurses5 is not longer required. This pull request removes it.