### PR TITLE
Fix merging for SomeSymBV

### DIFF
--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -397,8 +397,6 @@ TO_SYM_FROM_UNION_CON_BV(IntN, SymIntN)
 TO_SYM_FROM_UNION_CON_BV(WordN, SymWordN)
 TO_SYM_FROM_UNION_CON_FUN((=->), (=~>))
 TO_SYM_FROM_UNION_CON_FUN((-->), (-~>))
-TO_SYM_FROM_UNION_CON_BV_SOME(SomeIntN, SomeSymIntN)
-TO_SYM_FROM_UNION_CON_BV_SOME(SomeWordN, SomeSymWordN)
 #endif
 
 instance {-# INCOHERENT #-} (ToCon a b) => ToCon (UnionM a) b where

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -785,11 +785,6 @@ instance (KnownNat n, 1 <= n) => SimpleMergeable (symtype n) where \
   mrgIte = ites; \
   {-# INLINE mrgIte #-}
 
-#define SIMPLE_MERGEABLE_SOME_BV(symtype, bf) \
-instance SimpleMergeable symtype where \
-  mrgIte c = bf (ites c) "mrgIte"; \
-  {-# INLINE mrgIte #-}
-
 #define SIMPLE_MERGEABLE_FUN(op) \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => SimpleMergeable (sa op sb) where \
   mrgIte = ites; \
@@ -800,8 +795,6 @@ SIMPLE_MERGEABLE_SIMPLE(SymBool)
 SIMPLE_MERGEABLE_SIMPLE(SymInteger)
 SIMPLE_MERGEABLE_BV(SymIntN)
 SIMPLE_MERGEABLE_BV(SymWordN)
-SIMPLE_MERGEABLE_SOME_BV(SomeSymIntN, binSomeSymIntNR1)
-SIMPLE_MERGEABLE_SOME_BV(SomeSymWordN, binSomeSymWordNR1)
 SIMPLE_MERGEABLE_FUN(=~>)
 SIMPLE_MERGEABLE_FUN(-~>)
 #endif


### PR DESCRIPTION
We should allow SomeSymBV with different bit size coexists in a union. This pull request supports this.