### PR TITLE
Return false instead of crash on different bit width SomeBV

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,3 @@
 packages: grisette.cabal
-allow-newer: all
+tests: True
+allow-newer: text

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -111,9 +111,15 @@ binSomeWordNR2 op (SomeWordN (l :: WordN l)) (SomeWordN (r :: WordN r)) =
 {-# INLINE binSomeWordNR2 #-}
 
 instance Eq SomeWordN where
-  (==) = binSomeWordN (==)
+  SomeWordN (l :: WordN l) == SomeWordN (r :: WordN r) =
+    case sameNat (Proxy @l) (Proxy @r) of
+      Just Refl -> l == r
+      Nothing -> False
   {-# INLINE (==) #-}
-  (/=) = binSomeWordN (/=)
+  SomeWordN (l :: WordN l) /= SomeWordN (r :: WordN r) =
+    case sameNat (Proxy @l) (Proxy @r) of
+      Just Refl -> l /= r
+      Nothing -> True
   {-# INLINE (/=) #-}
 
 instance Ord SomeWordN where
@@ -205,9 +211,15 @@ binSomeIntNR2 op (SomeIntN (l :: IntN l)) (SomeIntN (r :: IntN r)) =
 {-# INLINE binSomeIntNR2 #-}
 
 instance Eq SomeIntN where
-  (==) = binSomeIntN (==)
+  SomeIntN (l :: IntN l) == SomeIntN (r :: IntN r) =
+    case sameNat (Proxy @l) (Proxy @r) of
+      Just Refl -> l == r
+      Nothing -> False
   {-# INLINE (==) #-}
-  (/=) = binSomeIntN (/=)
+  SomeIntN (l :: IntN l) /= SomeIntN (r :: IntN r) =
+    case sameNat (Proxy @l) (Proxy @r) of
+      Just Refl -> l /= r
+      Nothing -> True
   {-# INLINE (/=) #-}
 
 instance Ord SomeIntN where

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -1105,11 +1105,17 @@ instance SEq symtype where \
 instance (KnownNat n, 1 <= n) => SEq (symtype n) where \
   (symtype l) ==~ (symtype r) = SymBool $ pevalEqvTerm l r
 
-#define SEQ_BV_SOME(somety, bf) \
+#define SEQ_BV_SOME(somety, origty) \
 instance SEq somety where \
-  (==~) = bf (==~) "==~"; \
+  somety (l :: origty l) ==~ somety (r :: origty r) = \
+    (case sameNat (Proxy @l) (Proxy @r) of \
+      Just Refl -> l ==~ r; \
+      Nothing -> con False); \
   {-# INLINE (==~) #-}; \
-  (/=~) = bf (/=~) "/=~"; \
+  somety (l :: origty l) /=~ somety (r :: origty r) = \
+    (case sameNat (Proxy @l) (Proxy @r) of \
+      Just Refl -> l /=~ r; \
+      Nothing -> con True); \
   {-# INLINE (/=~) #-}
 
 #if 1
@@ -1117,8 +1123,8 @@ SEQ_SIMPLE(SymBool)
 SEQ_SIMPLE(SymInteger)
 SEQ_BV(SymIntN)
 SEQ_BV(SymWordN)
-SEQ_BV_SOME(SomeSymIntN, binSomeSymIntN)
-SEQ_BV_SOME(SomeSymWordN, binSomeSymWordN)
+SEQ_BV_SOME(SomeSymIntN, SymIntN)
+SEQ_BV_SOME(SomeSymWordN, SymWordN)
 #endif
 
 -- SOrd


### PR DESCRIPTION
This pull request changes the behavior of Eq and SEq for SomeBVs. They now return false instead of crashing when bit vectors with different bit widths are provided.