### PR TITLE
Add QuickCheck generator instances for bit vectors

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      QuickCheck ==2.14.*
+      QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
@@ -161,7 +161,7 @@ test-suite doctest
       doctest
   build-depends:
       Glob
-    , QuickCheck ==2.14.*
+    , QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
@@ -212,7 +212,7 @@ test-suite spec
   hs-source-dirs:
       test
   build-depends:
-      QuickCheck ==2.14.*
+      QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      array >=0.5.4 && <0.6
+      QuickCheck ==2.14.*
+    , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
     , call-stack >=0.1 && <0.5
@@ -160,6 +161,7 @@ test-suite doctest
       doctest
   build-depends:
       Glob
+    , QuickCheck ==2.14.*
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
@@ -210,7 +212,8 @@ test-suite spec
   hs-source-dirs:
       test
   build-depends:
-      array >=0.5.4 && <0.6
+      QuickCheck ==2.14.*
+    , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
     , call-stack >=0.1 && <0.5

--- a/package.yaml
+++ b/package.yaml
@@ -47,6 +47,7 @@ dependencies:
 - sbv >= 8.11 && < 10.3
 - parallel >= 3.2.2.0 && < 3.3
 - text >= 1.2.4.1 && < 2.1
+- QuickCheck >= 2.14 && < 2.15
 
 flags: {
   fast: {

--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,7 @@ dependencies:
 - sbv >= 8.11 && < 10.3
 - parallel >= 3.2.2.0 && < 3.3
 - text >= 1.2.4.1 && < 2.1
-- QuickCheck >= 2.14 && < 2.15
+- QuickCheck >= 2.13.2 && < 2.15
 
 flags: {
   fast: {

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -60,6 +60,7 @@ import Grisette.Core.Data.Class.BitVector
 import Grisette.Utils.Parameterized
 import Language.Haskell.TH.Syntax
 import Numeric
+import qualified Test.QuickCheck as QC
 import Text.Read
 import qualified Text.Read.Lex as L
 
@@ -417,6 +418,10 @@ instance Num SomeWordN where
   signum = unarySomeWordNR1 signum
   fromInteger = error "fromInteger is not defined for SomeWordN as no bitwidth is known"
 
+instance (KnownNat n, 1 <= n) => QC.Arbitrary (WordN n) where
+  arbitrary = QC.arbitrarySizedBoundedIntegral
+  shrink = QC.shrinkIntegral
+
 minusOneIntN :: forall proxy n. (KnownNat n) => proxy n -> IntN n
 minusOneIntN _ = IntN (1 `shiftL` fromIntegral (natVal (Proxy :: Proxy n)) - 1)
 
@@ -593,6 +598,10 @@ instance (KnownNat n, 1 <= n) => Ord (IntN n) where
       n = fromIntegral (natVal (Proxy :: Proxy n))
       as = testBit a (n - 1)
       bs = testBit b (n - 1)
+
+instance (KnownNat n, 1 <= n) => QC.Arbitrary (IntN n) where
+  arbitrary = QC.arbitrarySizedBoundedIntegral
+  shrink = QC.shrinkIntegral
 
 instance SizedBV WordN where
   sizedBVConcat :: forall l r. (KnownNat l, KnownNat r, 1 <= l, 1 <= r) => WordN l -> WordN r -> WordN (l + r)

--- a/stack-lts-18.28-lowerbound.yaml
+++ b/stack-lts-18.28-lowerbound.yaml
@@ -54,9 +54,11 @@ extra-deps:
   - hashtables-1.2.3.4
   - loch-th-0.2.2
   - th-compat-0.1.2
-  - QuickCheck-2.14.1
+  - QuickCheck-2.14
   - intern-0.9.2
   - array-0.5.4.0
+  - random-1.1
+  - splitmix-0.0.5
   - vector-0.12.1.2
   - sbv-8.11
   - tasty-quickcheck-0.10.1

--- a/stack-lts-18.28-lowerbound.yaml
+++ b/stack-lts-18.28-lowerbound.yaml
@@ -54,7 +54,7 @@ extra-deps:
   - hashtables-1.2.3.4
   - loch-th-0.2.2
   - th-compat-0.1.2
-  - QuickCheck-2.14
+  - QuickCheck-2.13.2
   - intern-0.9.2
   - array-0.5.4.0
   - random-1.1

--- a/stack-lts-18.28-lowerbound.yaml.lock
+++ b/stack-lts-18.28-lowerbound.yaml.lock
@@ -82,12 +82,12 @@ packages:
   original:
     hackage: th-compat-0.1.2
 - completed:
-    hackage: QuickCheck-2.14@sha256:3f536a4b86bef7ec39025f04ef8d76c5ac5a78ba0b42e660b25d0a8f9c811045,7004
+    hackage: QuickCheck-2.13.2@sha256:636e7265bf75122e7e2f97627c47aad3b772ee3b35b134cafb6095116ce8d07a,6974
     pantry-tree:
-      sha256: 7067593c50ff2e5e83c637ac73009f4bd8f43c29ff256e976bbb14674033abe9
-      size: 2203
+      sha256: b917f922fc59d98d47b789f50c5a569d1b80ae08d52f4fbebbaad7fc62479e0d
+      size: 2202
   original:
-    hackage: QuickCheck-2.14
+    hackage: QuickCheck-2.13.2
 - completed:
     hackage: intern-0.9.2@sha256:85eae3bd0a6cbfc622c0c70aa476641971bcd5e59dbc4c7a4b17888e432a5bd5,1619
     pantry-tree:

--- a/stack-lts-18.28-lowerbound.yaml.lock
+++ b/stack-lts-18.28-lowerbound.yaml.lock
@@ -82,12 +82,12 @@ packages:
   original:
     hackage: th-compat-0.1.2
 - completed:
-    hackage: QuickCheck-2.14.1@sha256:843e6428c2d80656a0cbff61929d3924e8b450841b6dfba463d0b3f41a48265c,8006
+    hackage: QuickCheck-2.14@sha256:3f536a4b86bef7ec39025f04ef8d76c5ac5a78ba0b42e660b25d0a8f9c811045,7004
     pantry-tree:
-      sha256: 543c1e661669b7235d3846b08ad3d1f6f6cba0d81c285dbfc15a28e148a347ed
-      size: 2315
+      sha256: 7067593c50ff2e5e83c637ac73009f4bd8f43c29ff256e976bbb14674033abe9
+      size: 2203
   original:
-    hackage: QuickCheck-2.14.1
+    hackage: QuickCheck-2.14
 - completed:
     hackage: intern-0.9.2@sha256:85eae3bd0a6cbfc622c0c70aa476641971bcd5e59dbc4c7a4b17888e432a5bd5,1619
     pantry-tree:
@@ -102,6 +102,20 @@ packages:
       size: 1135
   original:
     hackage: array-0.5.4.0
+- completed:
+    hackage: random-1.1@sha256:7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df,1777
+    pantry-tree:
+      sha256: 14a1b01728c5584e87c9fa00746a66e28ffd89dd2c0eabd334c8463953496e1b
+      size: 637
+  original:
+    hackage: random-1.1
+- completed:
+    hackage: splitmix-0.0.5@sha256:4a49661be63f5aea0e132e9ab51be918789bb4dceb4ab9b15b85ba9cbbef5999,5412
+    pantry-tree:
+      sha256: b41d4f60cfabab8b02840906191013ee06fe2357371103a471c7cc55eda9e462
+      size: 1148
+  original:
+    hackage: splitmix-0.0.5
 - completed:
     hackage: vector-0.12.1.2@sha256:9291bc581f36e51d5bda9fce57cb980fbec3dd292996896f285fef39eb80a9a0,7364
     pantry-tree:


### PR DESCRIPTION
This pull request adds the `Arbitrary` instances for `WordN` and `IntN`, resolves #91.