### PR TITLE
Fix the link to grisette GitHub page

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -16,8 +16,8 @@ description:    Grisette is a reusable symbolic evaluation library for Haskell. 
                 .
                 For more details, please checkout the README.
 category:       Formal Methods, Theorem Provers, Symbolic Computation, SMT
-homepage:       https://github.com/lsrcz/grisette-haskell#readme
-bug-reports:    https://github.com/lsrcz/grisette-haskell/issues
+homepage:       https://github.com/lsrcz/grisette#readme
+bug-reports:    https://github.com/lsrcz/grisette/issues
 author:         Sirui Lu, Rastislav Bodík
 maintainer:     Sirui Lu (siruilu@cs.washington.edu)
 copyright:      2021-2023 Sirui Lu
@@ -36,7 +36,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/lsrcz/grisette-haskell
+  location: https://github.com/lsrcz/grisette
 
 flag fast
   description: Compile with O2 optimization

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ author: "Sirui Lu, Rastislav Bodík"
 maintainer: Sirui Lu (siruilu@cs.washington.edu)
 license: BSD3
 license-file: LICENSE
-github: lsrcz/grisette-haskell
+github: lsrcz/grisette
 copyright: "2021-2023 Sirui Lu"
 extra-source-files:
 - CHANGELOG.md


### PR DESCRIPTION
This pull request fixes the link to grisette GitHub page and resolves #93.