### PR TITLE
Add missing instances for new symirs

### DIFF
--- a/src/Grisette/Core/Data/Class/Bool.hs
+++ b/src/Grisette/Core/Data/Class/Bool.hs
@@ -1,7 +1,9 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE Trustworthy #-}
@@ -40,6 +42,7 @@ import qualified Data.ByteString as B
 import Data.Functor.Sum
 import Data.Int
 import Data.Word
+import GHC.TypeNats
 import Generics.Deriving
 import {-# SOURCE #-} Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solvable
@@ -329,11 +332,33 @@ instance (SEq (m a)) => SEq (IdentityT m a) where
 
 #define ITEOP_SIMPLE(type) \
 instance ITEOp type where \
-  ites (SymBool c) (type t) (type f) = type $ pevalITETerm c t f
+  ites (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
+  {-# INLINE ites #-}
+
+#define ITEOP_BV(type) \
+instance (KnownNat n, 1 <= n) => ITEOp (type n) where \
+  ites (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
+  {-# INLINE ites #-}
+
+#define ITEOP_BV_SOME(symtype, bf) \
+instance ITEOp symtype where \
+  ites c = bf (ites c) "ites"; \
+  {-# INLINE ites #-}
+
+#define ITEOP_FUN(op, cons) \
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ITEOp (sa op sb) where \
+  ites (SymBool c) (cons t) (cons f) = cons $ pevalITETerm c t f; \
+  {-# INLINE ites #-}
 
 #if 1
 ITEOP_SIMPLE(SymBool)
 ITEOP_SIMPLE(SymInteger)
+ITEOP_BV(SymIntN)
+ITEOP_BV(SymWordN)
+ITEOP_BV_SOME(SomeSymIntN, binSomeSymIntNR1)
+ITEOP_BV_SOME(SomeSymWordN, binSomeSymWordNR1)
+ITEOP_FUN(=~>, SymTabularFun)
+ITEOP_FUN(-~>, SymGeneralFun)
 #endif
 
 instance LogicalOp SymBool where

--- a/src/Grisette/Core/Data/Class/Bool.hs-boot
+++ b/src/Grisette/Core/Data/Class/Bool.hs-boot
@@ -1,5 +1,7 @@
 module Grisette.Core.Data.Class.Bool (LogicalOp (..)) where
 
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+
 class LogicalOp b where
   -- | Symbolic disjunction
   (||~) :: b -> b -> b
@@ -29,3 +31,6 @@ class LogicalOp b where
   {-# INLINE implies #-}
 
   {-# MINIMAL (||~), nots | (&&~), nots #-}
+
+class ITEOp v where
+  ites :: SymBool -> v -> v -> v

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -69,6 +69,7 @@ import Data.Kind
 import qualified Data.Monoid as Monoid
 import Data.Typeable
 import Data.Word
+import GHC.TypeNats
 import Generics.Deriving
 import Grisette.Core.Data.Class.Bool
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
@@ -939,7 +940,25 @@ deriving via (Default1 Monoid.Sum) instance Mergeable1 Monoid.Sum
 instance Mergeable symtype where \
   rootStrategy = SimpleStrategy ites
 
+#define MERGEABLE_BV(symtype) \
+instance (KnownNat n, 1 <= n) => Mergeable (symtype n) where \
+  rootStrategy = SimpleStrategy ites
+
+#define MERGEABLE_BV_SOME(symtype) \
+instance Mergeable symtype where \
+  rootStrategy = SimpleStrategy ites
+
+#define MERGEABLE_FUN(op) \
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Mergeable (sa op sb) where \
+  rootStrategy = SimpleStrategy ites
+
 #if 1
 MERGEABLE_SIMPLE(SymBool)
 MERGEABLE_SIMPLE(SymInteger)
+MERGEABLE_BV(SymIntN)
+MERGEABLE_BV(SymWordN)
+MERGEABLE_BV_SOME(SomeSymIntN)
+MERGEABLE_BV_SOME(SomeSymWordN)
+MERGEABLE_FUN(=~>)
+MERGEABLE_FUN(-~>)
 #endif

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -2,7 +2,6 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -11,6 +10,9 @@
 
 module Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( SupportedPrim (..),
+    SymRep (..),
+    ConRep (..),
+    LinkedRep (..),
     UnaryOp (..),
     BinaryOp (..),
     TernaryOp (..),
@@ -52,6 +54,21 @@ class (Lift t, Typeable t, Hashable t, Eq t, Show t, NFData t) => SupportedPrim 
   defaultValue :: t
   defaultValueDynamic :: proxy t -> ModelValue
   defaultValueDynamic _ = toModelValue (defaultValue @t)
+
+class ConRep sym where
+  type ConType sym
+
+class SupportedPrim con => SymRep con where
+  type SymType con
+
+class
+  (ConRep sym, SymRep con, sym ~ SymType con, con ~ ConType sym) =>
+  LinkedRep con sym
+    | con -> sym,
+      sym -> con
+  where
+  underlyingTerm :: sym -> Term con
+  wrapTerm :: Term con -> sym
 
 class
   (SupportedPrim arg, SupportedPrim t, Lift tag, NFData tag, Show tag, Typeable tag, Eq tag, Hashable tag) =>

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -39,6 +39,16 @@ module Grisette.IR.SymPrim.Data.SymPrim
     ModelSymPair (..),
     symSize,
     symsSize,
+    unarySomeSymIntN,
+    unarySomeSymIntNR1,
+    binSomeSymIntN,
+    binSomeSymIntNR1,
+    binSomeSymIntNR2,
+    unarySomeSymWordN,
+    unarySomeSymWordNR1,
+    binSomeSymWordN,
+    binSomeSymWordNR1,
+    binSomeSymWordNR2,
   )
 where
 

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
@@ -1,24 +1,74 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Grisette.IR.SymPrim.Data.SymPrim
   ( SymBool (..),
     SymInteger (..),
+    SymIntN (..),
+    SymWordN (..),
+    SomeSymIntN (..),
+    SomeSymWordN (..),
+    type (=~>) (..),
+    type (-~>) (..),
+    unarySomeSymIntN,
+    unarySomeSymIntNR1,
+    binSomeSymIntN,
+    binSomeSymIntNR1,
+    binSomeSymIntNR2,
+    unarySomeSymWordN,
+    unarySomeSymWordNR1,
+    binSomeSymWordN,
+    binSomeSymWordNR1,
+    binSomeSymWordNR2,
   )
 where
 
 import Control.DeepSeq
 import Data.Hashable
 import GHC.Generics
-import {-# SOURCE #-} Grisette.Core.Data.Class.Bool
+import GHC.TypeNats
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Solvable
+import Grisette.IR.SymPrim.Data.BV
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+import Grisette.IR.SymPrim.Data.TabularFun
 import Language.Haskell.TH.Syntax
 
 newtype SymBool = SymBool {underlyingBoolTerm :: Term Bool}
+
+newtype SymIntN (n :: Nat) = SymIntN {underlyingIntNTerm :: Term (IntN n)}
+
+newtype SymWordN (n :: Nat) = SymWordN {underlyingWordNTerm :: Term (WordN n)}
+
+data SomeSymIntN where
+  SomeSymIntN :: (KnownNat n, 1 <= n) => SymIntN n -> SomeSymIntN
+
+data SomeSymWordN where
+  SomeSymWordN :: (KnownNat n, 1 <= n) => SymWordN n -> SomeSymWordN
+
+data sa =~> sb where
+  SymTabularFun :: (LinkedRep ca sa, LinkedRep cb sb) => Term (ca =-> cb) -> sa =~> sb
+
+data sa -~> sb where
+  SymGeneralFun :: (LinkedRep ca sa, LinkedRep cb sb) => Term (ca --> cb) -> sa -~> sb
+
+unarySomeSymIntN :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> r) -> String -> SomeSymIntN -> r
+unarySomeSymIntNR1 :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n) -> String -> SomeSymIntN -> SomeSymIntN
+binSomeSymIntN :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n -> r) -> String -> SomeSymIntN -> SomeSymIntN -> r
+binSomeSymIntNR1 :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n -> SymIntN n) -> String -> SomeSymIntN -> SomeSymIntN -> SomeSymIntN
+binSomeSymIntNR2 :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n -> (SymIntN n, SymIntN n)) -> String -> SomeSymIntN -> SomeSymIntN -> (SomeSymIntN, SomeSymIntN)
+unarySomeSymWordN :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> r) -> String -> SomeSymWordN -> r
+unarySomeSymWordNR1 :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n) -> String -> SomeSymWordN -> SomeSymWordN
+binSomeSymWordN :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n -> r) -> String -> SomeSymWordN -> SomeSymWordN -> r
+binSomeSymWordNR1 :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n -> SymWordN n) -> String -> SomeSymWordN -> SomeSymWordN -> SomeSymWordN
+binSomeSymWordNR2 :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n -> (SymWordN n, SymWordN n)) -> String -> SomeSymWordN -> SomeSymWordN -> (SomeSymWordN, SomeSymWordN)
 
 instance Solvable Bool SymBool
 
@@ -53,3 +103,11 @@ instance Hashable SymInteger
 instance EvaluateSym SymInteger
 
 instance ExtractSymbolics SymInteger
+
+instance (KnownNat n, 1 <= n) => Solvable (WordN n) (SymWordN n)
+
+instance (KnownNat n, 1 <= n) => Solvable (IntN n) (SymIntN n)
+
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Solvable (ca --> cb) (sa -~> sb)
+
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Solvable (ca =-> cb) (sa =~> sb)


### PR DESCRIPTION
This pull request adds some missing instances for `SymIntN`, `SymWordN`, `SomeSymIntN`, `SomeSymBoolN`, `=~>`, and `-~>`.