### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,3 +106,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+      if: matrix.os == 'ubuntu-latest' && matrix.plan.ismain

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,1 @@
+- ignore: {name: Redundant bracket}


### PR DESCRIPTION
This pull request ignores the hlint redundant bracket error, which conflicts with ormolu's formatting rule.

This pull request also fixes the failure of codecov action on macOS.