### PR TITLE
Use newest (possible) ghc toolchains and stackage snapshots.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
         - { build: stack, arg: "--stack-yaml stack-lts-18.28-lowerbound.yaml", ismain: false, experimental: false, ghc: "8107", cachekey: "stack-18.28-l" }
         - { build: stack, arg: "--stack-yaml stack-lts-19.33.yaml", ismain: false, experimental: false, ghc: "902", cachekey: "stack-19.33" }
         - { build: stack, arg: "--stack-yaml stack-lts-20.26.yaml", ismain: false, experimental: false, ghc: "928", cachekey: "stack-20.26" }
-        - { build: stack, arg: "", ismain: true, experimental: false, ghc: "945", cachekey: "stack-21.1" }
+        - { build: stack, arg: "", ismain: true, experimental: false, ghc: "946", cachekey: "stack-21.11" }
         - { build: stack, arg: "--stack-yaml stack-nightly.yaml --resolver nightly", ismain: false, experimental: false, ghc: "962", cachekey: "stack-nightly" }
         - { build: cabal, arg: "--constraint=sbv<10", ismain: false, experimental: false, ghc: "8107", cachekey: "cabal-8107" }
         - { build: cabal, arg: "--constraint=sbv<10", ismain: false, experimental: false, ghc: "902", cachekey: "cabal-902" }
         - { build: cabal, arg: "", ismain: false, experimental: false, ghc: "928", cachekey: "cabal-928" }
-        - { build: cabal, arg: "--allow-newer=text", ismain: false, experimental: false, ghc: "945", cachekey: "cabal-945" }
+        - { build: cabal, arg: "--allow-newer=text", ismain: false, experimental: false, ghc: "946", cachekey: "cabal-946" }
         - { build: cabal, arg: "--allow-newer=text,mtl", ismain: false, experimental: false, ghc: "962", cachekey: "cabal-962" }
   
     runs-on: ${{ matrix.os }}

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688590700,
-        "narHash": "sha256-ZF055rIUP89cVwiLpG5xkJzx00gEuuGFF60Bs/LM3wc=",
+        "lastModified": 1695644571,
+        "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f292b4964cb71f9dfbbd30dc9f511d6165cd109b",
+        "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         
-        hPkgs = pkgs.haskell.packages."ghc945";
+        hPkgs = pkgs.haskell.packages."ghc946";
         
         myDevTools = [
           hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2023-07-07
+resolver: nightly-2023-09-26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: tasty-test-reporter-0.1.1.4
 snapshots:
 - completed:
-    sha256: e134cdce2ef4c28a0791a8c33aa6e35d4a3eeebc30b842a3062b318b84ae2b68
-    size: 544564
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/7/7.yaml
-  original: nightly-2023-07-07
+    sha256: 2759c0a43a745a0aee7d085a37c43422373848a5913e21225113b0039577ed53
+    size: 669536
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/9/26.yaml
+  original: nightly-2023-09-26

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-21.1
+resolver: lts-21.11
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -13,7 +13,7 @@ packages:
     hackage: tasty-test-reporter-0.1.1.4
 snapshots:
 - completed:
-    sha256: c4381351ba5837a6356fcc0ebeb7a61fdcaf3a085c903a6f730f56b131d5cb58
-    size: 639143
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/1.yaml
-  original: lts-21.1
+    sha256: 64d66303f927e87ffe6b8ccf736229bf608731e80d7afdf62bdd63c59f857740
+    size: 640037
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/11.yaml
+  original: lts-21.11


### PR DESCRIPTION
This pull request updates the toolchain configurations. nixpkgs only provide ghc 9.4.6 but not ghc 9.4.7 so we are using lts-21.11 rather than lts-21.13.