### PR TITLE
Added pretty printer for the Grisette-introduced data types

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -66,6 +66,7 @@ library
       Grisette.Core.Data.Class.ExtractSymbolics
       Grisette.Core.Data.Class.Function
       Grisette.Core.Data.Class.GenSym
+      Grisette.Core.Data.Class.GPretty
       Grisette.Core.Data.Class.Mergeable
       Grisette.Core.Data.Class.ModelOps
       Grisette.Core.Data.Class.SafeArith
@@ -139,6 +140,7 @@ library
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
+    , prettyprinter >=1.5.0 && <1.8
     , sbv >=8.11 && <10.3
     , template-haskell >=2.16 && <2.21
     , text >=1.2.4.1 && <2.1
@@ -176,6 +178,7 @@ test-suite doctest
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
+    , prettyprinter >=1.5.0 && <1.8
     , sbv >=8.11 && <10.3
     , template-haskell >=2.16 && <2.21
     , text >=1.2.4.1 && <2.1
@@ -199,6 +202,7 @@ test-suite spec
       Grisette.Backend.SBV.Data.SMT.TermRewritingTests
       Grisette.Core.Control.Monad.UnionMTests
       Grisette.Core.Data.BVTests
+      Grisette.Core.Data.Class.GPrettyTests
       Grisette.IR.SymPrim.Data.Prim.BitsTests
       Grisette.IR.SymPrim.Data.Prim.BoolTests
       Grisette.IR.SymPrim.Data.Prim.BVTests
@@ -226,6 +230,7 @@ test-suite spec
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
+    , prettyprinter >=1.5.0 && <1.8
     , sbv >=8.11 && <10.3
     , tasty >=1.1.0.3 && <1.5
     , tasty-hunit ==0.10.*

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,9 +1,10 @@
 cradle:
   stack:
-    components:
-    - path: "src"
+    - path: "./src"
       component: "grisette:lib"
-    - path: "test"
-      component: "grisette:test:spec"
-    - path: "doctest"
+
+    - path: "./doctest"
       component: "grisette:test:doctest"
+
+    - path: "./test"
+      component: "grisette:test:spec"

--- a/package.yaml
+++ b/package.yaml
@@ -48,6 +48,7 @@ dependencies:
 - parallel >= 3.2.2.0 && < 3.3
 - text >= 1.2.4.1 && < 2.1
 - QuickCheck >= 2.13.2 && < 2.15
+- prettyprinter >= 1.5.0 && < 1.8
 
 flags: {
   fast: {

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -613,6 +613,9 @@ module Grisette.Core
     ToCon (..),
     ToSym (..),
 
+    -- * Pretty printing
+    GPretty (..),
+
     -- * Symbolic Generation
 
     -- | It is usually useful to generate complex symbolic values. For example,
@@ -1020,6 +1023,7 @@ import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Function
+import Grisette.Core.Data.Class.GPretty
 import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.ModelOps

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE Trustworthy #-}
@@ -55,6 +56,7 @@ import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Function
+import Grisette.Core.Data.Class.GPretty
 import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SOrd
@@ -70,6 +72,12 @@ import Grisette.IR.SymPrim.Data.SymPrim
 import Grisette.IR.SymPrim.Data.TabularFun
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Syntax.Compat (unTypeSplice)
+
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter
+#else
+import Data.Text.Prettyprint.Doc
+#endif
 
 -- $setup
 -- >>> import Grisette.Core
@@ -238,6 +246,11 @@ instance Show1 UnionM where
     wrapBracket '{' '}'
       . liftShowsPrecUnion sp sl 0
       $ a
+
+instance (GPretty a) => GPretty (UnionM a) where
+  gpretty = \case
+    (UAny a) -> groupedEnclose "<" ">" $ gpretty a
+    (UMrg _ a) -> groupedEnclose "{" "}" $ gpretty a
 
 -- | Extract the underlying Union. May be unmerged.
 underlyingUnion :: UnionM a -> Union a

--- a/src/Grisette/Core/Data/Class/GPretty.hs
+++ b/src/Grisette/Core/Data/Class/GPretty.hs
@@ -1,0 +1,376 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Grisette.Core.Data.Class.GPretty
+  ( GPretty (..),
+    groupedEnclose,
+    condEnclose,
+  )
+where
+
+import Control.Monad.Except
+import Control.Monad.Identity
+import Control.Monad.Trans.Maybe
+import qualified Control.Monad.Writer.Lazy as WriterLazy
+import qualified Control.Monad.Writer.Strict as WriterStrict
+import qualified Data.ByteString as B
+import Data.Functor.Sum
+import Data.Int
+import Data.Proxy
+import Data.String
+import qualified Data.Text as T
+import Data.Word
+import GHC.Generics
+import GHC.TypeLits
+import Generics.Deriving hiding (isNullary)
+import Grisette.Core.Data.BV
+
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter
+#else
+import Data.Text.Prettyprint.Doc
+#endif
+
+glist :: [Doc ann] -> Doc ann
+glist l
+  | null l = "[]"
+  | length l == 1 = "[" <> head l <> "]"
+  | otherwise = groupedEnclose "[" "]" $ encloseSep "" "" (flatAlt ", " ",") l
+
+class GPretty a where
+  gpretty :: a -> Doc ann
+  gprettyPrec :: Int -> a -> Doc ann
+  gprettyList :: [a] -> Doc ann
+  gprettyList = align . glist . map gpretty
+
+  gpretty = gprettyPrec 0
+  gprettyPrec _ = gpretty
+
+  {-# MINIMAL gpretty | gprettyPrec #-}
+
+instance (Generic a, GPretty' (Rep a)) => GPretty (Default a) where
+  gprettyPrec i v = gprettyPrec' Pref i $ from $ unDefault v
+
+data Type = Rec | Tup | Pref | Inf String Int
+
+class GPretty' a where
+  gprettyPrec' :: Type -> Int -> a c -> Doc ann
+  isNullary :: a c -> Bool
+  isNullary = error "generic gpretty (isNullary): unnecessary case"
+
+instance GPretty' V1 where
+  gprettyPrec' _ _ x = case x of {}
+
+instance GPretty' U1 where
+  gprettyPrec' _ _ U1 = ""
+  isNullary _ = True
+
+instance (GPretty c) => GPretty' (K1 i c) where
+  gprettyPrec' _ n (K1 a) = gprettyPrec n a
+  isNullary _ = False
+
+groupedEnclose :: Doc ann -> Doc ann -> Doc ann -> Doc ann
+groupedEnclose l r d = group $ align $ vcat [l <> flatAlt " " "" <> d, r]
+
+condEnclose :: Bool -> Doc ann -> Doc ann -> Doc ann -> Doc ann
+condEnclose b = if b then groupedEnclose else const $ const id
+
+instance (GPretty' a, Constructor c) => GPretty' (M1 C c a) where
+  gprettyPrec' _ n c@(M1 x) =
+    case t of
+      Tup ->
+        prettyBraces t (gprettyPrec' t 0 x)
+      Inf _ m ->
+        group $ condEnclose (n > m) "(" ")" $ gprettyPrec' t m x
+      _ ->
+        if isNullary x
+          then pretty (conName c)
+          else
+            group $
+              condEnclose (n > 10) "(" ")" $
+                align $
+                  nest 2 $
+                    vsep
+                      [ pretty (conName c),
+                        prettyBraces t (gprettyPrec' t 11 x)
+                      ]
+    where
+      prettyBraces :: Type -> Doc ann -> Doc ann
+      prettyBraces Rec = groupedEnclose "{" "}"
+      prettyBraces Tup = groupedEnclose "(" ")"
+      prettyBraces Pref = id
+      prettyBraces (Inf _ _) = id
+      fixity = conFixity c
+      t
+        | conIsRecord c = Rec
+        | conIsTuple c = Tup
+        | otherwise = case fixity of
+            Prefix -> Pref
+            Infix _ i -> Inf (conName c) i
+      conIsTuple :: C1 c f p -> Bool
+      conIsTuple y = tupleName (conName y)
+        where
+          tupleName ('(' : ',' : _) = True
+          tupleName _ = False
+
+instance (Selector s, GPretty' a) => GPretty' (M1 S s a) where
+  gprettyPrec' t n s@(M1 x)
+    | selName s == "" =
+        case t of
+          Pref -> gprettyPrec' t (n + 1) x
+          _ -> gprettyPrec' t (n + 1) x
+    | otherwise =
+        pretty (selName s) <+> "=" <+> gprettyPrec' t 0 x
+  isNullary (M1 x) = isNullary x
+
+instance (GPretty' a) => GPretty' (M1 D d a) where
+  gprettyPrec' t n (M1 x) = gprettyPrec' t n x
+
+instance (GPretty' a, GPretty' b) => GPretty' (a :+: b) where
+  gprettyPrec' t n (L1 x) = gprettyPrec' t n x
+  gprettyPrec' t n (R1 x) = gprettyPrec' t n x
+
+instance (GPretty' a, GPretty' b) => GPretty' (a :*: b) where
+  gprettyPrec' t@Rec n (a :*: b) =
+    vcat
+      [ gprettyPrec' t n a,
+        "," <+> gprettyPrec' t n b
+      ]
+  gprettyPrec' t@(Inf s _) n (a :*: b) =
+    align $
+      nest 2 $
+        vsep
+          [ gprettyPrec' t n a,
+            pretty s <+> gprettyPrec' t n b
+          ]
+  gprettyPrec' t@Tup n (a :*: b) =
+    vcat
+      [ gprettyPrec' t 0 a,
+        "," <> flatAlt " " "" <> gprettyPrec' t 0 b
+      ]
+  gprettyPrec' t@Pref n (a :*: b) =
+    vsep
+      [ gprettyPrec' t (n + 1) a,
+        gprettyPrec' t (n + 1) b
+      ]
+  isNullary _ = False
+
+viaShowsPrec :: (Int -> a -> ShowS) -> Int -> a -> Doc ann
+viaShowsPrec f n a = pretty (f n a "")
+
+#define GPRETTY_SIMPLE(type) \
+instance GPretty type where gprettyPrec = viaShowsPrec showsPrec
+
+instance GPretty Char where
+  gpretty = viaShow
+  gprettyList v = pretty (fromString v :: T.Text)
+
+#if 1
+GPRETTY_SIMPLE(Bool)
+GPRETTY_SIMPLE(Integer)
+GPRETTY_SIMPLE(Int)
+GPRETTY_SIMPLE(Int8)
+GPRETTY_SIMPLE(Int16)
+GPRETTY_SIMPLE(Int32)
+GPRETTY_SIMPLE(Int64)
+GPRETTY_SIMPLE(Word)
+GPRETTY_SIMPLE(Word8)
+GPRETTY_SIMPLE(Word16)
+GPRETTY_SIMPLE(Word32)
+GPRETTY_SIMPLE(Word64)
+GPRETTY_SIMPLE(SomeIntN)
+GPRETTY_SIMPLE(SomeWordN)
+GPRETTY_SIMPLE(B.ByteString)
+GPRETTY_SIMPLE(T.Text)
+#endif
+
+instance (KnownNat n, 1 <= n) => GPretty (IntN n) where
+  gpretty = viaShow
+
+instance (KnownNat n, 1 <= n) => GPretty (WordN n) where
+  gpretty = viaShow
+
+-- ()
+instance GPretty () where
+  gpretty = viaShow
+
+-- Either
+deriving via
+  (Default (Either a b))
+  instance
+    (GPretty a, GPretty b) => GPretty (Either a b)
+
+-- Maybe
+deriving via
+  (Default (Maybe a))
+  instance
+    (GPretty a) => GPretty (Maybe a)
+
+-- List
+instance (GPretty a) => GPretty [a] where
+  gpretty = gprettyList
+
+-- (,)
+deriving via
+  (Default (a, b))
+  instance
+    (GPretty a, GPretty b) => GPretty (a, b)
+
+-- (,,)
+deriving via
+  (Default (a, b, c))
+  instance
+    (GPretty a, GPretty b, GPretty c) => GPretty (a, b, c)
+
+-- (,,,)
+deriving via
+  (Default (a, b, c, d))
+  instance
+    ( GPretty a,
+      GPretty b,
+      GPretty c,
+      GPretty d
+    ) =>
+    GPretty (a, b, c, d)
+
+-- (,,,,)
+deriving via
+  (Default (a, b, c, d, e))
+  instance
+    ( GPretty a,
+      GPretty b,
+      GPretty c,
+      GPretty d,
+      GPretty e
+    ) =>
+    GPretty (a, b, c, d, e)
+
+-- (,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f))
+  instance
+    ( GPretty a,
+      GPretty b,
+      GPretty c,
+      GPretty d,
+      GPretty e,
+      GPretty f
+    ) =>
+    GPretty (a, b, c, d, e, f)
+
+-- (,,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f, g))
+  instance
+    ( GPretty a,
+      GPretty b,
+      GPretty c,
+      GPretty d,
+      GPretty e,
+      GPretty f,
+      GPretty g
+    ) =>
+    GPretty (a, b, c, d, e, f, g)
+
+-- (,,,,,,,)
+deriving via
+  (Default (a, b, c, d, e, f, g, h))
+  instance
+    ( GPretty a,
+      GPretty b,
+      GPretty c,
+      GPretty d,
+      GPretty e,
+      GPretty f,
+      GPretty g,
+      GPretty h
+    ) =>
+    GPretty (a, b, c, d, e, f, g, h)
+
+-- Sum
+deriving via
+  (Default (Sum f g a))
+  instance
+    (GPretty (f a), GPretty (g a)) =>
+    GPretty (Sum f g a)
+
+-- MaybeT
+instance
+  (GPretty (m (Maybe a))) =>
+  GPretty (MaybeT m a)
+  where
+  gprettyPrec i (MaybeT a) =
+    group $
+      nest 2 $
+        vsep
+          [ "MaybeT",
+            gprettyPrec 11 a
+          ]
+
+-- ExceptT
+instance
+  (GPretty (m (Either e a))) =>
+  GPretty (ExceptT e m a)
+  where
+  gprettyPrec i (ExceptT a) =
+    group $
+      nest 2 $
+        vsep
+          [ "ExceptT",
+            gprettyPrec 11 a
+          ]
+
+-- WriterT
+instance
+  (GPretty (m (a, w))) =>
+  GPretty (WriterLazy.WriterT w m a)
+  where
+  gprettyPrec i (WriterLazy.WriterT a) =
+    group $
+      nest 2 $
+        vsep
+          [ "WriterT",
+            gprettyPrec 11 a
+          ]
+
+instance
+  (GPretty (m (a, w))) =>
+  GPretty (WriterStrict.WriterT w m a)
+  where
+  gprettyPrec i (WriterStrict.WriterT a) =
+    group $
+      nest 2 $
+        vsep
+          [ "WriterT",
+            gprettyPrec 11 a
+          ]
+
+-- Identity
+instance (GPretty a) => GPretty (Identity a) where
+  gprettyPrec i (Identity a) =
+    group $
+      nest 2 $
+        vsep
+          [ "Identity",
+            gprettyPrec 11 a
+          ]
+
+-- IdentityT
+instance (GPretty (m a)) => GPretty (IdentityT m a) where
+  gprettyPrec i (IdentityT a) =
+    group $
+      nest 2 $
+        vsep
+          [ "IdentityT",
+            gprettyPrec 11 a
+          ]

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -83,6 +83,7 @@ import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Function
+import Grisette.Core.Data.Class.GPretty
 import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.ModelOps
@@ -607,6 +608,34 @@ instance Hashable ARG where
 
 -- Aggregate instances
 
+-- Prettyprint
+#define GPRETTY_SYM_SIMPLE(symtype) \
+instance GPretty symtype where \
+  gpretty (symtype t) = prettyPrintTerm t
+
+#define GPRETTY_SYM_BV(symtype) \
+instance (KnownNat n, 1 <= n) => GPretty (symtype n) where \
+  gpretty (symtype t) = prettyPrintTerm t
+
+#define GPRETTY_SYM_FUN(op, cons) \
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb)\
+  => GPretty (sa op sb) where \
+  gpretty (cons t) = prettyPrintTerm t
+
+#define GPRETTY_SYM_SOME_BV(symtype) \
+instance GPretty symtype where \
+  gpretty (symtype t) = gpretty t
+
+#if 1
+GPRETTY_SYM_SIMPLE(SymBool)
+GPRETTY_SYM_SIMPLE(SymInteger)
+GPRETTY_SYM_BV(SymIntN)
+GPRETTY_SYM_BV(SymWordN)
+GPRETTY_SYM_FUN(=~>, SymTabularFun)
+GPRETTY_SYM_FUN(-~>, SymGeneralFun)
+GPRETTY_SYM_SOME_BV(SomeSymIntN)
+GPRETTY_SYM_SOME_BV(SomeSymWordN)
+#endif
 -- Num
 
 #define NUM_BV(symtype) \

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
@@ -38,6 +38,7 @@ import GHC.TypeNats
 import Grisette.Core.Data.BV
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
+import Grisette.Core.Data.Class.GPretty
 import Grisette.Core.Data.Class.Solvable
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import Grisette.IR.SymPrim.Data.TabularFun
@@ -89,6 +90,8 @@ instance Hashable SymBool
 instance EvaluateSym SymBool
 
 instance ExtractSymbolics SymBool
+
+instance GPretty SymBool
 
 newtype SymInteger = SymInteger {underlyingIntegerTerm :: Term Integer}
 

--- a/stack-lts-18.28-lowerbound.yaml
+++ b/stack-lts-18.28-lowerbound.yaml
@@ -69,6 +69,7 @@ extra-deps:
   - call-stack-0.1.0
   - parallel-3.2.2.0
   - text-1.2.4.1
+  - prettyprinter-1.5.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack-lts-18.28-lowerbound.yaml.lock
+++ b/stack-lts-18.28-lowerbound.yaml.lock
@@ -186,6 +186,13 @@ packages:
       size: 7720
   original:
     hackage: text-1.2.4.1
+- completed:
+    hackage: prettyprinter-1.5.0@sha256:e92ed781622cd40e575639732e04dc2f6ba8e160d9055fd2a8aa86499d123006,5375
+    pantry-tree:
+      sha256: db4eb78e2845144563962a3e5d06da06453dcc96848c7b92928f3d1f7cbde0d8
+      size: 2105
+  original:
+    hackage: prettyprinter-1.5.0
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -1,0 +1,342 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Grisette.Core.Data.Class.GPrettyTests where
+
+import Data.Int
+import Data.Text as T
+import Data.Word
+import GHC.Generics
+import GHC.Stack
+import Generics.Deriving
+import Grisette.Core.Data.BV
+import Grisette.Core.Data.Class.Bool
+import Grisette.Core.Data.Class.GPretty
+import Grisette.IR.SymPrim.Data.SymPrim
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck hiding ((.&.))
+
+#if MIN_VERSION_prettyprinter(1,7,0)
+import Prettyprinter
+import Prettyprinter.Render.Text
+#else
+import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc.Render.Text
+#endif
+
+testGPretty :: (HasCallStack, GPretty a) => String -> Int -> a -> T.Text -> TestTree
+testGPretty n i a s =
+  testCase n $
+    renderStrict
+      ( layoutPretty
+          (LayoutOptions $ AvailablePerLine i 1)
+          (gpretty a)
+      )
+      @=? s
+
+propertyGPrettyShow ::
+  forall proxy a.
+  (HasCallStack, GPretty a, Show a) =>
+  String ->
+  Gen a ->
+  TestTree
+propertyGPrettyShow n g =
+  testProperty n $ forAll g $ \(a :: a) -> do
+    renderStrict (layoutPretty (LayoutOptions Unbounded) (gpretty a)) == T.pack (show a)
+
+propertyGPrettyRead ::
+  forall proxy a.
+  (HasCallStack, GPretty a, Read a, Show a, Eq a) =>
+  String ->
+  Gen a ->
+  TestTree
+propertyGPrettyRead n g =
+  testProperty n $ \i -> forAll g $ \(a :: a) -> do
+    read
+      ( T.unpack
+          ( renderStrict
+              ( layoutPretty
+                  (LayoutOptions $ AvailablePerLine (abs i) 0.8)
+                  (gpretty a)
+              )
+          )
+      )
+      == a
+
+propertyGPretty ::
+  forall proxy a.
+  (HasCallStack, GPretty a, Read a, Show a, Eq a) =>
+  String ->
+  Gen a ->
+  TestTree
+propertyGPretty n g =
+  testGroup
+    n
+    [ propertyGPrettyShow "single line" g,
+      propertyGPrettyRead "compact" g
+    ]
+
+data I5 a b = a :-: b
+  deriving (Generic, Show, Read, Eq)
+  deriving (GPretty) via (Default (I5 a b))
+
+infixl 5 :-:
+
+data I6 a b = a :--: b
+  deriving (Generic, Show, Read, Eq)
+  deriving (GPretty) via (Default (I6 a b))
+
+infixl 6 :--:
+
+instance
+  (Arbitrary a, Arbitrary b) =>
+  Arbitrary (I5 a b)
+  where
+  arbitrary = do
+    a <- arbitrary
+    b <- arbitrary
+    return $ a :-: b
+
+instance
+  (Arbitrary a, Arbitrary b) =>
+  Arbitrary (I6 a b)
+  where
+  arbitrary = do
+    a <- arbitrary
+    b <- arbitrary
+    return $ a :--: b
+
+data Record a b = Record {ra :: a, rb :: b}
+  deriving (Generic, Show, Read, Eq)
+  deriving (GPretty) via (Default (Record a b))
+
+instance
+  (Arbitrary a, Arbitrary b) =>
+  Arbitrary (Record a b)
+  where
+  arbitrary = do
+    a <- arbitrary
+    Record a <$> arbitrary
+
+gprettyTests :: TestTree
+gprettyTests =
+  testGroup
+    "GPrettyTests"
+    [ testGroup
+        "simple tests"
+        [ propertyGPretty "Bool" (arbitrary :: Gen Bool),
+          propertyGPretty "Integer" (arbitrary :: Gen Integer),
+          propertyGPretty "Int" (arbitrary :: Gen Int),
+          propertyGPretty "Int8" (arbitrary :: Gen Int8),
+          propertyGPretty "Int16" (arbitrary :: Gen Int16),
+          propertyGPretty "Int32" (arbitrary :: Gen Int32),
+          propertyGPretty "Int64" (arbitrary :: Gen Int64),
+          propertyGPretty "Word" (arbitrary :: Gen Word),
+          propertyGPretty "Word8" (arbitrary :: Gen Word8),
+          propertyGPretty "Word16" (arbitrary :: Gen Word16),
+          propertyGPretty "Word32" (arbitrary :: Gen Word32),
+          propertyGPretty "Word64" (arbitrary :: Gen Word64),
+          propertyGPrettyShow
+            "SomeWordN"
+            ( oneof
+                [ SomeWordN <$> (arbitrary :: Gen (WordN 8)),
+                  SomeWordN <$> (arbitrary :: Gen (WordN 9)),
+                  SomeWordN <$> (arbitrary :: Gen (WordN 10))
+                ]
+            ),
+          propertyGPretty "WordN 8" (arbitrary :: Gen (WordN 8)),
+          propertyGPretty "WordN 9" (arbitrary :: Gen (WordN 9)),
+          propertyGPrettyShow
+            "SomeIntN"
+            ( oneof
+                [ SomeIntN <$> (arbitrary :: Gen (IntN 8)),
+                  SomeIntN <$> (arbitrary :: Gen (IntN 9)),
+                  SomeIntN <$> (arbitrary :: Gen (IntN 10))
+                ]
+            ),
+          propertyGPretty "IntN 8" (arbitrary :: Gen (IntN 8)),
+          propertyGPretty "IntN 9" (arbitrary :: Gen (IntN 9)),
+          propertyGPretty "()" (arbitrary :: Gen ()),
+          propertyGPretty
+            "Either"
+            ( arbitrary :: Gen (Either Int Bool)
+            ),
+          propertyGPretty
+            "Maybe"
+            ( arbitrary :: Gen (Maybe Int)
+            ),
+          propertyGPretty
+            "List"
+            ( arbitrary :: Gen [Int]
+            ),
+          propertyGPretty
+            "(,)"
+            ( arbitrary :: Gen (Int, Int)
+            ),
+          propertyGPretty
+            "(,,)"
+            ( arbitrary :: Gen (Int, Int, Int)
+            ),
+          propertyGPretty
+            "(,,,)"
+            ( arbitrary :: Gen (Int, Int, Int, Int)
+            ),
+          propertyGPretty
+            "(,,,,)"
+            ( arbitrary :: Gen (Int, Int, Int, Int, Int)
+            ),
+          propertyGPretty
+            "(,,,,,)"
+            ( arbitrary :: Gen (Int, Int, Int, Int, Int, Int)
+            ),
+          propertyGPretty
+            "(,,,,,,)"
+            ( arbitrary :: Gen (Int, Int, Int, Int, Int, Int, Int)
+            ),
+          propertyGPretty
+            "(,,,,,,,)"
+            ( arbitrary :: Gen (Int, Int, Int, Int, Int, Int, Int, Int)
+            ),
+          propertyGPretty
+            "I5"
+            ( arbitrary :: Gen (I5 Int Int)
+            ),
+          propertyGPretty
+            "Record"
+            ( arbitrary :: Gen (Record Int Int)
+            )
+        ],
+      testGroup
+        "Combined types"
+        [ propertyGPretty
+            "Maybe Maybe"
+            ( arbitrary :: Gen (Maybe (Maybe Int))
+            ),
+          propertyGPretty
+            "Maybe (,)"
+            ( arbitrary :: Gen (Maybe (Int, Int))
+            ),
+          propertyGPretty
+            "Maybe I5"
+            ( arbitrary :: Gen (Maybe (I5 Int Int))
+            ),
+          propertyGPretty
+            "Maybe []"
+            ( arbitrary :: Gen (Maybe [Int])
+            ),
+          propertyGPretty
+            "Maybe Record"
+            ( arbitrary :: Gen (Maybe (Record Int Int))
+            ),
+          propertyGPretty
+            "(Maybe,Either)"
+            ( arbitrary :: Gen (Maybe Int, Either Int Int)
+            ),
+          propertyGPretty
+            "((,),(,))"
+            ( arbitrary :: Gen ((Int, Int), (Int, Int))
+            ),
+          propertyGPretty
+            "(I5,I5)"
+            ( arbitrary :: Gen (I5 Int Int, I5 Int Int)
+            ),
+          propertyGPretty
+            "([],[])"
+            ( arbitrary :: Gen ([Int], [Int])
+            ),
+          propertyGPretty
+            "(Record,Record)"
+            ( arbitrary :: Gen (Record Int Int, Record Int Int)
+            ),
+          propertyGPretty
+            "I5 Maybe Either"
+            ( arbitrary :: Gen (I5 (Maybe Int) (Either Int Int))
+            ),
+          propertyGPretty
+            "I5 (,) (,)"
+            ( arbitrary :: Gen (I5 (Int, Int) (Int, Int))
+            ),
+          propertyGPretty
+            "I5 I6 I6"
+            ( arbitrary :: Gen (I5 (I6 Int Int) (I6 Int Int))
+            ),
+          propertyGPretty
+            "I5 I5 I5"
+            ( arbitrary :: Gen (I5 (I5 Int Int) (I5 Int Int))
+            ),
+          propertyGPretty
+            "I6 I5 I5"
+            ( arbitrary :: Gen (I6 (I5 Int Int) (I5 Int Int))
+            ),
+          propertyGPretty
+            "I6 I6 I6"
+            ( arbitrary :: Gen (I6 (I6 Int Int) (I6 Int Int))
+            ),
+          propertyGPretty
+            "I5 [] []"
+            ( arbitrary :: Gen (I5 [Int] [Int])
+            ),
+          propertyGPretty
+            "I5 Record Record"
+            ( arbitrary :: Gen (I5 (Record Int Int) (Record Int Int))
+            ),
+          propertyGPretty
+            "[Maybe]"
+            ( arbitrary :: Gen [Maybe Int]
+            ),
+          propertyGPretty
+            "[(,)]"
+            ( arbitrary :: Gen [(Int, Int)]
+            ),
+          propertyGPretty
+            "[I5]"
+            ( arbitrary :: Gen [I5 Int Int]
+            ),
+          propertyGPretty
+            "[[]]"
+            ( arbitrary :: Gen [[Int]]
+            ),
+          propertyGPretty
+            "[Record]"
+            ( arbitrary :: Gen [Record Int Int]
+            ),
+          propertyGPretty
+            "Record Maybe Either"
+            ( arbitrary :: Gen (Record (Maybe Int) (Either Int Int))
+            ),
+          propertyGPretty
+            "Record (,) (,)"
+            ( arbitrary :: Gen (Record (Int, Int) (Int, Int))
+            ),
+          propertyGPretty
+            "Record I5 I6"
+            ( arbitrary :: Gen (Record (I5 Int Int) (I6 Int Int))
+            ),
+          propertyGPretty
+            "Record []"
+            ( arbitrary :: Gen (Record [Int] [Int])
+            ),
+          propertyGPretty
+            "Record Record"
+            ( arbitrary :: Gen (Record (Record Int Int) (Record Int Int))
+            )
+        ],
+      testGroup
+        "Symbolic types"
+        [ testGPretty
+            "enough space"
+            80
+            ("a" &&~ "b" :: SymBool)
+            "(&& a b)",
+          testGPretty
+            "not enough space"
+            6
+            ("a" &&~ "b" :: SymBool)
+            "..."
+        ]
+    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -27,6 +27,7 @@ import Grisette.Backend.SBV.Data.SMT.LoweringTests
 import Grisette.Backend.SBV.Data.SMT.TermRewritingTests
 import Grisette.Core.Control.Monad.UnionMTests
 import qualified Grisette.Core.Data.BVTests
+import Grisette.Core.Data.Class.GPrettyTests
 import qualified Grisette.IR.SymPrim.Data.Prim.BVTests
 import Grisette.IR.SymPrim.Data.Prim.BitsTests
 import Grisette.IR.SymPrim.Data.Prim.BoolTests
@@ -56,9 +57,17 @@ tests =
 coreTests :: TestTree
 coreTests =
   testGroup
-    "Grisette.Core.Control.Monad.UnionM"
-    [ unionMTests,
-      Grisette.Core.Data.BVTests.bvTests
+    "core"
+    [ testGroup
+        "Grisette.Core.Control.Monad.UnionM"
+        [unionMTests],
+      testGroup
+        "Grisette.Core.Data"
+        [ testGroup
+            "Class"
+            [gprettyTests],
+          Grisette.Core.Data.BVTests.bvTests
+        ]
     ]
 
 {-


### PR DESCRIPTION
This pull request added the `GPretty` class and provided various instances for it. Resolves #92.

A pretty printer for the symbolic types is included, which would omit the details of the formulas if they are too long.
