### PR TITLE
Parallel do

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -48,6 +48,7 @@ library
       Grisette.Core.BuiltinUnionWrappers
       Grisette.Core.Control.Exception
       Grisette.Core.Control.Monad.CBMCExcept
+      Grisette.Core.Control.Monad.Class.MonadParallelUnion
       Grisette.Core.Control.Monad.Union
       Grisette.Core.Control.Monad.UnionM
       Grisette.Core.Data.Class.BitVector
@@ -109,6 +110,7 @@ library
       Grisette.Lib.Data.List
       Grisette.Lib.Data.Traversable
       Grisette.Lib.Mtl
+      Grisette.Qualified.ParallelUnionDo
       Grisette.Utils
       Grisette.Utils.Parameterized
   other-modules:
@@ -128,6 +130,7 @@ library
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.3
     , once >=0.2 && <0.5
+    , parallel
     , sbv >=8.11 && <9.1
     , template-haskell >=2.16 && <2.20
     , th-compat >=0.1.2 && <0.2
@@ -163,6 +166,7 @@ test-suite doctest
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.3
     , once >=0.2 && <0.5
+    , parallel
     , sbv >=8.11 && <9.1
     , template-haskell >=2.16 && <2.20
     , th-compat >=0.1.2 && <0.2
@@ -210,6 +214,7 @@ test-suite spec
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.3
     , once >=0.2 && <0.5
+    , parallel
     , sbv >=8.11 && <9.1
     , tasty >=1.1.0.3 && <1.5
     , tasty-hunit ==0.10.*

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
 - vector >= 0.12.1 && < 0.14
 - once >= 0.2 && < 0.5
 - sbv >= 8.11 && < 9.1
+- parallel
 
 flags: {
   fast: {

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -1021,6 +1021,7 @@ import Generics.Deriving (Default (..), Default1 (..))
 import Grisette.Core.BuiltinUnionWrappers
 import Grisette.Core.Control.Exception
 import Grisette.Core.Control.Monad.CBMCExcept
+import Grisette.Core.Control.Monad.Class.MonadParallelUnion
 import Grisette.Core.Control.Monad.Union
 import Grisette.Core.Control.Monad.UnionM
 import Grisette.Core.Data.Class.BitVector

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -606,7 +606,7 @@ module Grisette.Core
     pattern SingleU,
     pattern IfU,
     MonadUnion,
-    MonadParallelUnion,
+    MonadParallelUnion (..),
     simpleMerge,
     onUnion,
     onUnion2,

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -606,6 +606,7 @@ module Grisette.Core
     pattern SingleU,
     pattern IfU,
     MonadUnion,
+    MonadParallelUnion,
     simpleMerge,
     onUnion,
     onUnion2,

--- a/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
+++ b/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
@@ -34,15 +34,14 @@ import Grisette.Lib.Control.Monad
 -- With the @QualifiedDo@ extension and the "Grisette.Qualified.ParallelUnionDo"
 -- module, one can execute the paths in parallel and merge the results with:
 --
--- >>> :set -XQualifiedDo -XOverloadedStrings
--- >>> import Grisette
--- >>> import qualified Grisette.Qualified.ParallelUnionDo as P
--- >>> :{
---   P.do
---     x <- mrgIf "a" (return 1) (return 2) :: UnionM Int
---     return $ x + 1
--- :}
--- {If a 2 3}
+-- > :set -XQualifiedDo -XOverloadedStrings
+-- > import Grisette
+-- > import qualified Grisette.Qualified.ParallelUnionDo as P
+-- > P.do
+-- >   x <- mrgIf "a" (return 1) (return 2) :: UnionM Int
+-- >   return $ x + 1
+-- >
+-- > -- {If a 2 3}
 class (UnionLike m, Monad m) => MonadParallelUnion m where
   parBindUnion :: (Mergeable b, NFData b) => m a -> (a -> m b) -> m b
 

--- a/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
+++ b/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Grisette.Core.Control.Monad.Class.MonadParallelUnion (MonadParallelUnion (..)) where
+
+import Control.DeepSeq
+import Control.Monad.Cont
+import Control.Monad.Except
+import Control.Monad.Identity
+import qualified Control.Monad.RWS.Lazy as RWSLazy
+import qualified Control.Monad.RWS.Strict as RWSStrict
+import Control.Monad.Reader
+import qualified Control.Monad.State.Lazy as StateLazy
+import qualified Control.Monad.State.Strict as StateStrict
+import Control.Monad.Trans.Maybe
+import qualified Control.Monad.Writer.Lazy as WriterLazy
+import qualified Control.Monad.Writer.Strict as WriterStrict
+import Grisette.Core.Data.Class.Mergeable
+import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Lib.Control.Monad
+
+class (UnionLike m, Monad m) => MonadParallelUnion m where
+  parBindUnion :: (Mergeable b, NFData b) => m a -> (a -> m b) -> m b
+
+instance (MonadParallelUnion m) => MonadParallelUnion (MaybeT m) where
+  parBindUnion (MaybeT x) f =
+    MaybeT $
+      x `parBindUnion` \case
+        Nothing -> return Nothing
+        Just x'' -> runMaybeT $ f x''
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable e, NFData e) => MonadParallelUnion (ExceptT e m) where
+  parBindUnion (ExceptT x) f =
+    ExceptT $
+      x `parBindUnion` \case
+        Left e -> return $ Left e
+        Right x'' -> runExceptT $ f x''
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable s, NFData s) => MonadParallelUnion (StateLazy.StateT s m) where
+  parBindUnion (StateLazy.StateT x) f = StateLazy.StateT $ \s ->
+    x s `parBindUnion` \case
+      ~(a, s') -> StateLazy.runStateT (f a) s'
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable s, NFData s) => MonadParallelUnion (StateStrict.StateT s m) where
+  parBindUnion (StateStrict.StateT x) f = StateStrict.StateT $ \s ->
+    x s `parBindUnion` \case
+      (a, s') -> StateStrict.runStateT (f a) s'
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable s, Monoid s, NFData s) => MonadParallelUnion (WriterLazy.WriterT s m) where
+  parBindUnion (WriterLazy.WriterT x) f =
+    WriterLazy.WriterT $
+      x `parBindUnion` \case
+        ~(a, w) ->
+          WriterLazy.runWriterT (f a) `parBindUnion` \case
+            ~(b, w') -> return (b, w <> w')
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable s, Monoid s, NFData s) => MonadParallelUnion (WriterStrict.WriterT s m) where
+  parBindUnion (WriterStrict.WriterT x) f =
+    WriterStrict.WriterT $
+      x `parBindUnion` \case
+        (a, w) ->
+          WriterStrict.runWriterT (f a) `parBindUnion` \case
+            (b, w') -> return (b, w <> w')
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m, Mergeable a, NFData a) => MonadParallelUnion (ReaderT a m) where
+  parBindUnion (ReaderT x) f = ReaderT $ \a ->
+    x a `parBindUnion` \a' -> runReaderT (f a') a
+  {-# INLINE parBindUnion #-}
+
+instance (MonadParallelUnion m) => MonadParallelUnion (IdentityT m) where
+  parBindUnion (IdentityT x) f = IdentityT $ x `parBindUnion` (merge . runIdentityT . f)
+  {-# INLINE parBindUnion #-}
+
+instance
+  (MonadParallelUnion m, Mergeable s, Mergeable r, Mergeable w, Monoid w, NFData r, NFData w, NFData s) =>
+  MonadParallelUnion (RWSStrict.RWST r w s m)
+  where
+  parBindUnion m k = RWSStrict.RWST $ \r s ->
+    RWSStrict.runRWST m r s `parBindUnion` \case
+      (a, s', w) ->
+        RWSStrict.runRWST (k a) r s' `parBindUnion` \case
+          (b, s'', w') -> return (b, s'', w <> w')
+  {-# INLINE parBindUnion #-}
+
+instance
+  (MonadParallelUnion m, Mergeable s, Mergeable r, Mergeable w, Monoid w, NFData r, NFData w, NFData s) =>
+  MonadParallelUnion (RWSLazy.RWST r w s m)
+  where
+  parBindUnion m k = RWSLazy.RWST $ \r s ->
+    RWSLazy.runRWST m r s `parBindUnion` \case
+      ~(a, s', w) ->
+        RWSLazy.runRWST (k a) r s' `parBindUnion` \case
+          ~(b, s'', w') -> return (b, s'', w <> w')
+  {-# INLINE parBindUnion #-}

--- a/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
+++ b/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
@@ -1,6 +1,17 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Grisette.Core.Control.Monad.Class.MonadParallelUnion (MonadParallelUnion (..)) where
+-- |
+-- Module      :   Grisette.Core.Control.Monad.Class.MonadParallelUnion
+-- Copyright   :   (c) Sirui Lu 2023
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Core.Control.Monad.Class.MonadParallelUnion
+  ( MonadParallelUnion (..),
+  )
+where
 
 import Control.DeepSeq
 import Control.Monad.Cont
@@ -18,6 +29,20 @@ import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Lib.Control.Monad
 
+-- | Parallel union monad.
+--
+-- With the @QualifiedDo@ extension and the "Grisette.Qualified.ParallelUnionDo"
+-- module, one can execute the paths in parallel and merge the results with:
+--
+-- >>> :set -XQualifiedDo -XOverloadedStrings
+-- >>> import Grisette
+-- >>> import qualified Grisette.Qualified.ParallelUnionDo as P
+-- >>> :{
+--   P.do
+--     x <- mrgIf "a" (return 1) (return 2) :: UnionM Int
+--     return $ x + 1
+-- :}
+-- {If a 2 3}
 class (UnionLike m, Monad m) => MonadParallelUnion m where
   parBindUnion :: (Mergeable b, NFData b) => m a -> (a -> m b) -> m b
 

--- a/src/Grisette/Qualified/ParallelUnionDo.hs
+++ b/src/Grisette/Qualified/ParallelUnionDo.hs
@@ -1,0 +1,11 @@
+module Grisette.Qualified.ParallelUnionDo where
+
+import Control.Parallel.Strategies
+import Grisette.Core.Control.Monad.Class.MonadParallelUnion
+import Grisette.Core.Data.Class.Mergeable
+
+(>>=) :: (MonadParallelUnion m, Mergeable b, NFData b) => m a -> (a -> m b) -> m b
+(>>=) = parBindUnion
+
+(>>) :: (MonadParallelUnion m, Mergeable b, NFData b) => m a -> m b -> m b
+(>>) a b = parBindUnion a $ const b

--- a/src/Grisette/Qualified/ParallelUnionDo.hs
+++ b/src/Grisette/Qualified/ParallelUnionDo.hs
@@ -1,3 +1,11 @@
+-- |
+-- Module      :   Grisette.Qualified.ParallelUnionDo
+-- Copyright   :   (c) Sirui Lu 2023
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
 module Grisette.Qualified.ParallelUnionDo where
 
 import Control.Parallel.Strategies


### PR DESCRIPTION
This pull request introduces the parallel do notation with the `QualifiedDo` extension.

For example: the following code will execute `f 1` and `f 2` in parallel.

```
>>> :set -XQualifiedDo -XOverloadedStrings
>>> import Grisette
>>> import qualified Grisette.Qualified.ParallelUnionDo as P
>>> :{
  P.do
    x <- mrgIf "a" (return 1) (return 2) :: UnionM Int
    return $ f x
:}
```