### PR TITLE
Add API to count term size for a complex type

### DIFF
--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -59,6 +59,7 @@ import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Core.Data.Union
+import Grisette.IR.SymPrim.Data.SymPrim
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Syntax.Compat (unTypeSplice)
 
@@ -487,6 +488,10 @@ instance
     where
       go (Single x) = fresh x
       go (If _ _ _ t f) = mrgIf <$> simpleFresh () <*> go t <*> go f
+
+-- AllSyms
+instance AllSyms a => AllSyms (UnionM a) where
+  allSymsS = allSymsS . underlyingUnion
 
 -- Concrete Key HashMaps
 

--- a/src/Grisette/Core/Data/Union.hs
+++ b/src/Grisette/Core/Data/Union.hs
@@ -128,6 +128,10 @@ instance (Hashable a) => Hashable (Union a) where
   s `hashWithSalt` (Single a) = s `hashWithSalt` (0 :: Int) `hashWithSalt` a
   s `hashWithSalt` (If _ _ c l r) = s `hashWithSalt` (1 :: Int) `hashWithSalt` c `hashWithSalt` l `hashWithSalt` r
 
+instance AllSyms a => AllSyms (Union a) where
+  allSymsS (Single v) = allSymsS v
+  allSymsS (If _ _ c t f) = \l -> SomeSym c : (allSymsS t . allSymsS f $ l)
+
 -- | Fully reconstruct a 'Union' to maintain the merged invariant.
 fullReconstruct :: MergingStrategy a -> Union a -> Union a
 fullReconstruct strategy (If _ False cond t f) =

--- a/src/Grisette/IR/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim.hs
@@ -36,6 +36,8 @@ module Grisette.IR.SymPrim
     TypedSymbol (..),
     symSize,
     symsSize,
+    AllSyms (..),
+    allSymsSize,
 
     -- ** Symbolic constant sets and models
     SymbolSet (..),

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
@@ -16,6 +16,8 @@ module Grisette.IR.SymPrim.Data.SymPrim
     SomeSymWordN (..),
     type (=~>) (..),
     type (-~>) (..),
+    SomeSym (..),
+    AllSyms (..),
     unarySomeSymIntN,
     unarySomeSymIntNR1,
     binSomeSymIntN,
@@ -72,6 +74,8 @@ binSomeSymWordNR2 :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n
 
 instance Solvable Bool SymBool
 
+instance LinkedRep Bool SymBool
+
 instance Eq SymBool
 
 instance Lift SymBool
@@ -111,3 +115,13 @@ instance (KnownNat n, 1 <= n) => Solvable (IntN n) (SymIntN n)
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Solvable (ca --> cb) (sa -~> sb)
 
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Solvable (ca =-> cb) (sa =~> sb)
+
+data SomeSym where
+  SomeSym :: (LinkedRep con sym) => sym -> SomeSym
+
+class AllSyms a where
+  allSymsS :: a -> [SomeSym] -> [SomeSym]
+  allSymsS a l = allSyms a ++ l
+  allSyms :: a -> [SomeSym]
+  allSyms a = allSymsS a []
+  {-# MINIMAL allSymsS | allSyms #-}


### PR DESCRIPTION
This pull request adds the API to count term size for complex types.

For example,

```haskell
>>> allSymsSize ("a" :: SymInteger, "a" + "b" :: SymInteger, ("a" + "b") * "c" :: SymInteger)
5
```

Here the result is 5 as the same subterm will be counted for only once, and there are 5 distinct subterms:
- a
- b
- c
- (+ a b)
- (* (+ a b) c)