### PR TITLE
Operator for measuring sizes of unions

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -187,6 +187,7 @@ test-suite spec
       Grisette.Backend.SBV.Data.SMT.LoweringTests
       Grisette.Backend.SBV.Data.SMT.TermRewritingGen
       Grisette.Backend.SBV.Data.SMT.TermRewritingTests
+      Grisette.Core.Control.Monad.UnionMTests
       Grisette.IR.SymPrim.Data.BVTests
       Grisette.IR.SymPrim.Data.Prim.BitsTests
       Grisette.IR.SymPrim.Data.Prim.BoolTests

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -565,6 +565,7 @@ module Grisette.Core
     makeUnionWrapper,
     makeUnionWrapper',
     liftToMonadUnion,
+    unionSize,
 
     -- *** Merging
 

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -32,6 +32,7 @@ module Grisette.Core.Control.Monad.UnionM
     isMerged,
     (#~),
     IsConcrete,
+    unionSize,
   )
 where
 
@@ -553,3 +554,9 @@ instance UnionWithExcept (UnionM (Either e v)) UnionM e v where
 
 instance UnionWithExcept (UnionM (CBMCEither e v)) UnionM e v where
   extractUnionExcept = fmap runCBMCEither
+
+unionSize :: UnionM a -> Int
+unionSize = unionSize' . underlyingUnion
+  where
+    unionSize' (Single _) = 1
+    unionSize' (If _ _ _ l r) = unionSize' l + unionSize' r

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -555,6 +555,15 @@ instance UnionWithExcept (UnionM (Either e v)) UnionM e v where
 instance UnionWithExcept (UnionM (CBMCEither e v)) UnionM e v where
   extractUnionExcept = fmap runCBMCEither
 
+-- | The size of a union is defined as the number of branches.
+-- For example,
+--
+-- >>> unionSize (single True)
+-- 1
+-- >>> unionSize (mrgIf "a" (single 1) (single 2) :: UnionM Integer)
+-- 2
+-- >>> unionSize (choose [1..7] "a" :: UnionM Integer)
+-- 7
 unionSize :: UnionM a -> Int
 unionSize = unionSize' . underlyingUnion
   where

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Grisette.Core.Control.Monad.UnionMTests where
+
+import Grisette.Core.Control.Monad.UnionM
+import Grisette.Core.Data.Class.GenSym
+import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.Solvable
+import Test.Tasty
+import Test.Tasty.HUnit
+
+unionMTests :: TestTree
+unionMTests =
+  testGroup
+    "UnionMTests"
+    [ testCase "unionSize" $ do
+        unionSize (single 1 :: UnionM Integer) @=? 1
+        unionSize (mrgIf (ssym "a") (single 1) (single 2) :: UnionM Integer) @=? 2
+        unionSize (choose [1, 2, 3, 4, 5, 6, 7] "a" :: UnionM Integer) @=? 7
+    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -25,6 +25,7 @@ import Grisette.Lib.Data.TraversableTests
 import Grisette.Backend.SBV.Data.SMT.CEGISTests
 import Grisette.Backend.SBV.Data.SMT.LoweringTests
 import Grisette.Backend.SBV.Data.SMT.TermRewritingTests
+import Grisette.Core.Control.Monad.UnionMTests (unionMTests)
 import qualified Grisette.IR.SymPrim.Data.BVTests
 import qualified Grisette.IR.SymPrim.Data.Prim.BVTests
 import Grisette.IR.SymPrim.Data.Prim.BitsTests
@@ -47,9 +48,16 @@ tests :: TestTree
 tests =
   testGroup
     "grisette"
-    [ irTests,
+    [ coreTests,
+      irTests,
       sbvTests
     ]
+
+coreTests :: TestTree
+coreTests =
+  testGroup
+    "Grisette.Core.Control.Monad.UnionM"
+    [unionMTests]
 
 {-
 coreTests :: TestTree


### PR DESCRIPTION
This pull request introduces a utility function for measuring union sizes.

```haskell
>>> unionSize (single True)
1
>>> unionSize (mrgIf "a" (single 1) (single 2) :: UnionM Integer)
2
>>> unionSize (choose [1..7] "a" :: UnionM Integer)
7
```