### PR TITLE
Add some warning flags to package.yaml

### DIFF
--- a/doctest/Main.hs
+++ b/doctest/Main.hs
@@ -1,4 +1,4 @@
-module Main where
+module Main (main) where
 
 import System.FilePath.Glob (glob)
 import Test.DocTest (doctest)

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields -Wunused-type-patterns
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields -Wunused-type-patterns
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields -Wunused-type-patterns
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat
+  ghc-options: -Wextra -Werror -Wcompat -Widentities
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat
+  ghc-options: -Wextra -Werror -Wcompat -Widentities
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat
+  ghc-options: -Wextra -Werror -Wcompat -Widentities
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -132,7 +132,6 @@ library
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
-    , call-stack >=0.1 && <0.5
     , deepseq >=1.4.4 && <1.5
     , generic-deriving >=1.14.1 && <1.15
     , hashable >=1.2.3 && <1.5
@@ -168,7 +167,6 @@ test-suite doctest
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
-    , call-stack >=0.1 && <0.5
     , deepseq >=1.4.4 && <1.5
     , doctest >=0.18.2 && <0.22
     , generic-deriving >=1.14.1 && <1.15
@@ -221,7 +219,6 @@ test-suite spec
     , array >=0.5.4 && <0.6
     , base >=4.14 && <5
     , bytestring >=0.10.12 && <0.12
-    , call-stack >=0.1 && <0.5
     , deepseq >=1.4.4 && <1.5
     , generic-deriving >=1.14.1 && <1.15
     , grisette

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields
+  ghc-options: -Wextra -Werror -Wcompat -Widentities -Wincomplete-record-updates -Wmissing-export-lists -Wmissing-home-modules -Wmissing-import-lists -Wpartial-fields
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,7 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
-  ghc-options: -Wextra -Werror
+  ghc-options: -Wextra -Werror -Wcompat
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -161,7 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
-  ghc-options: -Wextra -Werror
+  ghc-options: -Wextra -Werror -Wcompat
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -215,7 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
-  ghc-options: -Wextra -Werror
+  ghc-options: -Wextra -Werror -Wcompat
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -126,6 +126,7 @@ library
       Paths_grisette
   hs-source-dirs:
       src
+  ghc-options: -Wextra -Werror
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -147,7 +148,6 @@ library
     , th-compat >=0.1.2 && <0.2
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
-    , vector >=0.12.1 && <0.14
   default-language: Haskell2010
   if flag(fast)
     ghc-options: -O2
@@ -161,6 +161,7 @@ test-suite doctest
       Paths_grisette
   hs-source-dirs:
       doctest
+  ghc-options: -Wextra -Werror
   build-depends:
       Glob
     , QuickCheck >=2.13.2 && <2.15
@@ -185,7 +186,6 @@ test-suite doctest
     , th-compat >=0.1.2 && <0.2
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
-    , vector >=0.12.1 && <0.14
   default-language: Haskell2010
   if flag(fast)
     ghc-options: -O2
@@ -215,6 +215,7 @@ test-suite spec
       Paths_grisette
   hs-source-dirs:
       test
+  ghc-options: -Wextra -Werror
   build-depends:
       QuickCheck >=2.13.2 && <2.15
     , array >=0.5.4 && <0.6
@@ -241,7 +242,6 @@ test-suite spec
     , th-compat >=0.1.2 && <0.2
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
-    , vector >=0.12.1 && <0.14
   default-language: Haskell2010
   if flag(fast)
     ghc-options: -O2

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,7 @@ ghc-options:
   - -Wextra
   - -Werror
   - -Wcompat
+  - -Widentities
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -41,7 +41,6 @@ dependencies:
   - hashtables >= 1.2.3.4 && < 1.4
   - loch-th >= 0.2.2 && < 0.3
   - th-compat >= 0.1.2 && < 0.2
-  - call-stack >= 0.1 && < 0.5
   - array >= 0.5.4 && < 0.6
   - sbv >= 8.11 && < 10.3
   - parallel >= 3.2.2.0 && < 3.3

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,6 @@ dependencies:
 - th-compat >= 0.1.2 && < 0.2
 - call-stack >= 0.1 && < 0.5
 - array >= 0.5.4 && < 0.6
-- vector >= 0.12.1 && < 0.14
 - sbv >= 8.11 && < 10.3
 - parallel >= 3.2.2.0 && < 3.3
 - text >= 1.2.4.1 && < 2.1
@@ -64,6 +63,10 @@ when:
       ghc-options: -O2
     else:
       ghc-options: -O0
+
+ghc-options:
+  - -Wextra
+  - -Werror
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -67,6 +67,7 @@ when:
 ghc-options:
   - -Wextra
   - -Werror
+  - -Wcompat
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ ghc-options:
   - -Werror
   - -Wcompat
   - -Widentities
+  - -Wincomplete-record-updates
   - -Wmissing-export-lists
   - -Wmissing-home-modules
   - -Wpartial-fields

--- a/package.yaml
+++ b/package.yaml
@@ -71,6 +71,7 @@ ghc-options:
   - -Widentities
   - -Wmissing-export-lists
   - -Wmissing-home-modules
+  - -Wpartial-fields
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -18,44 +18,46 @@ license-file: LICENSE
 github: lsrcz/grisette
 copyright: "2021-2023 Sirui Lu"
 extra-source-files:
-- CHANGELOG.md
-- README.md
+  - CHANGELOG.md
+  - README.md
 tested-with:
-- GHC == 8.10.7
-- GHC == 9.0.2
-- GHC == 9.2.8
-- GHC == 9.4.5
-- GHC == 9.6.2
+  - GHC == 8.10.7
+  - GHC == 9.0.2
+  - GHC == 9.2.8
+  - GHC == 9.4.5
+  - GHC == 9.6.2
 
 dependencies:
-- base >= 4.14 && < 5
-- intern >= 0.9.2 && < 0.10
-- hashable >= 1.2.3 && < 1.5
-- mtl >= 2.2.2 && < 2.4
-- transformers >= 0.5.6 && < 0.7
-- generic-deriving >= 1.14.1 && < 1.15
-- bytestring >= 0.10.12 && < 0.12
-- unordered-containers >= 0.2.11 && < 0.3
-- template-haskell >= 2.16 && < 2.21
-- deepseq >= 1.4.4 && < 1.5
-- hashtables >= 1.2.3.4 && < 1.4
-- loch-th >= 0.2.2 && < 0.3
-- th-compat >= 0.1.2 && < 0.2
-- call-stack >= 0.1 && < 0.5
-- array >= 0.5.4 && < 0.6
-- sbv >= 8.11 && < 10.3
-- parallel >= 3.2.2.0 && < 3.3
-- text >= 1.2.4.1 && < 2.1
-- QuickCheck >= 2.13.2 && < 2.15
-- prettyprinter >= 1.5.0 && < 1.8
+  - base >= 4.14 && < 5
+  - intern >= 0.9.2 && < 0.10
+  - hashable >= 1.2.3 && < 1.5
+  - mtl >= 2.2.2 && < 2.4
+  - transformers >= 0.5.6 && < 0.7
+  - generic-deriving >= 1.14.1 && < 1.15
+  - bytestring >= 0.10.12 && < 0.12
+  - unordered-containers >= 0.2.11 && < 0.3
+  - template-haskell >= 2.16 && < 2.21
+  - deepseq >= 1.4.4 && < 1.5
+  - hashtables >= 1.2.3.4 && < 1.4
+  - loch-th >= 0.2.2 && < 0.3
+  - th-compat >= 0.1.2 && < 0.2
+  - call-stack >= 0.1 && < 0.5
+  - array >= 0.5.4 && < 0.6
+  - sbv >= 8.11 && < 10.3
+  - parallel >= 3.2.2.0 && < 3.3
+  - text >= 1.2.4.1 && < 2.1
+  - QuickCheck >= 2.13.2 && < 2.15
+  - prettyprinter >= 1.5.0 && < 1.8
 
-flags: {
-  fast: {
-    description: "Compile with O2 optimization",
-    manual: False,
-    default: True,
+flags:
+  {
+    fast:
+      {
+        description: "Compile with O2 optimization",
+        manual: False,
+        default: True,
+      },
   }
-}
 
 when:
   - condition: flag(fast)
@@ -72,6 +74,7 @@ ghc-options:
   - -Wincomplete-record-updates
   - -Wmissing-export-lists
   - -Wmissing-home-modules
+  - -Wmissing-import-lists
   - -Wpartial-fields
 
 library:
@@ -94,4 +97,3 @@ tests:
       - grisette
       - doctest >= 0.18.2 && < 0.22
       - Glob
-

--- a/package.yaml
+++ b/package.yaml
@@ -76,6 +76,7 @@ ghc-options:
   - -Wmissing-home-modules
   - -Wmissing-import-lists
   - -Wpartial-fields
+  - -Wunused-type-patterns
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -69,6 +69,7 @@ ghc-options:
   - -Werror
   - -Wcompat
   - -Widentities
+  - -Wmissing-export-lists
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -70,6 +70,7 @@ ghc-options:
   - -Wcompat
   - -Widentities
   - -Wmissing-export-lists
+  - -Wmissing-home-modules
 
 library:
   source-dirs: src

--- a/src/Grisette.hs
+++ b/src/Grisette.hs
@@ -1,5 +1,8 @@
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 -- |
--- Module      :   Grisette.Core
+-- Module      :   Grisette
 -- Copyright   :   (c) Sirui Lu 2021-2023
 -- License     :   BSD-3-Clause (see the LICENSE file)
 --

--- a/src/Grisette/Backend/SBV.hs
+++ b/src/Grisette/Backend/SBV.hs
@@ -1,3 +1,6 @@
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 -- |
 -- Module      :   Grisette.Backend.SBV
 -- Copyright   :   (c) Sirui Lu 2021-2023
@@ -34,3 +37,14 @@ where
 
 import qualified Data.SBV as SBV
 import Grisette.Backend.SBV.Data.SMT.Solving
+  ( ApproximationConfig (..),
+    ExtraConfig (..),
+    GrisetteSMTConfig (..),
+    SolvingFailure (..),
+    approx,
+    clearApprox,
+    clearTimeout,
+    precise,
+    withApprox,
+    withTimeout,
+  )

--- a/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
+++ b/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
@@ -39,8 +39,7 @@ where
 
 import Control.DeepSeq
 import Control.Exception
-import Control.Monad.Except
-import Control.Monad.IO.Class
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.HashSet as S
 import Data.Hashable
 import Data.Kind
@@ -56,7 +55,6 @@ import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.CEGISSolver
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
-import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.ModelOps
 import Grisette.Core.Data.Class.Solvable
 import Grisette.Core.Data.Class.Solver
@@ -325,7 +323,7 @@ instance Solver (GrisetteSMTConfig n) SolvingFailure where
 
 instance CEGISSolver (GrisetteSMTConfig n) SolvingFailure where
   cegisMultiInputs ::
-    forall inputs spec.
+    forall inputs.
     (ExtractSymbolics inputs, EvaluateSym inputs) =>
     GrisetteSMTConfig n ->
     [inputs] ->

--- a/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
+++ b/src/Grisette/Backend/SBV/Data/SMT/Solving.hs
@@ -100,7 +100,7 @@ import Language.Haskell.TH.Syntax (Lift)
 
 type Aux :: Bool -> Nat -> Type
 type family Aux o n where
-  Aux 'True n = SBV.SInteger
+  Aux 'True _ = SBV.SInteger
   Aux 'False n = SBV.SInt n
 
 type IsZero :: Nat -> Bool
@@ -112,8 +112,8 @@ type TermTy :: Nat -> Type -> Type
 type family TermTy bitWidth b where
   TermTy _ Bool = SBV.SBool
   TermTy n Integer = Aux (IsZero n) n
-  TermTy n (IntN x) = SBV.SBV (SBV.IntN x)
-  TermTy n (WordN x) = SBV.SBV (SBV.WordN x)
+  TermTy _ (IntN x) = SBV.SBV (SBV.IntN x)
+  TermTy _ (WordN x) = SBV.SBV (SBV.WordN x)
   TermTy n (a =-> b) = TermTy n a -> TermTy n b
   TermTy n (a --> b) = TermTy n a -> TermTy n b
   TermTy _ v = v

--- a/src/Grisette/Backend/SBV/Data/SMT/Solving.hs-boot
+++ b/src/Grisette/Backend/SBV/Data/SMT/Solving.hs-boot
@@ -13,12 +13,14 @@ module Grisette.Backend.SBV.Data.SMT.Solving
   )
 where
 
-import Data.Kind
+import Data.Kind (Type)
 import qualified Data.SBV as SBV
-import GHC.TypeNats
-import Grisette.Core.Data.BV
+import GHC.TypeNats (KnownNat, Nat)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.TabularFun
+  ( type (-->),
+  )
+import Grisette.IR.SymPrim.Data.TabularFun (type (=->))
 
 type Aux :: Bool -> Nat -> Type
 type family Aux o n where

--- a/src/Grisette/Backend/SBV/Data/SMT/Solving.hs-boot
+++ b/src/Grisette/Backend/SBV/Data/SMT/Solving.hs-boot
@@ -24,7 +24,7 @@ import Grisette.IR.SymPrim.Data.TabularFun (type (=->))
 
 type Aux :: Bool -> Nat -> Type
 type family Aux o n where
-  Aux 'True n = SBV.SInteger
+  Aux 'True _ = SBV.SInteger
   Aux 'False n = SBV.SInt n
 
 type IsZero :: Nat -> Bool
@@ -36,8 +36,8 @@ type TermTy :: Nat -> Type -> Type
 type family TermTy bitWidth b where
   TermTy _ Bool = SBV.SBool
   TermTy n Integer = Aux (IsZero n) n
-  TermTy n (IntN x) = SBV.SBV (SBV.IntN x)
-  TermTy n (WordN x) = SBV.SBV (SBV.WordN x)
+  TermTy _ (IntN x) = SBV.SBV (SBV.IntN x)
+  TermTy _ (WordN x) = SBV.SBV (SBV.WordN x)
   TermTy n (a =-> b) = TermTy n a -> TermTy n b
   TermTy n (a --> b) = TermTy n a -> TermTy n b
   TermTy _ v = v

--- a/src/Grisette/Backend/SBV/Data/SMT/SymBiMap.hs
+++ b/src/Grisette/Backend/SBV/Data/SMT/SymBiMap.hs
@@ -19,11 +19,15 @@ module Grisette.Backend.SBV.Data.SMT.SymBiMap
   )
 where
 
-import Data.Dynamic
+import Data.Dynamic (Dynamic)
 import qualified Data.HashMap.Strict as M
-import GHC.Stack
+import GHC.Stack (HasCallStack)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm
+  ( SomeTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SomeTypedSymbol,
+  )
 
 data SymBiMap = SymBiMap
   { biMapToSBV :: M.HashMap SomeTerm Dynamic,

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Trustworthy #-}
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 -- |
 -- Module      :   Grisette.Core
@@ -1011,33 +1013,188 @@ where
 
 import Generics.Deriving (Default (..), Default1 (..))
 import Grisette.Core.BuiltinUnionWrappers
+  ( mrgAssertionViolation,
+    mrgAssumptionViolation,
+    mrgFalse,
+    mrgInL,
+    mrgInR,
+    mrgJust,
+    mrgLeft,
+    mrgNothing,
+    mrgRight,
+    mrgTrue,
+    mrgTuple2,
+    mrgTuple3,
+    mrgUnit,
+  )
 import Grisette.Core.Control.Exception
+  ( AssertionError (..),
+    VerificationConditions (..),
+    symAssert,
+    symAssume,
+  )
 import Grisette.Core.Control.Monad.CBMCExcept
+  ( CBMCEither (..),
+    CBMCExceptT (..),
+    cbmcExcept,
+    mapCBMCExceptT,
+    withCBMCExceptT,
+  )
 import Grisette.Core.Control.Monad.Class.MonadParallelUnion
-import Grisette.Core.Control.Monad.Union
+  ( MonadParallelUnion (..),
+  )
+import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Control.Monad.UnionM
+  ( IsConcrete,
+    UnionM,
+    liftToMonadUnion,
+    unionSize,
+    (#~),
+  )
 import Grisette.Core.Data.Class.BitVector
+  ( BV (..),
+    SizedBV (..),
+    bvExtract,
+    sizedBVExtract,
+  )
 import Grisette.Core.Data.Class.Bool
+  ( ITEOp (..),
+    LogicalOp (..),
+    SEq (..),
+    SymBoolOp,
+  )
 import Grisette.Core.Data.Class.CEGISSolver
+  ( CEGISCondition (..),
+    CEGISSolver (..),
+    cegis,
+    cegisExcept,
+    cegisExceptMultiInputs,
+    cegisExceptStdVC,
+    cegisExceptStdVCMultiInputs,
+    cegisExceptVC,
+    cegisExceptVCMultiInputs,
+    cegisPostCond,
+    cegisPrePost,
+  )
 import Grisette.Core.Data.Class.Error
+  ( TransformError (..),
+    symAssertTransformableError,
+    symAssertWith,
+    symThrowTransformableError,
+  )
 import Grisette.Core.Data.Class.Evaluate
+  ( EvaluateSym (..),
+    evaluateSymToCon,
+  )
 import Grisette.Core.Data.Class.ExtractSymbolics
-import Grisette.Core.Data.Class.Function
-import Grisette.Core.Data.Class.GPretty
+  ( ExtractSymbolics (..),
+  )
+import Grisette.Core.Data.Class.Function (Function (..))
+import Grisette.Core.Data.Class.GPretty (GPretty (..))
 import Grisette.Core.Data.Class.GenSym
+  ( EnumGenBound (..),
+    EnumGenUpperBound (..),
+    Fresh,
+    FreshIdent (..),
+    FreshIndex (..),
+    FreshT,
+    GenSym (..),
+    GenSymSimple (..),
+    ListSpec (..),
+    MonadFresh (..),
+    SimpleListSpec (..),
+    choose,
+    chooseFresh,
+    chooseSimple,
+    chooseSimpleFresh,
+    chooseUnion,
+    chooseUnionFresh,
+    derivedNoSpecFresh,
+    derivedNoSpecSimpleFresh,
+    derivedSameShapeSimpleFresh,
+    genSym,
+    genSymSimple,
+    name,
+    nameWithInfo,
+    runFresh,
+    runFreshT,
+  )
 import Grisette.Core.Data.Class.Mergeable
+  ( DynamicSortedIdx (..),
+    Mergeable (..),
+    Mergeable1 (..),
+    Mergeable2 (..),
+    Mergeable3 (..),
+    MergingStrategy (..),
+    StrategyList (..),
+    buildStrategyList,
+    derivedRootStrategy,
+    product2Strategy,
+    resolveStrategy,
+    resolveStrategy',
+    rootStrategy1,
+    rootStrategy2,
+    rootStrategy3,
+    wrapStrategy,
+  )
 import Grisette.Core.Data.Class.ModelOps
-import Grisette.Core.Data.Class.SOrd
+  ( ModelOps (..),
+    ModelRep (..),
+    SymbolSetOps (..),
+    SymbolSetRep (..),
+  )
+import Grisette.Core.Data.Class.SOrd (SOrd (..))
 import Grisette.Core.Data.Class.SafeArith
+  ( SafeDivision (..),
+    SafeLinearArith (..),
+    SymIntegerOp,
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
+  ( SimpleMergeable (..),
+    SimpleMergeable1 (..),
+    SimpleMergeable2 (..),
+    UnionLike (..),
+    UnionPrjOp (..),
+    merge,
+    mrgIf,
+    mrgIte1,
+    mrgIte2,
+    mrgSingle,
+    onUnion,
+    onUnion2,
+    onUnion3,
+    onUnion4,
+    simpleMerge,
+    pattern IfU,
+    pattern SingleU,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (..), pattern Con)
 import Grisette.Core.Data.Class.Solver
+  ( Solver (..),
+    UnionWithExcept (..),
+    solveExcept,
+    solveMultiExcept,
+  )
 import Grisette.Core.Data.Class.Substitute
-import Grisette.Core.Data.Class.ToCon
-import Grisette.Core.Data.Class.ToSym
+  ( SubstituteSym (..),
+    SubstituteSym' (..),
+  )
+import Grisette.Core.Data.Class.ToCon (ToCon (..))
+import Grisette.Core.Data.Class.ToSym (ToSym (..))
 import Grisette.Core.Data.FileLocation
+  ( FileLocation (..),
+    ilocsym,
+    nameWithLoc,
+    slocsym,
+  )
 import Grisette.Core.Data.MemoUtils
-import Grisette.Core.TH
+  ( htmemo,
+    htmemo2,
+    htmemo3,
+    htmemoFix,
+    htmup,
+  )
+import Grisette.Core.TH (makeUnionWrapper, makeUnionWrapper')
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/BuiltinUnionWrappers.hs
+++ b/src/Grisette/Core/BuiltinUnionWrappers.hs
@@ -30,10 +30,10 @@ module Grisette.Core.BuiltinUnionWrappers
   )
 where
 
-import Data.Functor.Sum
-import Grisette.Core.Control.Exception
-import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.TH
+import Data.Functor.Sum (Sum)
+import Grisette.Core.Control.Exception (VerificationConditions)
+import Grisette.Core.Data.Class.SimpleMergeable (mrgSingle)
+import Grisette.Core.TH (makeUnionWrapper, makeUnionWrapper')
 
 $(makeUnionWrapper "mrg" ''Bool)
 $(makeUnionWrapper' ["mrgUnit"] ''())

--- a/src/Grisette/Core/Control/Exception.hs
+++ b/src/Grisette/Core/Control/Exception.hs
@@ -24,23 +24,33 @@ module Grisette.Core.Control.Exception
   )
 where
 
-import Control.DeepSeq
-import Control.Exception
-import Control.Monad.Except
-import GHC.Generics
-import Generics.Deriving
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
+import Control.DeepSeq (NFData)
+import Control.Exception (ArithException, ArrayException)
+import Control.Monad.Except (MonadError)
+import GHC.Generics (Generic)
+import Generics.Deriving (Default (Default))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Bool (SEq)
 import Grisette.Core.Data.Class.Error
-import Grisette.Core.Data.Class.Evaluate
+  ( TransformError (transformError),
+    symAssertTransformableError,
+  )
+import Grisette.Core.Data.Class.Evaluate (EvaluateSym)
 import Grisette.Core.Data.Class.ExtractSymbolics
-import Grisette.Core.Data.Class.Mergeable
+  ( ExtractSymbolics,
+  )
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SOrd
+  ( SOrd (symCompare, (<=~), (<~), (>=~), (>~)),
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
-import Grisette.Core.Data.Class.ToCon
-import Grisette.Core.Data.Class.ToSym
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+  ( SimpleMergeable,
+    mrgSingle,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (con))
+import Grisette.Core.Data.Class.ToCon (ToCon)
+import Grisette.Core.Data.Class.ToSym (ToSym)
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
+++ b/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
@@ -13,19 +13,22 @@ module Grisette.Core.Control.Monad.Class.MonadParallelUnion
   )
 where
 
-import Control.DeepSeq
-import Control.Monad.Except
-import Control.Monad.Identity
+import Control.DeepSeq (NFData)
+import Control.Monad.Except (ExceptT (ExceptT), runExceptT)
+import Control.Monad.Identity (IdentityT (IdentityT, runIdentityT))
 import qualified Control.Monad.RWS.Lazy as RWSLazy
 import qualified Control.Monad.RWS.Strict as RWSStrict
-import Control.Monad.Reader
+import Control.Monad.Reader (ReaderT (ReaderT, runReaderT))
 import qualified Control.Monad.State.Lazy as StateLazy
 import qualified Control.Monad.State.Strict as StateStrict
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
-import Grisette.Core.Data.Class.Mergeable
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SimpleMergeable
+  ( UnionLike,
+    merge,
+  )
 
 -- | Parallel union monad.
 --

--- a/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
+++ b/src/Grisette/Core/Control/Monad/Class/MonadParallelUnion.hs
@@ -14,7 +14,6 @@ module Grisette.Core.Control.Monad.Class.MonadParallelUnion
 where
 
 import Control.DeepSeq
-import Control.Monad.Cont
 import Control.Monad.Except
 import Control.Monad.Identity
 import qualified Control.Monad.RWS.Lazy as RWSLazy
@@ -27,7 +26,6 @@ import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Lib.Control.Monad
 
 -- | Parallel union monad.
 --

--- a/src/Grisette/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Core/Control/Monad/Union.hs
@@ -19,7 +19,7 @@ module Grisette.Core.Control.Monad.Union
   )
 where
 
-import Grisette.Core.Data.Class.SimpleMergeable
+import Grisette.Core.Data.Class.SimpleMergeable (UnionLike)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -39,14 +39,11 @@ module Grisette.Core.Control.Monad.UnionM
 where
 
 import Control.DeepSeq
-import Control.Monad.Identity (Identity (..))
 import Control.Parallel.Strategies
 import Data.Functor.Classes
 import qualified Data.HashMap.Lazy as HML
 import Data.Hashable
-import Data.IORef
 import Data.String
-import GHC.IO hiding (evaluate)
 import GHC.TypeNats
 import Grisette.Core.Control.Monad.CBMCExcept
 import Grisette.Core.Control.Monad.Class.MonadParallelUnion
@@ -63,7 +60,6 @@ import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solvable
 import Grisette.Core.Data.Class.Solver
-import Grisette.Core.Data.Class.Substitute
 import Grisette.Core.Data.Class.ToCon
 import Grisette.Core.Data.Class.ToSym
 import Grisette.Core.Data.Union
@@ -72,12 +68,6 @@ import Grisette.IR.SymPrim.Data.SymPrim
 import Grisette.IR.SymPrim.Data.TabularFun
 import Language.Haskell.TH.Syntax
 import Language.Haskell.TH.Syntax.Compat (unTypeSplice)
-
-#if MIN_VERSION_prettyprinter(1,7,0)
-import Prettyprinter
-#else
-import Data.Text.Prettyprint.Doc
-#endif
 
 -- $setup
 -- >>> import Grisette.Core
@@ -238,11 +228,11 @@ wrapBracket :: Char -> Char -> ShowS -> ShowS
 wrapBracket l r p = showChar l . p . showChar r
 
 instance Show1 UnionM where
-  liftShowsPrec sp sl i (UAny a) =
+  liftShowsPrec sp sl _ (UAny a) =
     wrapBracket '<' '>'
       . liftShowsPrecUnion sp sl 0
       $ a
-  liftShowsPrec sp sl i (UMrg _ a) =
+  liftShowsPrec sp sl _ (UMrg _ a) =
     wrapBracket '{' '}'
       . liftShowsPrecUnion sp sl 0
       $ a

--- a/src/Grisette/Core/Control/Monad/UnionM.hs-boot
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs-boot
@@ -4,9 +4,9 @@
 
 module Grisette.Core.Control.Monad.UnionM (UnionM (..)) where
 
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Union
+import Grisette.Core.Data.Class.Mergeable (MergingStrategy)
+import Grisette.Core.Data.Class.SimpleMergeable (UnionLike)
+import Grisette.Core.Data.Union (Union)
 
 data UnionM a where
   -- | 'UnionM' with no 'Mergeable' knowledge.

--- a/src/Grisette/Core/Control/Monad/UnionM.hs-boot
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs-boot
@@ -4,8 +4,6 @@
 
 module Grisette.Core.Control.Monad.UnionM (UnionM (..)) where
 
-import Data.IORef
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Union

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -44,28 +44,93 @@ module Grisette.Core.Data.BV
   )
 where
 
-import Control.Applicative
-import Control.DeepSeq
+import Control.Applicative (Alternative ((<|>)))
+import Control.DeepSeq (NFData (rnf))
 import Control.Exception
+  ( ArithException (Overflow),
+    Exception (displayException),
+    throw,
+  )
 import Data.Bits
-import Data.CallStack
-import Data.Hashable
-import Data.Maybe
-import Data.Proxy
-import Data.Typeable
+  ( Bits
+      ( bit,
+        bitSize,
+        bitSizeMaybe,
+        clearBit,
+        complement,
+        complementBit,
+        isSigned,
+        popCount,
+        rotate,
+        rotateL,
+        rotateR,
+        setBit,
+        shift,
+        shiftL,
+        shiftR,
+        testBit,
+        unsafeShiftL,
+        unsafeShiftR,
+        xor,
+        zeroBits,
+        (.&.),
+        (.|.)
+      ),
+    FiniteBits (countLeadingZeros, countTrailingZeros, finiteBitSize),
+  )
+import Data.CallStack (HasCallStack)
+import Data.Hashable (Hashable (hashWithSalt))
+import Data.Maybe (fromMaybe, isJust)
+import Data.Proxy (Proxy (Proxy))
+import Data.Typeable (type (:~:) (Refl))
 import GHC.Enum
-import GHC.Generics
+  ( boundedEnumFrom,
+    boundedEnumFromThen,
+    predError,
+    succError,
+    toEnumError,
+  )
+import GHC.Generics (Generic)
 import GHC.Read
-import GHC.Real
+  ( Read (readListPrec, readPrec),
+    parens,
+    readListDefault,
+    readListPrecDefault,
+    readNumber,
+  )
+import GHC.Real ((%))
 import GHC.TypeNats
+  ( KnownNat,
+    Nat,
+    natVal,
+    sameNat,
+    type (+),
+    type (<=),
+  )
 import Grisette.Core.Data.Class.BitVector
+  ( BV (bvConcat, bvExt, bvSelect, bvSext, bvZext),
+    BVSignConversion (toSigned, toUnsigned),
+    SizedBV (sizedBVConcat, sizedBVExt, sizedBVSelect, sizedBVSext, sizedBVZext),
+  )
 import Grisette.Utils.Parameterized
-import Language.Haskell.TH.Syntax
-import Numeric
+  ( KnownProof (KnownProof),
+    LeqProof (LeqProof),
+    knownAdd,
+    leqAddPos,
+    unsafeKnownProof,
+    unsafeLeqProof,
+  )
+import Language.Haskell.TH.Syntax (Lift (liftTyped))
+import Numeric (showHex, showIntAtBase)
 import qualified Test.QuickCheck as QC
 import Text.ParserCombinators.ReadP (string)
 import Text.ParserCombinators.ReadPrec
-import Text.Read
+  ( ReadPrec,
+    get,
+    look,
+    pfail,
+  )
+import Text.Read (lift)
 import qualified Text.Read.Lex as L
 
 data BitwidthMismatch = BitwidthMismatch

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -78,7 +78,6 @@ import Data.Bits
       ),
     FiniteBits (countLeadingZeros, countTrailingZeros, finiteBitSize),
   )
-import Data.CallStack (HasCallStack)
 import Data.Hashable (Hashable (hashWithSalt))
 import Data.Maybe (fromMaybe, isJust)
 import Data.Proxy (Proxy (Proxy))
@@ -149,29 +148,29 @@ newtype WordN (n :: Nat) = WordN {unWordN :: Integer}
 data SomeWordN where
   SomeWordN :: (KnownNat n, 1 <= n) => WordN n -> SomeWordN
 
-unarySomeWordN :: (HasCallStack) => (forall n. (KnownNat n, 1 <= n) => WordN n -> r) -> SomeWordN -> r
+unarySomeWordN :: (forall n. (KnownNat n, 1 <= n) => WordN n -> r) -> SomeWordN -> r
 unarySomeWordN op (SomeWordN (w :: WordN w)) = op w
 {-# INLINE unarySomeWordN #-}
 
-unarySomeWordNR1 :: (HasCallStack) => (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n) -> SomeWordN -> SomeWordN
+unarySomeWordNR1 :: (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n) -> SomeWordN -> SomeWordN
 unarySomeWordNR1 op (SomeWordN (w :: WordN w)) = SomeWordN $ op w
 {-# INLINE unarySomeWordNR1 #-}
 
-binSomeWordN :: (HasCallStack) => (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> r) -> SomeWordN -> SomeWordN -> r
+binSomeWordN :: (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> r) -> SomeWordN -> SomeWordN -> r
 binSomeWordN op (SomeWordN (l :: WordN l)) (SomeWordN (r :: WordN r)) =
   case sameNat (Proxy @l) (Proxy @r) of
     Just Refl -> op l r
     Nothing -> throw BitwidthMismatch
 {-# INLINE binSomeWordN #-}
 
-binSomeWordNR1 :: (HasCallStack) => (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> WordN n) -> SomeWordN -> SomeWordN -> SomeWordN
+binSomeWordNR1 :: (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> WordN n) -> SomeWordN -> SomeWordN -> SomeWordN
 binSomeWordNR1 op (SomeWordN (l :: WordN l)) (SomeWordN (r :: WordN r)) =
   case sameNat (Proxy @l) (Proxy @r) of
     Just Refl -> SomeWordN $ op l r
     Nothing -> throw BitwidthMismatch
 {-# INLINE binSomeWordNR1 #-}
 
-binSomeWordNR2 :: (HasCallStack) => (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> (WordN n, WordN n)) -> SomeWordN -> SomeWordN -> (SomeWordN, SomeWordN)
+binSomeWordNR2 :: (forall n. (KnownNat n, 1 <= n) => WordN n -> WordN n -> (WordN n, WordN n)) -> SomeWordN -> SomeWordN -> (SomeWordN, SomeWordN)
 binSomeWordNR2 op (SomeWordN (l :: WordN l)) (SomeWordN (r :: WordN r)) =
   case sameNat (Proxy @l) (Proxy @r) of
     Just Refl ->

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -63,7 +63,7 @@ import Grisette.Utils.Parameterized
 import Language.Haskell.TH.Syntax
 import Numeric
 import qualified Test.QuickCheck as QC
-import Text.ParserCombinators.ReadP (skipSpaces, string)
+import Text.ParserCombinators.ReadP (string)
 import Text.ParserCombinators.ReadPrec
 import Text.Read
 import qualified Text.Read.Lex as L
@@ -699,7 +699,7 @@ instance BV SomeWordN where
     where
       n = fromIntegral $ natVal (Proxy @n)
       res :: forall (w :: Nat) (ix :: Nat). Proxy w -> Proxy ix -> SomeWordN
-      res p1 p2 =
+      res _ _ =
         case ( unsafeKnownProof @ix (fromIntegral ix),
                unsafeKnownProof @w (fromIntegral w),
                unsafeLeqProof @1 @w,
@@ -709,7 +709,7 @@ instance BV SomeWordN where
             SomeWordN $ sizedBVSelect (Proxy @ix) (Proxy @w) a
 
 instance BV SomeIntN where
-  bvConcat l r = toSigned $ bvConcat (toUnsigned l) (toUnsigned l)
+  bvConcat l r = toSigned $ bvConcat (toUnsigned l) (toUnsigned r)
   {-# INLINE bvConcat #-}
   bvZext l = toSigned . bvZext l . toUnsigned
   {-# INLINE bvZext #-}

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -28,9 +28,17 @@ module Grisette.Core.Data.Class.BitVector
   )
 where
 
-import Data.Proxy
-import GHC.TypeNats
+import Data.Proxy (Proxy (Proxy))
+import GHC.TypeNats (KnownNat, type (+), type (-), type (<=))
 import Grisette.Utils.Parameterized
+  ( KnownProof (KnownProof),
+    LeqProof (LeqProof),
+    addNat,
+    hasRepr,
+    natRepr,
+    subNat,
+    unsafeLeqProof,
+  )
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/Bool.hs
+++ b/src/Grisette/Core/Data/Class/Bool.hs
@@ -30,27 +30,59 @@ module Grisette.Core.Data.Class.Bool
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
   ( Identity (Identity),
     IdentityT (IdentityT),
   )
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeNats
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
-import Grisette.Core.Data.BV
+  ( Default (Default),
+    Generic (Rep, from),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    V1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 import {-# SOURCE #-} Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
+  ( SimpleMergeable,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( LinkedRep,
+    SupportedPrim,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalAndTerm,
+    pevalITETerm,
+    pevalImplyTerm,
+    pevalNotTerm,
+    pevalOrTerm,
+    pevalXorTerm,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+  ( SomeSymIntN,
+    SomeSymWordN,
+    SymBool (SymBool),
+    SymIntN (SymIntN),
+    SymInteger (SymInteger),
+    SymWordN (SymWordN),
+    binSomeSymIntNR1,
+    binSomeSymWordNR1,
+    type (-~>) (SymGeneralFun),
+    type (=~>) (SymTabularFun),
+  )
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/Bool.hs-boot
+++ b/src/Grisette/Core/Data/Class/Bool.hs-boot
@@ -1,6 +1,6 @@
 module Grisette.Core.Data.Class.Bool (LogicalOp (..), ITEOp (..)) where
 
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 class LogicalOp b where
   -- | Symbolic disjunction

--- a/src/Grisette/Core/Data/Class/Bool.hs-boot
+++ b/src/Grisette/Core/Data/Class/Bool.hs-boot
@@ -1,4 +1,4 @@
-module Grisette.Core.Data.Class.Bool (LogicalOp (..)) where
+module Grisette.Core.Data.Class.Bool (LogicalOp (..), ITEOp (..)) where
 
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
 

--- a/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -39,17 +39,25 @@ module Grisette.Core.Data.Class.CEGISSolver
   )
 where
 
-import GHC.Generics
-import Generics.Deriving
+import GHC.Generics (Generic)
+import Generics.Deriving (Default (Default))
 import Grisette.Core.Control.Exception
-import Grisette.Core.Data.Class.Evaluate
+  ( VerificationConditions (AssertionViolation, AssumptionViolation),
+  )
+import Grisette.Core.Data.Class.Evaluate (EvaluateSym)
 import Grisette.Core.Data.Class.ExtractSymbolics
-import Grisette.Core.Data.Class.Mergeable
+  ( ExtractSymbolics,
+  )
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
-import Grisette.Core.Data.Class.Solver
-import Grisette.IR.SymPrim.Data.Prim.Model
-import Grisette.IR.SymPrim.Data.SymPrim
+  ( SimpleMergeable,
+    UnionPrjOp,
+    simpleMerge,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (con))
+import Grisette.Core.Data.Class.Solver (UnionWithExcept (extractUnionExcept))
+import Grisette.IR.SymPrim.Data.Prim.Model (Model)
+import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -42,7 +42,6 @@ where
 import GHC.Generics
 import Generics.Deriving
 import Grisette.Core.Control.Exception
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Mergeable

--- a/src/Grisette/Core/Data/Class/Error.hs
+++ b/src/Grisette/Core/Data/Class/Error.hs
@@ -23,7 +23,6 @@ where
 
 import Control.Monad.Except
 import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim

--- a/src/Grisette/Core/Data/Class/Error.hs
+++ b/src/Grisette/Core/Data/Class/Error.hs
@@ -21,16 +21,17 @@ module Grisette.Core.Data.Class.Error
   )
 where
 
-import Control.Monad.Except
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SimpleMergeable
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+import Control.Monad.Except (MonadError (throwError))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+import Grisette.Core.Data.Class.SimpleMergeable (merge, mrgIf)
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 -- $setup
 -- >>> import Control.Exception
 -- >>> import Grisette.Core
 -- >>> import Grisette.IR.SymPrim
+-- >>> import Control.Monad.Except
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XFlexibleContexts
 

--- a/src/Grisette/Core/Data/Class/Evaluate.hs
+++ b/src/Grisette/Core/Data/Class/Evaluate.hs
@@ -40,7 +40,6 @@ import GHC.TypeNats
 import Generics.Deriving
 import Generics.Deriving.Instances ()
 import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.ModelOps
 import Grisette.Core.Data.Class.ToCon
 import Grisette.IR.SymPrim.Data.Prim.Model
 

--- a/src/Grisette/Core/Data/Class/Evaluate.hs
+++ b/src/Grisette/Core/Data/Class/Evaluate.hs
@@ -25,23 +25,34 @@ module Grisette.Core.Data.Class.Evaluate
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
-import Data.Maybe
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Maybe (fromJust)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeNats
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
+  ( Default (Default, unDefault),
+    Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
 import Generics.Deriving.Instances ()
-import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.ToCon
-import Grisette.IR.SymPrim.Data.Prim.Model
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
+import Grisette.IR.SymPrim.Data.Prim.Model (Model)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
+++ b/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
@@ -24,20 +24,33 @@ module Grisette.Core.Data.Class.ExtractSymbolics
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeNats
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
-import Grisette.Core.Data.BV
+  ( Default (Default, unDefault),
+    Generic (Rep, from),
+    K1 (unK1),
+    M1 (unM1),
+    U1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.Model
+  ( SymbolSet,
+  )
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/GPretty.hs
+++ b/src/Grisette/Core/Data/Class/GPretty.hs
@@ -18,26 +18,68 @@ module Grisette.Core.Data.Class.GPretty
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
-import Data.String
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.String (IsString (fromString))
 import qualified Data.Text as T
-import Data.Word
+import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Generics
-import GHC.TypeLits
-import Generics.Deriving hiding (isNullary)
-import Grisette.Core.Data.BV
+  ( C,
+    C1,
+    Constructor (conFixity, conIsRecord, conName),
+    D,
+    Fixity (Infix, Prefix),
+    Generic (Rep, from),
+    K1 (K1),
+    M1 (M1),
+    S,
+    Selector (selName),
+    U1 (U1),
+    V1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import GHC.TypeLits (KnownNat, type (<=))
+import Generics.Deriving (Default (Default, unDefault))
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 
 #if MIN_VERSION_prettyprinter(1,7,0)
 import Prettyprinter
+  ( (<+>),
+    align,
+    encloseSep,
+    flatAlt,
+    group,
+    nest,
+    vcat,
+    viaShow,
+    vsep,
+    Doc,
+    Pretty(pretty),
+  )
 #else
 import Data.Text.Prettyprint.Doc
+  ( (<+>),
+    align,
+    encloseSep,
+    flatAlt,
+    group,
+    nest,
+    vcat,
+    viaShow,
+    vsep,
+    Doc,
+    Pretty(pretty),
+  )
 #endif
 
 glist :: [Doc ann] -> Doc ann

--- a/src/Grisette/Core/Data/Class/GPretty.hs
+++ b/src/Grisette/Core/Data/Class/GPretty.hs
@@ -26,7 +26,6 @@ import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
 import Data.Functor.Sum
 import Data.Int
-import Data.Proxy
 import Data.String
 import qualified Data.Text as T
 import Data.Word
@@ -153,7 +152,7 @@ instance (GPretty' a, GPretty' b) => GPretty' (a :*: b) where
           [ gprettyPrec' t n a,
             pretty s <+> gprettyPrec' t n b
           ]
-  gprettyPrec' t@Tup n (a :*: b) =
+  gprettyPrec' t@Tup _ (a :*: b) =
     vcat
       [ gprettyPrec' t 0 a,
         "," <> flatAlt " " "" <> gprettyPrec' t 0 b
@@ -309,7 +308,7 @@ instance
   (GPretty (m (Maybe a))) =>
   GPretty (MaybeT m a)
   where
-  gprettyPrec i (MaybeT a) =
+  gprettyPrec _ (MaybeT a) =
     group $
       nest 2 $
         vsep
@@ -322,7 +321,7 @@ instance
   (GPretty (m (Either e a))) =>
   GPretty (ExceptT e m a)
   where
-  gprettyPrec i (ExceptT a) =
+  gprettyPrec _ (ExceptT a) =
     group $
       nest 2 $
         vsep
@@ -335,7 +334,7 @@ instance
   (GPretty (m (a, w))) =>
   GPretty (WriterLazy.WriterT w m a)
   where
-  gprettyPrec i (WriterLazy.WriterT a) =
+  gprettyPrec _ (WriterLazy.WriterT a) =
     group $
       nest 2 $
         vsep
@@ -347,7 +346,7 @@ instance
   (GPretty (m (a, w))) =>
   GPretty (WriterStrict.WriterT w m a)
   where
-  gprettyPrec i (WriterStrict.WriterT a) =
+  gprettyPrec _ (WriterStrict.WriterT a) =
     group $
       nest 2 $
         vsep
@@ -357,7 +356,7 @@ instance
 
 -- Identity
 instance (GPretty a) => GPretty (Identity a) where
-  gprettyPrec i (Identity a) =
+  gprettyPrec _ (Identity a) =
     group $
       nest 2 $
         vsep
@@ -367,7 +366,7 @@ instance (GPretty a) => GPretty (Identity a) where
 
 -- IdentityT
 instance (GPretty (m a)) => GPretty (IdentityT m a) where
-  gprettyPrec i (IdentityT a) =
+  gprettyPrec _ (IdentityT a) =
     group $
       nest 2 $
         vsep

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -72,7 +72,6 @@ import qualified Data.Text as T
 import Data.Typeable
 import Data.Word
 import GHC.Natural
-import qualified GHC.TypeLits
 import GHC.TypeNats
 import Generics.Deriving
 import Grisette.Core.Data.BV
@@ -467,8 +466,8 @@ CONCRETE_ORD_MERGEABLE_BV(IntN)
 instance Mergeable SomeIntN where
   rootStrategy =
     SortedStrategy @Natural
-      (\(SomeIntN (v :: IntN n)) -> natVal (Proxy @n))
-      ( \n ->
+      (\(SomeIntN (_ :: IntN n)) -> natVal (Proxy @n))
+      ( \_ ->
           SortedStrategy @Integer
             (\(SomeIntN (IntN i)) -> toInteger i)
             (const $ SimpleStrategy $ \_ l _ -> l)
@@ -477,8 +476,8 @@ instance Mergeable SomeIntN where
 instance Mergeable SomeWordN where
   rootStrategy =
     SortedStrategy @Natural
-      (\(SomeWordN (v :: WordN n)) -> natVal (Proxy @n))
-      ( \n ->
+      (\(SomeWordN (_ :: WordN n)) -> natVal (Proxy @n))
+      ( \_ ->
           SortedStrategy @Integer
             (\(SomeWordN (WordN i)) -> toInteger i)
             (const $ SimpleStrategy $ \_ l _ -> l)
@@ -513,14 +512,14 @@ deriving via (Default1 Maybe) instance Mergeable1 Maybe
 -- | Helper type for building efficient merge strategy for list-like containers.
 data StrategyList container where
   StrategyList ::
-    forall bool a container.
+    forall a container.
     container [DynamicSortedIdx] ->
     container (MergingStrategy a) ->
     StrategyList container
 
 -- | Helper function for building efficient merge strategy for list-like containers.
 buildStrategyList ::
-  forall bool a container.
+  forall a container.
   (Functor container) =>
   MergingStrategy a ->
   container a ->
@@ -994,8 +993,8 @@ MERGEABLE_FUN(-~>)
 instance Mergeable SomeSymIntN where
   rootStrategy =
     SortedStrategy @Natural
-      (\(SomeSymIntN (v :: SymIntN n)) -> natVal (Proxy @n))
-      ( \n ->
+      (\(SomeSymIntN (_ :: SymIntN n)) -> natVal (Proxy @n))
+      ( \_ ->
           SimpleStrategy
             ( \c (SomeSymIntN (l :: SymIntN l)) (SomeSymIntN (r :: SymIntN r)) ->
                 case unsafeAxiom @l @r of
@@ -1006,8 +1005,8 @@ instance Mergeable SomeSymIntN where
 instance Mergeable SomeSymWordN where
   rootStrategy =
     SortedStrategy @Natural
-      (\(SomeSymWordN (v :: SymWordN n)) -> natVal (Proxy @n))
-      ( \n ->
+      (\(SomeSymWordN (_ :: SymWordN n)) -> natVal (Proxy @n))
+      ( \_ ->
           SimpleStrategy
             ( \c (SomeSymWordN (l :: SymWordN l)) (SomeSymWordN (r :: SymWordN r)) ->
                 case unsafeAxiom @l @r of
@@ -1027,6 +1026,6 @@ instance Mergeable ArithException where
           Denormal -> 4 :: Int
           RatioZeroDenominator -> 5 :: Int
       )
-      (const $ SimpleStrategy $ \_ l r -> l)
+      (const $ SimpleStrategy $ \_ l _ -> l)
 
 deriving via (Default BitwidthMismatch) instance (Mergeable BitwidthMismatch)

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -469,7 +469,7 @@ instance Mergeable SomeIntN where
       (\(SomeIntN (_ :: IntN n)) -> natVal (Proxy @n))
       ( \_ ->
           SortedStrategy @Integer
-            (\(SomeIntN (IntN i)) -> toInteger i)
+            (\(SomeIntN (IntN i)) -> i)
             (const $ SimpleStrategy $ \_ l _ -> l)
       )
 
@@ -479,7 +479,7 @@ instance Mergeable SomeWordN where
       (\(SomeWordN (_ :: WordN n)) -> natVal (Proxy @n))
       ( \_ ->
           SortedStrategy @Integer
-            (\(SomeWordN (WordN i)) -> toInteger i)
+            (\(SomeWordN (WordN i)) -> i)
             (const $ SimpleStrategy $ \_ l _ -> l)
       )
 

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -51,35 +51,90 @@ module Grisette.Core.Data.Class.Mergeable
 where
 
 import Control.Exception
-import Control.Monad.Cont
-import Control.Monad.Except
+  ( ArithException
+      ( Denormal,
+        DivideByZero,
+        LossOfPrecision,
+        Overflow,
+        RatioZeroDenominator,
+        Underflow
+      ),
+  )
+import Control.Monad.Cont (ContT (ContT))
+import Control.Monad.Except (ExceptT (ExceptT), runExceptT)
 import Control.Monad.Identity
+  ( Identity (Identity, runIdentity),
+    IdentityT (IdentityT, runIdentityT),
+  )
 import qualified Control.Monad.RWS.Lazy as RWSLazy
 import qualified Control.Monad.RWS.Strict as RWSStrict
-import Control.Monad.Reader
+import Control.Monad.Reader (ReaderT (ReaderT, runReaderT))
 import qualified Control.Monad.State.Lazy as StateLazy
 import qualified Control.Monad.State.Strict as StateStrict
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
 import Data.Functor.Classes
-import Data.Functor.Sum
-import Data.Int
-import Data.Kind
+  ( Eq1,
+    Ord1,
+    Show1,
+    compare1,
+    eq1,
+    showsPrec1,
+  )
+import Data.Functor.Sum (Sum (InL, InR))
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Kind (Type)
 import qualified Data.Monoid as Monoid
 import qualified Data.Text as T
 import Data.Typeable
-import Data.Word
-import GHC.Natural
-import GHC.TypeNats
+  ( Proxy (Proxy),
+    Typeable,
+    eqT,
+    type (:~:) (Refl),
+  )
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.Natural (Natural)
+import GHC.TypeNats (KnownNat, natVal, type (<=))
 import Generics.Deriving
+  ( Default (Default),
+    Default1 (Default1),
+    Generic (Rep, from, to),
+    Generic1 (Rep1, from1, to1),
+    K1 (K1, unK1),
+    M1 (M1, unM1),
+    Par1 (Par1, unPar1),
+    Rec1 (Rec1, unRec1),
+    U1,
+    V1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
 import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.Bool
+  ( BitwidthMismatch,
+    IntN (IntN),
+    SomeIntN (SomeIntN),
+    SomeWordN (SomeWordN),
+    WordN (WordN),
+  )
+import Grisette.Core.Data.Class.Bool (ITEOp (ites))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( LinkedRep,
+    SupportedPrim,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
-import Grisette.Utils
-import Unsafe.Coerce
+  ( SomeSymIntN (SomeSymIntN),
+    SomeSymWordN (SomeSymWordN),
+    SymBool,
+    SymIntN,
+    SymInteger,
+    SymWordN,
+    type (-~>),
+    type (=~>),
+  )
+import Grisette.Utils.Parameterized (unsafeAxiom)
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Helper type for combining arbitrary number of indices into one.
 -- Useful when trying to write efficient merge strategy for lists/vectors.

--- a/src/Grisette/Core/Data/Class/Mergeable.hs-boot
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs-boot
@@ -2,7 +2,12 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Trustworthy #-}
 
-module Grisette.Core.Data.Class.Mergeable where
+module Grisette.Core.Data.Class.Mergeable
+  ( MergingStrategy (..),
+    Mergeable' (..),
+    Mergeable (..),
+  )
+where
 
 import Data.Typeable
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim

--- a/src/Grisette/Core/Data/Class/Mergeable.hs-boot
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs-boot
@@ -9,8 +9,8 @@ module Grisette.Core.Data.Class.Mergeable
   )
 where
 
-import Data.Typeable
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+import Data.Typeable (Typeable)
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 data MergingStrategy a where
   SimpleStrategy :: (SymBool -> a -> a -> a) -> MergingStrategy a

--- a/src/Grisette/Core/Data/Class/ModelOps.hs
+++ b/src/Grisette/Core/Data/Class/ModelOps.hs
@@ -21,9 +21,7 @@ module Grisette.Core.Data.Class.ModelOps
   )
 where
 
-import Data.Hashable
 import Data.Kind
-import Data.Typeable
 
 -- $setup
 -- >>> import Grisette.Core
@@ -88,7 +86,7 @@ class
 -- SymbolSet {a :: Bool, b :: Bool}
 class
   (SymbolSetOps symbolSet typedSymbol) =>
-  SymbolSetRep rep symbolSet (typedSymbol :: * -> *)
+  SymbolSetRep rep symbolSet (typedSymbol :: Type -> Type)
   where
   -- | Build a symbolic constant set
   buildSymbolSet :: rep -> symbolSet

--- a/src/Grisette/Core/Data/Class/ModelOps.hs
+++ b/src/Grisette/Core/Data/Class/ModelOps.hs
@@ -21,7 +21,7 @@ module Grisette.Core.Data.Class.ModelOps
   )
 where
 
-import Data.Kind
+import Data.Kind (Type)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/SOrd.hs
+++ b/src/Grisette/Core/Data/Class/SOrd.hs
@@ -26,24 +26,43 @@ module Grisette.Core.Data.Class.SOrd
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeLits
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeLits (KnownNat, type (<=))
 import Generics.Deriving
-import {-# SOURCE #-} Grisette.Core.Control.Monad.UnionM
-import Grisette.Core.Data.BV
+  ( Default (Default),
+    Generic (Rep, from),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    V1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import {-# SOURCE #-} Grisette.Core.Control.Monad.UnionM (UnionM)
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 import Grisette.Core.Data.Class.Bool
+  ( LogicalOp ((&&~), (||~)),
+    SEq ((/=~), (==~)),
+    SEq' ((==~~)),
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+  ( mrgIf,
+    mrgSingle,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (con))
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/SafeArith.hs
+++ b/src/Grisette/Core/Data/Class/SafeArith.hs
@@ -30,23 +30,39 @@ module Grisette.Core.Data.Class.SafeArith
   )
 where
 
-import Control.Exception
-import Control.Monad.Except
-import Data.Int
-import Data.Typeable
-import Data.Word
-import GHC.TypeNats
-import Grisette.Core.Control.Monad.Union
+import Control.Exception (ArithException (DivideByZero, Overflow, Underflow))
+import Control.Monad.Except (MonadError (throwError))
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, sameNat, type (<=))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.BV
+  ( BitwidthMismatch (BitwidthMismatch),
+    IntN,
+    SomeIntN (SomeIntN),
+    SomeWordN (SomeWordN),
+    WordN,
+  )
 import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.Mergeable
+  ( LogicalOp ((&&~), (||~)),
+    SEq ((==~)),
+  )
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SOrd
+  ( SOrd ((<=~), (<~), (>=~), (>~)),
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
+  ( merge,
+    mrgIf,
+    mrgSingle,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (con))
 
 -- $setup
 -- >>> import Grisette.Core
 -- >>> import Grisette.IR.SymPrim
+-- >>> import Control.Monad.Except
 
 -- | Safe division with monadic error handling in multi-path
 -- execution. These procedures throw an exception when the

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -46,26 +46,53 @@ module Grisette.Core.Data.Class.SimpleMergeable
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
 import qualified Control.Monad.RWS.Lazy as RWSLazy
 import qualified Control.Monad.RWS.Strict as RWSStrict
-import Control.Monad.Reader
+import Control.Monad.Reader (ReaderT (ReaderT))
 import qualified Control.Monad.State.Lazy as StateLazy
 import qualified Control.Monad.State.Strict as StateStrict
-import Control.Monad.Trans.Cont
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Cont (ContT (ContT))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
-import Data.Kind
+import Data.Kind (Type)
 import GHC.Generics
-import GHC.TypeNats
-import Generics.Deriving
-import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.Function
+  ( Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    V1,
+    type (:*:) ((:*:)),
+  )
+import GHC.TypeNats (KnownNat, type (<=))
+import Generics.Deriving (Default (Default))
+import Grisette.Core.Data.Class.Bool (ITEOp (ites))
+import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
 import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable (rootStrategy),
+    Mergeable',
+    Mergeable1 (liftRootStrategy),
+    Mergeable2 (liftRootStrategy2),
+    Mergeable3 (liftRootStrategy3),
+    MergingStrategy (SimpleStrategy),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( LinkedRep,
+    SupportedPrim,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+  ( SymBool,
+    SymIntN,
+    SymInteger,
+    SymWordN,
+    type (-~>),
+    type (=~>),
+  )
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -718,7 +718,7 @@ pattern IfU c t f <-
 -- <If a b c>
 -- >>> simpleMerge $ (unionIf (ssym "a") (return $ ssym "b") (return $ ssym "c") :: UnionM SymBool)
 -- (ite a b c)
-simpleMerge :: forall bool u a. (SimpleMergeable a, UnionLike u, UnionPrjOp u) => u a -> a
+simpleMerge :: forall u a. (SimpleMergeable a, UnionLike u, UnionPrjOp u) => u a -> a
 simpleMerge u = case merge u of
   SingleU x -> x
   _ -> error "Should not happen"
@@ -730,7 +730,7 @@ simpleMerge u = case merge u of
 -- >>> sumU (unionIf "cond" (return ["a"]) (return ["b","c"]) :: UnionM [SymInteger])
 -- (ite cond a (+ b c))
 onUnion ::
-  forall bool u a r.
+  forall u a r.
   (SimpleMergeable r, UnionLike u, UnionPrjOp u, Monad u) =>
   (a -> r) ->
   (u a -> r)
@@ -738,7 +738,7 @@ onUnion f = simpleMerge . fmap f
 
 -- | Lift a function to work on union values.
 onUnion2 ::
-  forall bool u a b r.
+  forall u a b r.
   (SimpleMergeable r, UnionLike u, UnionPrjOp u, Monad u) =>
   (a -> b -> r) ->
   (u a -> u b -> r)
@@ -746,7 +746,7 @@ onUnion2 f ua ub = simpleMerge $ f <$> ua <*> ub
 
 -- | Lift a function to work on union values.
 onUnion3 ::
-  forall bool u a b c r.
+  forall u a b c r.
   (SimpleMergeable r, UnionLike u, UnionPrjOp u, Monad u) =>
   (a -> b -> c -> r) ->
   (u a -> u b -> u c -> r)
@@ -754,7 +754,7 @@ onUnion3 f ua ub uc = simpleMerge $ f <$> ua <*> ub <*> uc
 
 -- | Lift a function to work on union values.
 onUnion4 ::
-  forall bool u a b c d r.
+  forall u a b c d r.
   (SimpleMergeable r, UnionLike u, UnionPrjOp u, Monad u) =>
   (a -> b -> c -> d -> r) ->
   (u a -> u b -> u c -> u d -> r)

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs-boot
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs-boot
@@ -4,7 +4,9 @@
 module Grisette.Core.Data.Class.SimpleMergeable (SimpleMergeable (..)) where
 
 import {-# SOURCE #-} Grisette.Core.Data.Class.Mergeable
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
+  ( Mergeable,
+  )
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 
 class (Mergeable a) => SimpleMergeable a where
   mrgIte :: SymBool -> a -> a -> a

--- a/src/Grisette/Core/Data/Class/Solvable.hs
+++ b/src/Grisette/Core/Data/Class/Solvable.hs
@@ -18,11 +18,11 @@ module Grisette.Core.Data.Class.Solvable
   )
 where
 
-import Control.DeepSeq
-import Data.Hashable
-import Data.String
-import Data.Typeable
-import Language.Haskell.TH.Syntax
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable)
+import Data.String (IsString)
+import Data.Typeable (Typeable)
+import Language.Haskell.TH.Syntax (Lift)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Core/Data/Class/Solver.hs
@@ -43,12 +43,7 @@ import Control.DeepSeq
 import Control.Monad.Except
 import Data.Hashable
 import Generics.Deriving
-import Grisette.Core.Control.Exception
-import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.Evaluate
-import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
 import Grisette.IR.SymPrim.Data.Prim.Model
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
 import Language.Haskell.TH.Syntax

--- a/src/Grisette/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Core/Data/Class/Solver.hs
@@ -39,16 +39,20 @@ module Grisette.Core.Data.Class.Solver
   )
 where
 
-import Control.DeepSeq
-import Control.Monad.Except
-import Data.Hashable
-import Generics.Deriving
+import Control.DeepSeq (NFData)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic)
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.IR.SymPrim.Data.Prim.Model
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
-import Language.Haskell.TH.Syntax
+  ( UnionPrjOp,
+    simpleMerge,
+  )
+import Grisette.IR.SymPrim.Data.Prim.Model (Model)
+import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim (SymBool)
+import Language.Haskell.TH.Syntax (Lift)
 
-data SolveInternal = SolveInternal deriving (Eq, Show, Ord, Generic, Hashable, Lift, NFData)
+data SolveInternal = SolveInternal
+  deriving (Eq, Show, Ord, Generic, Hashable, Lift, NFData)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/Substitute.hs
+++ b/src/Grisette/Core/Data/Class/Substitute.hs
@@ -40,9 +40,6 @@ import Generics.Deriving
 import Generics.Deriving.Instances ()
 import Grisette.Core.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/Substitute.hs
+++ b/src/Grisette/Core/Data/Class/Substitute.hs
@@ -25,21 +25,35 @@ module Grisette.Core.Data.Class.Substitute
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeNats
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
+  ( Default (Default, unDefault),
+    Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
 import Generics.Deriving.Instances ()
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( LinkedRep,
+    TypedSymbol,
+  )
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/ToCon.hs
+++ b/src/Grisette/Core/Data/Class/ToCon.hs
@@ -24,21 +24,31 @@ module Grisette.Core.Data.Class.ToCon
   )
 where
 
-import Control.Monad.Except
+import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Identity
-import Control.Monad.Trans.Maybe
+  ( Identity (Identity, runIdentity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
+import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Generics
-import GHC.TypeNats
-import Generics.Deriving
+  ( Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import GHC.TypeNats (KnownNat, type (<=))
+import Generics.Deriving (Default (Default))
 import Generics.Deriving.Instances ()
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/ToSym.hs
+++ b/src/Grisette/Core/Data/Class/ToSym.hs
@@ -25,21 +25,32 @@ module Grisette.Core.Data.Class.ToSym
 where
 
 import Control.Monad.Identity
-import Control.Monad.Reader
+  ( Identity (Identity),
+    IdentityT (IdentityT),
+  )
+import Control.Monad.Reader (ReaderT (ReaderT))
 import qualified Control.Monad.State.Lazy as StateLazy
 import qualified Control.Monad.State.Strict as StateStrict
-import Control.Monad.Trans.Except
-import Control.Monad.Trans.Maybe
+import Control.Monad.Trans.Except (ExceptT (ExceptT))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.ByteString as B
-import Data.Functor.Sum
-import Data.Int
+import Data.Functor.Sum (Sum)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Word
-import GHC.TypeNats
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
-import Grisette.Core.Data.BV
+  ( Default (Default),
+    Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1,
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
+import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
 
 -- $setup
 -- >>> import Grisette.IR.SymPrim

--- a/src/Grisette/Core/Data/FileLocation.hs
+++ b/src/Grisette/Core/Data/FileLocation.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 
+{- HLINT ignore "Unused LANGUAGE pragma" -}
+
 -- |
 -- Module      :   Grisette.Core.Data.FileLocation
 -- Copyright   :   (c) Sirui Lu 2021-2023
@@ -21,14 +23,16 @@ module Grisette.Core.Data.FileLocation
   )
 where
 
-import Control.DeepSeq
-import Data.Hashable
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable)
 import Debug.Trace.LocationTH (__LOCATION__)
-import GHC.Generics
-import Grisette.Core.Data.Class.GenSym
+import GHC.Generics (Generic)
+import Grisette.Core.Data.Class.GenSym (FreshIdent, nameWithInfo)
 import Grisette.Core.Data.Class.Solvable
-import Language.Haskell.TH.Syntax
-import Language.Haskell.TH.Syntax.Compat
+  ( Solvable (iinfosym, sinfosym),
+  )
+import Language.Haskell.TH.Syntax (Lift, unsafeTExpCoerce)
+import Language.Haskell.TH.Syntax.Compat (SpliceQ, liftSplice)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/MemoUtils.hs
+++ b/src/Grisette/Core/Data/MemoUtils.hs
@@ -22,9 +22,9 @@ module Grisette.Core.Data.MemoUtils
 where
 
 import Data.Function (fix)
-import Data.HashTable.IO as H
-import Data.Hashable
-import System.IO.Unsafe
+import qualified Data.HashTable.IO as H
+import Data.Hashable (Hashable)
+import System.IO.Unsafe (unsafePerformIO)
 
 type HashTable k v = H.BasicHashTable k v
 

--- a/src/Grisette/Core/Data/Union.hs
+++ b/src/Grisette/Core/Data/Union.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -26,22 +27,47 @@ module Grisette.Core.Data.Union
   )
 where
 
-import Control.DeepSeq
+import Control.DeepSeq (NFData (rnf), NFData1 (liftRnf), rnf1)
 import Data.Functor.Classes
-import Data.Hashable
-import GHC.Generics
+  ( Eq1 (liftEq),
+    Show1 (liftShowsPrec),
+    showsPrec1,
+    showsUnaryWith,
+  )
+import Data.Hashable (Hashable (hashWithSalt))
+import GHC.Generics (Generic, Generic1)
 import Grisette.Core.Data.Class.Bool
+  ( ITEOp (ites),
+    LogicalOp (nots, (&&~), (||~)),
+  )
 import Grisette.Core.Data.Class.GPretty
+  ( GPretty (gprettyPrec),
+    condEnclose,
+  )
 import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable (rootStrategy),
+    Mergeable1 (liftRootStrategy),
+    MergingStrategy (NoStrategy, SimpleStrategy, SortedStrategy),
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
+  ( SimpleMergeable (mrgIte),
+    SimpleMergeable1 (liftMrgIte),
+    UnionLike (mergeWithStrategy, mrgIfWithStrategy, mrgSingleWithStrategy, single, unionIf),
+    UnionPrjOp (ifView, leftMost, singleView),
+    mrgIf,
+  )
+import Grisette.Core.Data.Class.Solvable (pattern Con)
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.SymPrim
-import Language.Haskell.TH.Syntax
+  ( AllSyms (allSymsS),
+    SomeSym (SomeSym),
+    SymBool,
+  )
+import Language.Haskell.TH.Syntax (Lift)
 
 #if MIN_VERSION_prettyprinter(1,7,0)
-import Prettyprinter
+import Prettyprinter (align, group, nest, vsep)
 #else
-import Data.Text.Prettyprint.Doc
+import Data.Text.Prettyprint.Doc (align, group, nest, vsep)
 #endif
 
 -- | The default union implementation.

--- a/src/Grisette/Core/TH.hs
+++ b/src/Grisette/Core/TH.hs
@@ -17,10 +17,25 @@ module Grisette.Core.TH
   )
 where
 
-import Control.Monad
-import Grisette.Core.THCompat
+import Control.Monad (join, replicateM, when, zipWithM)
+import Grisette.Core.THCompat (augmentFinalType)
 import Language.Haskell.TH
-import Language.Haskell.TH.Syntax
+  ( Body (NormalB),
+    Clause (Clause),
+    Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
+    Dec (DataD, FunD, NewtypeD, SigD),
+    Exp (AppE, ConE, LamE, VarE),
+    Info (DataConI, TyConI),
+    Name,
+    Pat (VarP),
+    Q,
+    Type (ForallT),
+    mkName,
+    newName,
+    pprint,
+    reify,
+  )
+import Language.Haskell.TH.Syntax (Name (Name), OccName (OccName))
 
 -- | Generate constructor wrappers that wraps the result in a union-like monad with provided names.
 --

--- a/src/Grisette/Core/THCompat.hs
+++ b/src/Grisette/Core/THCompat.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE Trustworthy #-}
-{- ORMOLU_DISABLE -}
 
 -- |
 -- Module      :   Grisette.Core.THCompat
@@ -11,17 +10,38 @@
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-
 module Grisette.Core.THCompat (augmentFinalType) where
 
-import Data.Bifunctor
+import Data.Bifunctor (Bifunctor (second))
+import Grisette.Core.Control.Monad.UnionM (UnionM)
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+#if MIN_VERSION_template_haskell(2,17,0)
 import Language.Haskell.TH.Syntax
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Control.Monad.UnionM
+  ( Pred,
+    Q,
+    Specificity,
+    TyVarBndr,
+    Type
+      ( AppT,
+        ArrowT,
+        MulArrowT
+      ),
+  )
+#else
+import Language.Haskell.TH.Syntax
+  ( Pred,
+    Q,
+    TyVarBndr,
+    Type
+      ( AppT,
+        ArrowT
+      ),
+  )
+#endif
 
 #if MIN_VERSION_template_haskell(2,17,0)
 augmentFinalType :: Type -> Q (([TyVarBndr Specificity], [Pred]), Type)
-#elif MIN_VERSION_template_haskell(2,16,0)
+#else
 augmentFinalType :: Type -> Q (([TyVarBndr], [Pred]), Type)
 #endif
 augmentFinalType (AppT a@(AppT ArrowT _) t) = do

--- a/src/Grisette/Core/THCompat.hs
+++ b/src/Grisette/Core/THCompat.hs
@@ -16,11 +16,8 @@ module Grisette.Core.THCompat (augmentFinalType) where
 
 import Data.Bifunctor
 import Language.Haskell.TH.Syntax
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Control.Monad.UnionM
-import Grisette.IR.SymPrim.Data.SymPrim
 
 #if MIN_VERSION_template_haskell(2,17,0)
 augmentFinalType :: Type -> Q (([TyVarBndr Specificity], [Pred]), Type)

--- a/src/Grisette/Experimental.hs
+++ b/src/Grisette/Experimental.hs
@@ -1,3 +1,6 @@
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 module Grisette.Experimental
   ( -- * Experimental features
 
@@ -23,3 +26,14 @@ module Grisette.Experimental
 where
 
 import Grisette.Experimental.GenSymConstrained
+  ( GenSymConstrained (..),
+    GenSymSimpleConstrained (..),
+    SOrdBound (..),
+    SOrdLowerBound (..),
+    SOrdUpperBound (..),
+    derivedFreshConstrainedNoSpec,
+    derivedSimpleFreshConstrainedNoSpec,
+    derivedSimpleFreshConstrainedSameShape,
+    genSymConstrained,
+    genSymSimpleConstrained,
+  )

--- a/src/Grisette/Experimental/GenSymConstrained.hs
+++ b/src/Grisette/Experimental/GenSymConstrained.hs
@@ -30,13 +30,9 @@ where
 
 import Control.Monad.Except
 import Control.Monad.Trans.Maybe
-import Data.Int
-import Data.Word
 import Debug.Trace
 import GHC.Generics
-import GHC.TypeLits
 import Grisette.Core.Control.Monad.UnionM
-import Grisette.Core.Data.BV
 import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.GenSym
 import Grisette.Core.Data.Class.Mergeable
@@ -160,7 +156,7 @@ instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSymSimple spec a) => GenS
     mrgSingle s
 
 instance GenSymConstrained (SOrdBound Integer ()) Integer where
-  freshConstrained e (SOrdBound l r _) = chooseFresh [l .. r - 1]
+  freshConstrained _ (SOrdBound l r _) = chooseFresh [l .. r - 1]
 
 -- Either
 instance
@@ -740,7 +736,7 @@ instance
   GenSymConstrainedNoSpec (a :+: b)
   where
   freshConstrainedNoSpec ::
-    forall m u c e.
+    forall m c e.
     ( MonadFresh m,
       MonadError e m,
       UnionLike m
@@ -758,7 +754,7 @@ instance
   GenSymConstrainedNoSpec (a :*: b)
   where
   freshConstrainedNoSpec ::
-    forall m u c e.
+    forall m c e.
     ( MonadFresh m,
       MonadError e m,
       UnionLike m
@@ -782,7 +778,7 @@ instance
 --
 -- __Note:__ __Never__ use on recursive types.
 derivedFreshConstrainedNoSpec ::
-  forall bool a m u e.
+  forall a m e.
   ( Generic a,
     GenSymConstrainedNoSpec (Rep a),
     Mergeable a,

--- a/src/Grisette/Experimental/GenSymConstrained.hs
+++ b/src/Grisette/Experimental/GenSymConstrained.hs
@@ -28,16 +28,40 @@ module Grisette.Experimental.GenSymConstrained
   )
 where
 
-import Control.Monad.Except
-import Control.Monad.Trans.Maybe
-import Debug.Trace
+import Control.Monad.Except (ExceptT (ExceptT), MonadError (throwError))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import GHC.Generics
+  ( Generic (Rep, from, to),
+    K1 (K1),
+    M1 (M1),
+    U1 (U1),
+    type (:*:) ((:*:)),
+    type (:+:) (L1, R1),
+  )
 import Grisette.Core.Control.Monad.UnionM
-import Grisette.Core.Data.Class.Bool
+  ( UnionM,
+    liftToMonadUnion,
+  )
+import Grisette.Core.Data.Class.Bool (LogicalOp ((||~)))
 import Grisette.Core.Data.Class.GenSym
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SOrd
+  ( FreshIdent,
+    GenSym (fresh),
+    GenSymSimple (simpleFresh),
+    ListSpec (ListSpec),
+    MonadFresh,
+    SimpleListSpec (SimpleListSpec),
+    chooseFresh,
+    chooseUnionFresh,
+    runFreshT,
+  )
+import Grisette.Core.Data.Class.Mergeable (Mergeable, Mergeable1)
+import Grisette.Core.Data.Class.SOrd (SOrd ((<~), (>=~)))
 import Grisette.Core.Data.Class.SimpleMergeable
+  ( UnionLike,
+    merge,
+    mrgIf,
+    mrgSingle,
+  )
 
 -- $setup
 -- >>> import Grisette.Core
@@ -672,7 +696,7 @@ instance
   ) =>
   GenSymConstrained spec (ExceptT a m b)
   where
-  freshConstrained e v = trace "x" $ do
+  freshConstrained e v = do
     x <- freshConstrained e v
     mrgSingle $ merge . fmap ExceptT $ x
 

--- a/src/Grisette/IR/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE ExplicitNamespaces #-}
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 -- |
 -- Module      :   Grisette.IR.SymPrim
@@ -22,8 +24,8 @@ module Grisette.IR.SymPrim
 
     -- ** Symbolic types
     SupportedPrim,
-    SymRep (..),
-    ConRep (..),
+    SymRep (SymType),
+    ConRep (ConType),
     LinkedRep,
     SymBool (..),
     SymInteger (..),
@@ -48,7 +50,38 @@ module Grisette.IR.SymPrim
 where
 
 import Grisette.Core.Data.BV
+  ( IntN,
+    SomeIntN (..),
+    SomeWordN (..),
+    WordN,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( ConRep (..),
+    LinkedRep,
+    SupportedPrim,
+    SymRep (..),
+    TypedSymbol (..),
+    type (-->),
+  )
 import Grisette.IR.SymPrim.Data.Prim.Model
+  ( Model (..),
+    ModelValuePair (..),
+    SymbolSet (..),
+  )
 import Grisette.IR.SymPrim.Data.SymPrim
-import Grisette.IR.SymPrim.Data.TabularFun
+  ( AllSyms (..),
+    ModelSymPair (..),
+    SomeSymIntN (..),
+    SomeSymWordN (..),
+    SymBool (..),
+    SymIntN (..),
+    SymInteger (..),
+    SymWordN (..),
+    allSymsSize,
+    symSize,
+    symsSize,
+    (-->),
+    type (-~>) (..),
+    type (=~>) (..),
+  )
+import Grisette.IR.SymPrim.Data.TabularFun (type (=->) (..))

--- a/src/Grisette/IR/SymPrim/Data/IntBitwidth.hs
+++ b/src/Grisette/IR/SymPrim/Data/IntBitwidth.hs
@@ -9,7 +9,7 @@
 module Grisette.IR.SymPrim.Data.IntBitwidth (intBitwidthQ) where
 
 import Data.Bits (FiniteBits (finiteBitSize))
-import Language.Haskell.TH
+import Language.Haskell.TH (TyLit (NumTyLit), Type (LitT), TypeQ)
 
 intBitwidthQ :: TypeQ
 intBitwidthQ = return $ LitT (NumTyLit $ toInteger $ finiteBitSize (undefined :: Int))

--- a/src/Grisette/IR/SymPrim/Data/IntBitwidth.hs
+++ b/src/Grisette/IR/SymPrim/Data/IntBitwidth.hs
@@ -6,7 +6,7 @@
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-module Grisette.IR.SymPrim.Data.IntBitwidth where
+module Grisette.IR.SymPrim.Data.IntBitwidth (intBitwidthQ) where
 
 import Data.Bits (FiniteBits (finiteBitSize))
 import Language.Haskell.TH

--- a/src/Grisette/IR/SymPrim/Data/Prim/Helpers.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Helpers.hs
@@ -24,10 +24,14 @@ module Grisette.IR.SymPrim.Data.Prim.Helpers
   )
 where
 
-import Data.Typeable
+import Data.Typeable (Typeable, cast)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( Term (BinaryTerm, TernaryTerm, UnaryTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
-import Unsafe.Coerce
+  ( castTerm,
+  )
+import Unsafe.Coerce (unsafeCoerce)
 
 unsafeUnaryTermView :: forall a b tag. (Typeable tag) => Term a -> Maybe (tag, Term b)
 unsafeUnaryTermView (UnaryTerm _ (tag :: tagt) t1) =

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Caches.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Caches.hs
@@ -16,13 +16,20 @@
 module Grisette.IR.SymPrim.Data.Prim.InternedTerm.Caches (typeMemoizedCache) where
 
 import Control.Concurrent
-import Data.Data
+  ( forkIO,
+    newEmptyMVar,
+    putMVar,
+    readMVar,
+    takeMVar,
+    tryPutMVar,
+  )
+import Data.Data (Proxy (Proxy), TypeRep, Typeable, typeRep)
 import qualified Data.HashMap.Strict as M
-import Data.IORef
-import Data.Interned
+import Data.IORef (IORef, atomicModifyIORef', newIORef)
+import Data.Interned (Cache, Interned, mkCache)
 import GHC.Base (Any)
-import GHC.IO
-import Unsafe.Coerce
+import GHC.IO (unsafeDupablePerformIO, unsafePerformIO)
+import Unsafe.Coerce (unsafeCoerce)
 
 mkOnceIO :: IO a -> IO (IO a)
 mkOnceIO io = do

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
@@ -65,21 +65,79 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
   )
 where
 
-import Control.DeepSeq
-import Data.Array
-import Data.Bits
+import Control.DeepSeq (NFData)
+import Data.Array ((!))
+import Data.Bits (Bits)
 import qualified Data.HashMap.Strict as M
-import Data.Hashable
+import Data.Hashable (Hashable (hash))
 import Data.IORef (atomicModifyIORef')
 import Data.Interned
+  ( Interned (Uninterned, cache, cacheWidth, describe, identify),
+  )
 import Data.Interned.Internal
+  ( Cache (getCache),
+    CacheState (CacheState),
+  )
 import GHC.IO (unsafeDupablePerformIO)
-import GHC.TypeNats
+import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
+  ( BVSignConversion,
+    SizedBV,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import {-# SOURCE #-} Grisette.IR.SymPrim.Data.TabularFun
-import Language.Haskell.TH.Syntax
-import Type.Reflection
+  ( BinaryOp,
+    SupportedPrim,
+    Term,
+    TernaryOp,
+    TypedSymbol (IndexedSymbol, SimpleSymbol, WithInfo),
+    UTerm
+      ( UAbsNumTerm,
+        UAddNumTerm,
+        UAndBitsTerm,
+        UAndTerm,
+        UBVConcatTerm,
+        UBVExtendTerm,
+        UBVSelectTerm,
+        UBVToSignedTerm,
+        UBVToUnsignedTerm,
+        UBinaryTerm,
+        UComplementBitsTerm,
+        UConTerm,
+        UDivBoundedIntegralTerm,
+        UDivIntegralTerm,
+        UEqvTerm,
+        UGeneralFunApplyTerm,
+        UITETerm,
+        ULENumTerm,
+        ULTNumTerm,
+        UModBoundedIntegralTerm,
+        UModIntegralTerm,
+        UNotTerm,
+        UOrBitsTerm,
+        UOrTerm,
+        UQuotBoundedIntegralTerm,
+        UQuotIntegralTerm,
+        URemBoundedIntegralTerm,
+        URemIntegralTerm,
+        URotateBitsTerm,
+        UShiftBitsTerm,
+        USignumNumTerm,
+        USymTerm,
+        UTabularFunApplyTerm,
+        UTernaryTerm,
+        UTimesNumTerm,
+        UUMinusNumTerm,
+        UUnaryTerm,
+        UXorBitsTerm
+      ),
+    UnaryOp,
+    type (-->),
+  )
+import Grisette.IR.SymPrim.Data.TabularFun
+  ( type (=->),
+  )
+import Language.Haskell.TH.Syntax (Lift)
+import Type.Reflection (Typeable, typeRep)
 
 internTerm :: forall t. (SupportedPrim t) => Uninterned (Term t) -> Term t
 internTerm !bt = unsafeDupablePerformIO $ atomicModifyIORef' slot go

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
@@ -54,15 +54,28 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
   )
 where
 
-import Control.DeepSeq
-import Data.Bits
-import Data.Hashable
-import Data.Typeable
-import GHC.TypeNats
+import Control.DeepSeq (NFData)
+import Data.Bits (Bits)
+import Data.Hashable (Hashable)
+import Data.Typeable (Typeable)
+import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
+  ( BVSignConversion,
+    SizedBV,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( BinaryOp,
+    SupportedPrim,
+    Term,
+    TernaryOp,
+    TypedSymbol,
+    UnaryOp,
+    type (-->),
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.TabularFun
-import Language.Haskell.TH.Syntax
+  ( type (=->),
+  )
+import Language.Haskell.TH.Syntax (Lift)
 
 constructUnary ::
   forall tag arg t.

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/SomeTerm.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/SomeTerm.hs
@@ -13,10 +13,15 @@
 -- Portability :   GHC only
 module Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm (SomeTerm (..)) where
 
-import Data.Hashable
-import Data.Typeable
+import Data.Hashable (Hashable (hashWithSalt))
+import Data.Typeable (Proxy (Proxy), typeRep)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
+  ( identityWithTypeRep,
+  )
 
 data SomeTerm where
   SomeTerm :: forall a. (SupportedPrim a) => Term a -> SomeTerm

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
@@ -170,7 +170,7 @@ import Data.Text.Prettyprint.Doc
 -- term.
 class (Lift t, Typeable t, Hashable t, Eq t, Show t, NFData t) => SupportedPrim t where
   type PrimConstraint t :: Constraint
-  type PrimConstraint t = ()
+  type PrimConstraint _ = ()
   default withPrim :: (PrimConstraint t) => proxy t -> ((PrimConstraint t) => a) -> a
   withPrim :: proxy t -> ((PrimConstraint t) => a) -> a
   withPrim _ i = i

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -50,7 +50,7 @@ import Type.Reflection (TypeRep, Typeable)
 
 class (Lift t, Typeable t, Hashable t, Eq t, Show t, NFData t) => SupportedPrim t where
   type PrimConstraint t :: Constraint
-  type PrimConstraint t = ()
+  type PrimConstraint _ = ()
   default withPrim :: (PrimConstraint t) => proxy t -> ((PrimConstraint t) => a) -> a
   withPrim :: proxy t -> ((PrimConstraint t) => a) -> a
   withPrim _ i = i

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -28,17 +28,25 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   )
 where
 
-import Control.DeepSeq
-import Data.Bits
-import Data.Hashable
-import Data.Interned
-import Data.Kind
-import GHC.TypeNats
+import Control.DeepSeq (NFData)
+import Data.Bits (Bits)
+import Data.Hashable (Hashable)
+import Data.Interned (Cache, Id)
+import Data.Kind (Constraint)
+import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
+  ( BVSignConversion,
+    SizedBV,
+  )
 import Grisette.IR.SymPrim.Data.Prim.ModelValue
+  ( ModelValue,
+    toModelValue,
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.TabularFun
-import Language.Haskell.TH.Syntax
-import Type.Reflection
+  ( type (=->),
+  )
+import Language.Haskell.TH.Syntax (Lift)
+import Type.Reflection (TypeRep, Typeable)
 
 class (Lift t, Typeable t, Hashable t, Eq t, Show t, NFData t) => SupportedPrim t where
   type PrimConstraint t :: Constraint

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -35,7 +35,6 @@ import Data.Interned
 import Data.Kind
 import GHC.TypeNats
 import Grisette.Core.Data.Class.BitVector
-import Grisette.Core.Data.Class.Function
 import Grisette.IR.SymPrim.Data.Prim.ModelValue
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.TabularFun
 import Language.Haskell.TH.Syntax

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs-boot
@@ -1,7 +1,20 @@
 {-# LANGUAGE RankNTypes #-}
 
-module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution (substTerm) where
+module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
+  ( substTerm,
+  )
+where
 
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term,
+    TypedSymbol,
+  )
 
-substTerm :: forall a b. (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term a -> Term b -> Term b
+substTerm ::
+  forall a b.
+  (SupportedPrim a, SupportedPrim b) =>
+  TypedSymbol a ->
+  Term a ->
+  Term b ->
+  Term b

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs
@@ -27,13 +27,74 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
 where
 
 import Control.Monad.State
-import Data.HashMap.Strict as M
-import Data.HashSet as S
-import Data.Interned
+  ( MonadState (get, put),
+    State,
+    evalState,
+    execState,
+    gets,
+    modify',
+  )
+import qualified Data.HashMap.Strict as M
+import qualified Data.HashSet as S
+import Data.Interned (Id)
 import Data.Typeable
+  ( Proxy (Proxy),
+    TypeRep,
+    Typeable,
+    cast,
+    typeRep,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm
+  ( SomeTerm (SomeTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.TabularFun ()
+  ( BinaryOp (pformatBinary),
+    SomeTypedSymbol (SomeTypedSymbol),
+    SupportedPrim (pformatCon, pformatSym),
+    Term
+      ( AbsNumTerm,
+        AddNumTerm,
+        AndBitsTerm,
+        AndTerm,
+        BVConcatTerm,
+        BVExtendTerm,
+        BVSelectTerm,
+        BVToSignedTerm,
+        BVToUnsignedTerm,
+        BinaryTerm,
+        ComplementBitsTerm,
+        ConTerm,
+        DivBoundedIntegralTerm,
+        DivIntegralTerm,
+        EqvTerm,
+        GeneralFunApplyTerm,
+        ITETerm,
+        LENumTerm,
+        LTNumTerm,
+        ModBoundedIntegralTerm,
+        ModIntegralTerm,
+        NotTerm,
+        OrBitsTerm,
+        OrTerm,
+        QuotBoundedIntegralTerm,
+        QuotIntegralTerm,
+        RemBoundedIntegralTerm,
+        RemIntegralTerm,
+        RotateBitsTerm,
+        ShiftBitsTerm,
+        SignumNumTerm,
+        SymTerm,
+        TabularFunApplyTerm,
+        TernaryTerm,
+        TimesNumTerm,
+        UMinusNumTerm,
+        UnaryTerm,
+        XorBitsTerm
+      ),
+    TernaryOp (pformatTernary),
+    TypedSymbol,
+    UnaryOp (pformatUnary),
+  )
 import qualified Type.Reflection as R
 
 identity :: Term t -> Id

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs-boot
@@ -12,10 +12,14 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
   )
 where
 
-import Data.HashSet as S
-import Data.Interned
-import Data.Typeable
+import qualified Data.HashSet as S
+import Data.Interned (Id)
+import Data.Typeable (TypeRep, Typeable)
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SomeTypedSymbol,
+    SupportedPrim,
+    Term,
+  )
 
 identity :: Term t -> Id
 identityWithTypeRep :: forall t. Term t -> (TypeRep, Id)

--- a/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
@@ -30,7 +30,7 @@ where
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
 import Data.Hashable
-import Data.List
+import Data.List (sort, sortOn)
 import Data.Proxy
 import GHC.Generics
 import Grisette.Core.Data.Class.ExtractSymbolics

--- a/src/Grisette/IR/SymPrim/Data/Prim/Model.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Model.hs-boot
@@ -5,6 +5,8 @@ where
 
 import qualified Data.HashSet as S
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SomeTypedSymbol,
+  )
 
 newtype SymbolSet = SymbolSet {unSymbolSet :: S.HashSet SomeTypedSymbol}
 

--- a/src/Grisette/IR/SymPrim/Data/Prim/Model.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Model.hs-boot
@@ -1,4 +1,7 @@
-module Grisette.IR.SymPrim.Data.Prim.Model where
+module Grisette.IR.SymPrim.Data.Prim.Model
+  ( SymbolSet (..),
+  )
+where
 
 import qualified Data.HashSet as S
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term

--- a/src/Grisette/IR/SymPrim/Data/Prim/ModelValue.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/ModelValue.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -18,8 +19,14 @@ module Grisette.IR.SymPrim.Data.Prim.ModelValue
   )
 where
 
-import Data.Hashable
+import Data.Hashable (Hashable (hashWithSalt))
 import Type.Reflection
+  ( TypeRep,
+    Typeable,
+    eqTypeRep,
+    typeRep,
+    type (:~~:) (HRefl),
+  )
 
 data ModelValue where
   ModelValue :: forall v. (Show v, Eq v, Hashable v) => TypeRep v -> v -> ModelValue

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/BV.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/BV.hs
@@ -29,13 +29,31 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
   )
 where
 
-import Data.Typeable
-import GHC.TypeNats
+import Data.Typeable (Typeable)
+import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
+  ( BVSignConversion (toSigned, toUnsigned),
+    SizedBV (sizedBVConcat, sizedBVSelect, sizedBVSext, sizedBVZext),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( bvToSignedTerm,
+    bvToUnsignedTerm,
+    bvconcatTerm,
+    bvextendTerm,
+    bvselectTerm,
+    conTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (BVToSignedTerm, BVToUnsignedTerm, ConTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
+  ( castTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
+  ( binaryUnfoldOnce,
+    unaryUnfoldOnce,
+  )
 
 -- ToSigned
 pevalBVToSignedTerm ::

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Bits.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Bits.hs
@@ -26,10 +26,35 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
 where
 
 import Data.Bits
-import Data.Typeable
+  ( Bits
+      ( bitSizeMaybe,
+        complement,
+        rotate,
+        shift,
+        xor,
+        zeroBits,
+        (.&.),
+        (.|.)
+      ),
+  )
+import Data.Typeable (Typeable, cast)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( andBitsTerm,
+    complementBitsTerm,
+    conTerm,
+    orBitsTerm,
+    rotateBitsTerm,
+    shiftBitsTerm,
+    xorBitsTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (ComplementBitsTerm, ConTerm, RotateBitsTerm, ShiftBitsTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
+  ( binaryUnfoldOnce,
+    unaryUnfoldOnce,
+  )
 
 bitsConTermView :: (Bits b, Typeable b) => Term a -> Maybe b
 bitsConTermView (ConTerm _ b) = cast b

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Bool.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Bool.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -35,14 +36,34 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
   )
 where
 
-import Control.Monad
-import Data.Maybe
-import Data.Typeable
+import Control.Monad (msum)
+import Data.Maybe (fromMaybe)
+import Data.Typeable (cast, eqT, type (:~:) (Refl))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( andTerm,
+    conTerm,
+    eqvTerm,
+    iteTerm,
+    notTerm,
+    orTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term
+      ( AddNumTerm,
+        AndTerm,
+        ConTerm,
+        EqvTerm,
+        ITETerm,
+        NotTerm,
+        OrTerm
+      ),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
-import Grisette.IR.SymPrim.Data.Prim.Utils
-import Unsafe.Coerce
+  ( castTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.Utils (pattern Dyn)
+import Unsafe.Coerce (unsafeCoerce)
 
 trueTerm :: Term Bool
 trueTerm = conTerm True

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/GeneralFun.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/GeneralFun.hs
@@ -13,7 +13,6 @@
 -- Portability :   GHC only
 module Grisette.IR.SymPrim.Data.Prim.PartialEval.GeneralFun (pevalGeneralFunApplyTerm) where
 
-import Grisette.Core.Data.Class.Function
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/GeneralFun.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/GeneralFun.hs
@@ -11,13 +11,26 @@
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-module Grisette.IR.SymPrim.Data.Prim.PartialEval.GeneralFun (pevalGeneralFunApplyTerm) where
+module Grisette.IR.SymPrim.Data.Prim.PartialEval.GeneralFun
+  ( pevalGeneralFunApplyTerm,
+  )
+where
 
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( generalFunApplyTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (ConTerm, ITETerm),
+    type (-->) (GeneralFun),
+  )
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution
+  ( substTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool (pevalITETerm)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
+  ( totalize2,
+  )
 
 pevalGeneralFunApplyTerm :: (SupportedPrim a, SupportedPrim b) => Term (a --> b) -> Term a -> Term b
 pevalGeneralFunApplyTerm = totalize2 doPevalGeneralFunApplyTerm generalFunApplyTerm

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Integral.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Integral.hs
@@ -21,8 +21,21 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Integral
 where
 
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( conTerm,
+    divBoundedIntegralTerm,
+    divIntegralTerm,
+    modIntegralTerm,
+    quotBoundedIntegralTerm,
+    quotIntegralTerm,
+    remIntegralTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (ConTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
+  ( binaryUnfoldOnce,
+  )
 
 -- div
 pevalDivIntegralTerm :: (SupportedPrim a, Integral a) => Term a -> Term a -> Term a

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Integral.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Integral.hs
@@ -20,12 +20,9 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Integral
   )
 where
 
-import Grisette.Core.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
-import Grisette.IR.SymPrim.Data.Prim.Utils
 
 -- div
 pevalDivIntegralTerm :: (SupportedPrim a, Integral a) => Term a -> Term a -> Term a

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Num.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Num.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -31,12 +32,33 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
   )
 where
 
-import Data.Typeable
+import Data.Typeable (Typeable, cast, eqT, type (:~:) (Refl))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( absNumTerm,
+    addNumTerm,
+    conTerm,
+    leNumTerm,
+    ltNumTerm,
+    signumNumTerm,
+    timesNumTerm,
+    uminusNumTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term
+      ( AbsNumTerm,
+        AddNumTerm,
+        ConTerm,
+        TimesNumTerm,
+        UMinusNumTerm
+      ),
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
-import Grisette.IR.SymPrim.Data.Prim.Utils
-import Unsafe.Coerce
+  ( binaryUnfoldOnce,
+    unaryUnfoldOnce,
+  )
+import Grisette.IR.SymPrim.Data.Prim.Utils (pattern Dyn)
+import Unsafe.Coerce (unsafeCoerce)
 
 numConTermView :: (Num b, Typeable b) => Term a -> Maybe b
 numConTermView (ConTerm _ b) = cast b

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/PartialEval.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/PartialEval.hs
@@ -31,8 +31,8 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
   )
 where
 
-import Control.Monad.Except
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+import Control.Monad.Except (MonadError (catchError))
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 
 type PartialFun a b = a -> Maybe b
 

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/TabularFun.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/TabularFun.hs
@@ -16,12 +16,25 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
   )
 where
 
-import Grisette.Core.Data.Class.Function
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( conTerm,
+    tabularFunApplyTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (ConTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalEqvTerm,
+    pevalITETerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
+  ( totalize2,
+  )
 import Grisette.IR.SymPrim.Data.TabularFun
+  ( type (=->) (TabularFun),
+  )
 
 pevalTabularFunApplyTerm :: (SupportedPrim a, SupportedPrim b) => Term (a =-> b) -> Term a -> Term b
 pevalTabularFunApplyTerm = totalize2 doPevalTabularFunApplyTerm tabularFunApplyTerm

--- a/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Unfold.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/PartialEval/Unfold.hs
@@ -16,11 +16,23 @@ module Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
   )
 where
 
-import Control.Monad.Except
-import Data.Typeable
+import Control.Monad.Except (MonadError (catchError))
+import Data.Typeable (Typeable)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term (ITETerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalITETerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
+  ( PartialRuleBinary,
+    PartialRuleUnary,
+    TotalRuleBinary,
+    TotalRuleUnary,
+    totalize,
+    totalize2,
+  )
 
 unaryPartialUnfoldOnce ::
   forall a b.

--- a/src/Grisette/IR/SymPrim/Data/Prim/Utils.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
@@ -26,6 +27,12 @@ where
 
 import Data.Typeable (cast)
 import Type.Reflection
+  ( TypeRep,
+    Typeable,
+    eqTypeRep,
+    typeRep,
+    type (:~~:) (HRefl),
+  )
 
 pattern Dyn :: (Typeable a, Typeable b) => a -> b
 pattern Dyn x <- (cast -> Just x)

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -79,13 +79,10 @@ import Grisette.Core.Control.Exception
 import Grisette.Core.Data.BV
 import Grisette.Core.Data.Class.BitVector
 import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Function
 import Grisette.Core.Data.Class.GPretty
-import Grisette.Core.Data.Class.GenSym
-import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.ModelOps
 import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SafeArith
@@ -186,7 +183,7 @@ instance SafeLinearArith ArithException SymInteger where
   safeNeg v = mrgReturn $ -v
   safeNeg' _ v = mrgReturn $ -v
   safeMinus ls rs = mrgReturn $ ls - rs
-  safeMinus' e ls rs = mrgReturn $ ls - rs
+  safeMinus' _ ls rs = mrgReturn $ ls - rs
 
 instance SymIntegerOp SymInteger
 
@@ -320,11 +317,11 @@ data SomeSymIntN where
   SomeSymIntN :: (KnownNat n, 1 <= n) => SymIntN n -> SomeSymIntN
 
 unarySomeSymIntN :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> r) -> String -> SomeSymIntN -> r
-unarySomeSymIntN op str (SomeSymIntN (w :: SymIntN w)) = op w
+unarySomeSymIntN op _ (SomeSymIntN (w :: SymIntN w)) = op w
 {-# INLINE unarySomeSymIntN #-}
 
 unarySomeSymIntNR1 :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n) -> String -> SomeSymIntN -> SomeSymIntN
-unarySomeSymIntNR1 op str (SomeSymIntN (w :: SymIntN w)) = SomeSymIntN $ op w
+unarySomeSymIntNR1 op _ (SomeSymIntN (w :: SymIntN w)) = SomeSymIntN $ op w
 {-# INLINE unarySomeSymIntNR1 #-}
 
 binSomeSymIntN :: (forall n. (KnownNat n, 1 <= n) => SymIntN n -> SymIntN n -> r) -> String -> SomeSymIntN -> SomeSymIntN -> r
@@ -432,11 +429,11 @@ data SomeSymWordN where
   SomeSymWordN :: (KnownNat n, 1 <= n) => SymWordN n -> SomeSymWordN
 
 unarySomeSymWordN :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> r) -> String -> SomeSymWordN -> r
-unarySomeSymWordN op str (SomeSymWordN (w :: SymWordN w)) = op w
+unarySomeSymWordN op _ (SomeSymWordN (w :: SymWordN w)) = op w
 {-# INLINE unarySomeSymWordN #-}
 
 unarySomeSymWordNR1 :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n) -> String -> SomeSymWordN -> SomeSymWordN
-unarySomeSymWordNR1 op str (SomeSymWordN (w :: SymWordN w)) = SomeSymWordN $ op w
+unarySomeSymWordNR1 op _ (SomeSymWordN (w :: SymWordN w)) = SomeSymWordN $ op w
 {-# INLINE unarySomeSymWordNR1 #-}
 
 binSomeSymWordN :: (forall n. (KnownNat n, 1 <= n) => SymWordN n -> SymWordN n -> r) -> String -> SomeSymWordN -> SomeSymWordN -> r
@@ -1356,7 +1353,7 @@ bvSelect ix w (somety (a :: origty n)) \
     where \
       n = fromIntegral $ natVal (Proxy @n); \
       res :: forall (w :: Nat) (ix :: Nat). Proxy w -> Proxy ix -> somety; \
-      res p1 p2 = \
+      res _ _ = \
         case ( unsafeKnownProof @ix (fromIntegral ix), \
                unsafeKnownProof @w (fromIntegral w), \
                unsafeLeqProof @1 @w, \
@@ -1447,10 +1444,6 @@ data SomeSym where
 
 someUnderlyingTerm :: SomeSym -> SomeTerm
 someUnderlyingTerm (SomeSym s) = SomeTerm $ underlyingTerm s
-
-someSymSize :: [SomeSym] -> Int
-someSymSize = someTermsSize . fmap someUnderlyingTerm
-{-# INLINE someSymSize #-}
 
 someSymsSize :: [SomeSym] -> Int
 someSymsSize = someTermsSize . fmap someUnderlyingTerm

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
@@ -31,17 +31,24 @@ module Grisette.IR.SymPrim.Data.SymPrim
   )
 where
 
-import Control.DeepSeq
-import Data.Hashable
-import GHC.TypeNats
-import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.Evaluate
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable)
+import GHC.TypeNats (KnownNat, Nat, type (<=))
+import Grisette.Core.Data.BV (IntN, WordN)
+import Grisette.Core.Data.Class.Evaluate (EvaluateSym)
 import Grisette.Core.Data.Class.ExtractSymbolics
-import Grisette.Core.Data.Class.GPretty
-import Grisette.Core.Data.Class.Solvable
+  ( ExtractSymbolics,
+  )
+import Grisette.Core.Data.Class.GPretty (GPretty)
+import Grisette.Core.Data.Class.Solvable (Solvable)
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.TabularFun
-import Language.Haskell.TH.Syntax
+  ( LinkedRep,
+    SupportedPrim,
+    Term,
+    type (-->),
+  )
+import Grisette.IR.SymPrim.Data.TabularFun (type (=->))
+import Language.Haskell.TH.Syntax (Lift)
 
 newtype SymBool = SymBool {underlyingBoolTerm :: Term Bool}
 

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs-boot
@@ -33,7 +33,6 @@ where
 
 import Control.DeepSeq
 import Data.Hashable
-import GHC.Generics
 import GHC.TypeNats
 import Grisette.Core.Data.BV
 import Grisette.Core.Data.Class.Evaluate

--- a/src/Grisette/IR/SymPrim/Data/TabularFun.hs
+++ b/src/Grisette/IR/SymPrim/Data/TabularFun.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -19,12 +18,11 @@ module Grisette.IR.SymPrim.Data.TabularFun
   )
 where
 
-import Control.DeepSeq
-import Data.Hashable
-import GHC.Generics
-import Grisette.Core.Data.Class.Function
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Language.Haskell.TH.Syntax
+import Control.DeepSeq (NFData, NFData1)
+import Data.Hashable (Hashable)
+import GHC.Generics (Generic, Generic1)
+import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
+import Language.Haskell.TH.Syntax (Lift)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -45,13 +43,6 @@ data (=->) a b = TabularFun {funcTable :: [(a, b)], defaultFuncValue :: b}
   deriving (Show, Eq, Generic, Generic1, Lift, NFData, NFData1)
 
 infixr 0 =->
-
-instance
-  (SupportedPrim a, SupportedPrim b) =>
-  SupportedPrim (a =-> b)
-  where
-  type PrimConstraint (a =-> b) = (SupportedPrim a, SupportedPrim b)
-  defaultValue = TabularFun [] (defaultValue @b)
 
 instance (Eq a) => Function (a =-> b) where
   type Arg (a =-> b) = a

--- a/src/Grisette/IR/SymPrim/Data/TabularFun.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/TabularFun.hs-boot
@@ -5,4 +5,18 @@ module Grisette.IR.SymPrim.Data.TabularFun
   )
 where
 
+import Control.DeepSeq (NFData)
+import Data.Hashable (Hashable)
+import Language.Haskell.TH.Syntax (Lift)
+
 data (=->) a b = TabularFun {funcTable :: [(a, b)], defaultFuncValue :: b}
+
+instance (Eq a, Eq b) => Eq (a =-> b)
+
+instance (Show a, Show b) => Show (a =-> b)
+
+instance (Hashable a, Hashable b) => Hashable (a =-> b)
+
+instance (Lift a, Lift b) => Lift (a =-> b)
+
+instance (NFData a, NFData b) => NFData (a =-> b)

--- a/src/Grisette/Internal/Backend/SBV.hs
+++ b/src/Grisette/Internal/Backend/SBV.hs
@@ -14,4 +14,7 @@ module Grisette.Internal.Backend.SBV
 where
 
 import Grisette.Backend.SBV.Data.SMT.Lowering
-import Grisette.Backend.SBV.Data.SMT.Solving
+  ( lowerSinglePrim,
+    parseModel,
+  )
+import Grisette.Backend.SBV.Data.SMT.Solving (TermTy)

--- a/src/Grisette/Internal/Core.hs
+++ b/src/Grisette/Internal/Core.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE Trustworthy #-}
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 -- |
 -- Module      :   Grisette.Internal.Core
@@ -23,4 +25,13 @@ module Grisette.Internal.Core
 where
 
 import Grisette.Core.Control.Monad.UnionM
+  ( UnionM (..),
+    isMerged,
+    underlyingUnion,
+  )
 import Grisette.Core.Data.Union
+  ( Union (..),
+    fullReconstruct,
+    ifWithLeftMost,
+    ifWithStrategy,
+  )

--- a/src/Grisette/Internal/IR/SymPrim.hs
+++ b/src/Grisette/Internal/IR/SymPrim.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 -- |
 -- Module      :   Grisette.Internal.IR.SymPrim
@@ -91,15 +93,103 @@ module Grisette.Internal.IR.SymPrim
 where
 
 import Grisette.IR.SymPrim.Data.Prim.Helpers
+  ( pattern BinaryTermPatt,
+    pattern TernaryTermPatt,
+    pattern UnaryTermPatt,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( conTerm,
+    constructBinary,
+    constructTernary,
+    constructUnary,
+    iinfosymTerm,
+    isymTerm,
+    sinfosymTerm,
+    ssymTerm,
+    symTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm
+  ( SomeTerm (..),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( BinaryOp (..),
+    SomeTypedSymbol (..),
+    SupportedPrim (..),
+    Term (..),
+    TernaryOp (..),
+    UnaryOp (..),
+    showUntyped,
+    someTypedSymbol,
+    withSymbolSupported,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
-import Grisette.IR.SymPrim.Data.Prim.Model
+  ( castTerm,
+    extractSymbolicsTerm,
+    identity,
+    identityWithTypeRep,
+    introSupportedPrimConstraint,
+    pformat,
+    termSize,
+    termsSize,
+  )
+import Grisette.IR.SymPrim.Data.Prim.Model (evaluateTerm)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( falseTerm,
+    pevalAndTerm,
+    pevalEqvTerm,
+    pevalITETerm,
+    pevalImplyTerm,
+    pevalNotEqvTerm,
+    pevalNotTerm,
+    pevalOrTerm,
+    pevalXorTerm,
+    trueTerm,
+    pattern BoolConTerm,
+    pattern BoolTerm,
+    pattern FalseTerm,
+    pattern TrueTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.GeneralFun
+  ( pevalGeneralFunApplyTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Integral
+  ( pevalDivIntegralTerm,
+    pevalModIntegralTerm,
+    pevalQuotIntegralTerm,
+    pevalRemIntegralTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
+  ( pevalAbsNumTerm,
+    pevalAddNumTerm,
+    pevalGeNumTerm,
+    pevalGtNumTerm,
+    pevalLeNumTerm,
+    pevalLtNumTerm,
+    pevalMinusNumTerm,
+    pevalSignumNumTerm,
+    pevalTimesNumTerm,
+    pevalUMinusNumTerm,
+    pattern NumConTerm,
+    pattern NumOrdConTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
+  ( BinaryCommPartialStrategy (..),
+    BinaryPartialStrategy (..),
+    PartialFun,
+    PartialRuleBinary,
+    PartialRuleUnary,
+    TotalRuleBinary,
+    TotalRuleUnary,
+    UnaryPartialStrategy (..),
+    binaryPartial,
+    totalize,
+    totalize2,
+    unaryPartial,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
+  ( pevalTabularFunApplyTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
+  ( binaryUnfoldOnce,
+    unaryUnfoldOnce,
+  )

--- a/src/Grisette/Internal/IR/SymPrim.hs
+++ b/src/Grisette/Internal/IR/SymPrim.hs
@@ -103,4 +103,3 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.PartialEval
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Unfold
-import Grisette.IR.SymPrim.Data.SymPrim

--- a/src/Grisette/Lib/Base.hs
+++ b/src/Grisette/Lib/Base.hs
@@ -49,6 +49,37 @@ module Grisette.Lib.Base
 where
 
 import Grisette.Lib.Control.Monad
+  ( mrgBindWithStrategy,
+    mrgFmap,
+    mrgFoldM,
+    mrgMplus,
+    mrgMzero,
+    mrgReturn,
+    mrgReturnWithStrategy,
+    (>>=~),
+    (>>~),
+  )
 import Grisette.Lib.Data.Foldable
+  ( mrgFoldlM,
+    mrgFoldrM,
+    mrgForM_,
+    mrgFor_,
+    mrgMapM_,
+    mrgMsum,
+    mrgSequence_,
+    mrgTraverse_,
+  )
 import Grisette.Lib.Data.List
+  ( symDrop,
+    symFilter,
+    symTake,
+    (!!~),
+  )
 import Grisette.Lib.Data.Traversable
+  ( mrgFor,
+    mrgForM,
+    mrgMapM,
+    mrgSequence,
+    mrgSequenceA,
+    mrgTraverse,
+  )

--- a/src/Grisette/Lib/Control/Monad.hs
+++ b/src/Grisette/Lib/Control/Monad.hs
@@ -25,11 +25,17 @@ module Grisette.Lib.Control.Monad
   )
 where
 
-import Control.Monad
-import Grisette.Core.Control.Monad.Union
+import Control.Monad (MonadPlus (mplus, mzero))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable,
+    MergingStrategy,
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Lib.Data.Foldable
+  ( UnionLike (mergeWithStrategy),
+    merge,
+  )
+import Grisette.Lib.Data.Foldable (mrgFoldlM)
 
 -- | 'return' with 'MergingStrategy' knowledge propagation.
 mrgReturnWithStrategy :: (MonadUnion u) => MergingStrategy a -> a -> u a

--- a/src/Grisette/Lib/Control/Monad.hs
+++ b/src/Grisette/Lib/Control/Monad.hs
@@ -27,7 +27,6 @@ where
 
 import Control.Monad
 import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Lib.Data.Foldable

--- a/src/Grisette/Lib/Control/Monad.hs-boot
+++ b/src/Grisette/Lib/Control/Monad.hs-boot
@@ -1,7 +1,18 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE Trustworthy #-}
 
-module Grisette.Lib.Control.Monad where
+module Grisette.Lib.Control.Monad
+  ( mrgReturnWithStrategy,
+    mrgBindWithStrategy,
+    mrgReturn,
+    (>>=~),
+    mrgFoldM,
+    (>>~),
+    mrgMzero,
+    mrgMplus,
+    mrgFmap,
+  )
+where
 
 import Control.Monad
 import Grisette.Core.Control.Monad.Union

--- a/src/Grisette/Lib/Control/Monad.hs-boot
+++ b/src/Grisette/Lib/Control/Monad.hs-boot
@@ -14,9 +14,12 @@ module Grisette.Lib.Control.Monad
   )
 where
 
-import Control.Monad
-import Grisette.Core.Control.Monad.Union
+import Control.Monad (MonadPlus)
+import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable,
+    MergingStrategy,
+  )
 
 mrgReturnWithStrategy :: (MonadUnion u) => MergingStrategy a -> a -> u a
 mrgBindWithStrategy :: (MonadUnion u) => MergingStrategy b -> u a -> (a -> u b) -> u b

--- a/src/Grisette/Lib/Control/Monad.hs-boot
+++ b/src/Grisette/Lib/Control/Monad.hs-boot
@@ -5,7 +5,6 @@ module Grisette.Lib.Control.Monad where
 
 import Control.Monad
 import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 
 mrgReturnWithStrategy :: (MonadUnion u) => MergingStrategy a -> a -> u a

--- a/src/Grisette/Lib/Control/Monad/Except.hs
+++ b/src/Grisette/Lib/Control/Monad/Except.hs
@@ -15,10 +15,10 @@ module Grisette.Lib.Control.Monad.Except
   )
 where
 
-import Control.Monad.Except
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SimpleMergeable
+import Control.Monad.Except (MonadError (catchError, throwError))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+import Grisette.Core.Data.Class.SimpleMergeable (merge)
 
 -- | 'throwError' with 'MergingStrategy' knowledge propagation.
 mrgThrowError :: (MonadError e m, MonadUnion m, Mergeable a) => e -> m a

--- a/src/Grisette/Lib/Control/Monad/Except.hs
+++ b/src/Grisette/Lib/Control/Monad/Except.hs
@@ -17,7 +17,6 @@ where
 
 import Control.Monad.Except
 import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 

--- a/src/Grisette/Lib/Control/Monad/Trans.hs
+++ b/src/Grisette/Lib/Control/Monad/Trans.hs
@@ -16,10 +16,10 @@ module Grisette.Lib.Control.Monad.Trans
   )
 where
 
-import Control.Monad.Trans
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SimpleMergeable
+import Control.Monad.Trans (MonadTrans (lift))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+import Grisette.Core.Data.Class.SimpleMergeable (merge)
 
 -- | 'lift' with 'MergingStrategy' knowledge propagation.
 mrgLift ::

--- a/src/Grisette/Lib/Control/Monad/Trans/Cont.hs
+++ b/src/Grisette/Lib/Control/Monad/Trans/Cont.hs
@@ -16,9 +16,8 @@ module Grisette.Lib.Control.Monad.Trans.Cont
   )
 where
 
-import Control.Monad.Cont
-import Control.Monad.Trans.Class
-import Grisette.Core.Data.Class.Bool
+import Control.Monad.Cont (ContT (..))
+import Control.Monad.Trans.Class (lift)
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Lib.Control.Monad

--- a/src/Grisette/Lib/Control/Monad/Trans/Cont.hs
+++ b/src/Grisette/Lib/Control/Monad/Trans/Cont.hs
@@ -16,11 +16,14 @@ module Grisette.Lib.Control.Monad.Trans.Cont
   )
 where
 
-import Control.Monad.Cont (ContT (..))
+import Control.Monad.Cont (ContT (runContT))
 import Control.Monad.Trans.Class (lift)
-import Grisette.Core.Data.Class.Mergeable
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Lib.Control.Monad
+  ( UnionLike,
+    merge,
+  )
+import Grisette.Lib.Control.Monad (mrgReturn)
 
 -- | 'Control.Monad.Cont.runContT' with 'MergingStrategy' knowledge propagation
 mrgRunContT :: (UnionLike m, Mergeable r) => ContT r m a -> (a -> m r) -> m r

--- a/src/Grisette/Lib/Data/Foldable.hs
+++ b/src/Grisette/Lib/Data/Foldable.hs
@@ -24,7 +24,6 @@ where
 
 import Control.Monad
 import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
 import {-# SOURCE #-} Grisette.Lib.Control.Monad

--- a/src/Grisette/Lib/Data/Foldable.hs
+++ b/src/Grisette/Lib/Data/Foldable.hs
@@ -22,11 +22,15 @@ module Grisette.Lib.Data.Foldable
   )
 where
 
-import Control.Monad
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SimpleMergeable
+import Control.Monad (MonadPlus)
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+import Grisette.Core.Data.Class.SimpleMergeable (merge)
 import {-# SOURCE #-} Grisette.Lib.Control.Monad
+  ( mrgMplus,
+    mrgMzero,
+    mrgReturn,
+  )
 
 -- | 'Data.Foldable.foldlM' with 'MergingStrategy' knowledge propagation.
 mrgFoldlM :: (MonadUnion m, Mergeable b, Foldable t) => (b -> a -> m b) -> b -> t a -> m b

--- a/src/Grisette/Lib/Data/List.hs
+++ b/src/Grisette/Lib/Data/List.hs
@@ -24,7 +24,6 @@ import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SOrd
-import Grisette.Core.Data.Class.SafeArith
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.IR.SymPrim.Data.SymPrim
 import Grisette.Lib.Control.Monad

--- a/src/Grisette/Lib/Data/List.hs
+++ b/src/Grisette/Lib/Data/List.hs
@@ -17,16 +17,16 @@ module Grisette.Lib.Data.List
   )
 where
 
-import Control.Exception
-import Control.Monad.Except
-import Grisette.Core.Control.Monad.Union
-import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.Error
-import Grisette.Core.Data.Class.Mergeable
-import Grisette.Core.Data.Class.SOrd
-import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.IR.SymPrim.Data.SymPrim
-import Grisette.Lib.Control.Monad
+import Control.Exception (ArrayException (IndexOutOfBounds))
+import Control.Monad.Except (MonadError (throwError))
+import Grisette.Core.Control.Monad.Union (MonadUnion)
+import Grisette.Core.Data.Class.Bool (SEq ((==~)))
+import Grisette.Core.Data.Class.Error (TransformError (transformError))
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
+import Grisette.Core.Data.Class.SOrd (SOrd ((<=~)))
+import Grisette.Core.Data.Class.SimpleMergeable (mrgIf)
+import Grisette.IR.SymPrim.Data.SymPrim (SymBool, SymInteger)
+import Grisette.Lib.Control.Monad (mrgFmap, mrgReturn)
 
 -- | Symbolic version of 'Data.List.!!', the result would be merged and
 -- propagate the mergeable knowledge.

--- a/src/Grisette/Lib/Data/Traversable.hs
+++ b/src/Grisette/Lib/Data/Traversable.hs
@@ -21,9 +21,16 @@ module Grisette.Lib.Data.Traversable
   )
 where
 
-import Grisette.Core.Control.Monad.Union
+import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable,
+    Mergeable1,
+    rootStrategy1,
+  )
 import Grisette.Core.Data.Class.SimpleMergeable
+  ( UnionLike (mergeWithStrategy),
+    merge,
+  )
 
 -- | 'Data.Traversable.traverse' with 'MergingStrategy' knowledge propagation.
 mrgTraverse ::

--- a/src/Grisette/Lib/Mtl.hs
+++ b/src/Grisette/Lib/Mtl.hs
@@ -26,5 +26,12 @@ module Grisette.Lib.Mtl
 where
 
 import Grisette.Lib.Control.Monad.Except
-import Grisette.Lib.Control.Monad.Trans
+  ( mrgCatchError,
+    mrgThrowError,
+  )
+import Grisette.Lib.Control.Monad.Trans (mrgLift)
 import Grisette.Lib.Control.Monad.Trans.Cont
+  ( mrgEvalContT,
+    mrgResetT,
+    mrgRunContT,
+  )

--- a/src/Grisette/Qualified/ParallelUnionDo.hs
+++ b/src/Grisette/Qualified/ParallelUnionDo.hs
@@ -6,11 +6,12 @@
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-module Grisette.Qualified.ParallelUnionDo where
+module Grisette.Qualified.ParallelUnionDo ((>>=), (>>)) where
 
 import Control.Parallel.Strategies
 import Grisette.Core.Control.Monad.Class.MonadParallelUnion
 import Grisette.Core.Data.Class.Mergeable
+import Prelude (const, ($))
 
 (>>=) :: (MonadParallelUnion m, Mergeable b, NFData b) => m a -> (a -> m b) -> m b
 (>>=) = parBindUnion

--- a/src/Grisette/Qualified/ParallelUnionDo.hs
+++ b/src/Grisette/Qualified/ParallelUnionDo.hs
@@ -8,9 +8,11 @@
 -- Portability :   GHC only
 module Grisette.Qualified.ParallelUnionDo ((>>=), (>>)) where
 
-import Control.Parallel.Strategies
+import Control.Parallel.Strategies (NFData)
 import Grisette.Core.Control.Monad.Class.MonadParallelUnion
-import Grisette.Core.Data.Class.Mergeable
+  ( MonadParallelUnion (parBindUnion),
+  )
+import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Prelude (const, ($))
 
 (>>=) :: (MonadParallelUnion m, Mergeable b, NFData b) => m a -> (a -> m b) -> m b

--- a/src/Grisette/Utils.hs
+++ b/src/Grisette/Utils.hs
@@ -1,3 +1,6 @@
+-- Disable this warning because we are re-exporting things.
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 -- |
 -- Module      :   Grisette.Utils
 -- Copyright   :   (c) Sirui Lu 2021-2023
@@ -48,3 +51,32 @@ module Grisette.Utils
 where
 
 import Grisette.Utils.Parameterized
+  ( KnownProof (..),
+    LeqProof (..),
+    NatRepr,
+    addNat,
+    decNat,
+    divNat,
+    halfNat,
+    hasRepr,
+    incNat,
+    knownAdd,
+    leqAdd,
+    leqAdd2,
+    leqAddPos,
+    leqRefl,
+    leqSucc,
+    leqTrans,
+    leqZero,
+    natRepr,
+    natValue,
+    predNat,
+    subNat,
+    testLeq,
+    unsafeAxiom,
+    unsafeKnownProof,
+    unsafeLeqProof,
+    unsafeMkNatRepr,
+    withKnownProof,
+    withLeqProof,
+  )

--- a/src/Grisette/Utils/Parameterized.hs
+++ b/src/Grisette/Utils/Parameterized.hs
@@ -176,7 +176,7 @@ hasRepr (NatRepr nVal) =
 
 -- | Adding two type-level natural numbers with known runtime values gives a
 -- type-level natural number with a known runtime value.
-knownAdd :: forall m n r. KnownProof m -> KnownProof n -> KnownProof (m + n)
+knownAdd :: forall m n. KnownProof m -> KnownProof n -> KnownProof (m + n)
 knownAdd KnownProof KnownProof = hasRepr @(m + n) (NatRepr (natVal (Proxy @m) + natVal (Proxy @n)))
 
 -- | @'LeqProof m n'@ is a type whose values are only inhabited when @m <= n@.

--- a/src/Grisette/Utils/Parameterized.hs
+++ b/src/Grisette/Utils/Parameterized.hs
@@ -88,10 +88,20 @@ module Grisette.Utils.Parameterized
   )
 where
 
-import Data.Typeable
-import GHC.Natural
+import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
+import GHC.Natural (Natural)
 import GHC.TypeNats
-import Unsafe.Coerce
+  ( Div,
+    KnownNat,
+    Nat,
+    SomeNat (SomeNat),
+    natVal,
+    someNatVal,
+    type (+),
+    type (-),
+    type (<=),
+  )
+import Unsafe.Coerce (unsafeCoerce)
 
 -- | Assert a proof of equality between two types.
 -- This is unsafe if used improperly, so use this with caution!

--- a/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Grisette.Backend.SBV.Data.SMT.CEGISTests where
+module Grisette.Backend.SBV.Data.SMT.CEGISTests (cegisTests) where
 
 import Control.Monad.Except
 import Data.Proxy

--- a/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/CEGISTests.hs
@@ -8,18 +8,15 @@
 module Grisette.Backend.SBV.Data.SMT.CEGISTests where
 
 import Control.Monad.Except
-import qualified Data.HashSet as S
 import Data.Proxy
 import qualified Data.SBV as SBV
 import Data.String
 import Grisette.Backend.SBV
-import Grisette.Backend.SBV.Data.SMT.Solving
 import Grisette.Core.Control.Exception
 import Grisette.Core.Control.Monad.UnionM
 import Grisette.Core.Data.Class.BitVector
 import Grisette.Core.Data.Class.Bool
 import Grisette.Core.Data.Class.CEGISSolver
-import Grisette.Core.Data.Class.Error
 import Grisette.Core.Data.Class.Evaluate
 import Grisette.Core.Data.Class.ExtractSymbolics
 import Grisette.Core.Data.Class.Function
@@ -27,8 +24,6 @@ import Grisette.Core.Data.Class.SOrd
 import Grisette.Core.Data.Class.SimpleMergeable
 import Grisette.Core.Data.Class.Solvable
 import Grisette.Core.Data.Class.Solver
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.Prim.Model
 import Grisette.IR.SymPrim.Data.SymPrim
 import Test.Tasty
 import Test.Tasty.HUnit

--- a/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Grisette.Backend.SBV.Data.SMT.LoweringTests where
+module Grisette.Backend.SBV.Data.SMT.LoweringTests (loweringTests) where
 
 import Control.Monad.Trans
 import Data.Bits
@@ -70,21 +70,21 @@ testUnaryOpLowering config f name sbvfun = do
           SBV.Unsat -> return ()
           _ -> lift $ assertFailure $ "Lowering for " ++ name ++ " generated unknown formula"
 
-testUnaryOpLowering' ::
-  forall a b as n tag.
-  ( HasCallStack,
-    UnaryOp tag a b,
-    SBV.EqSymbolic (TermTy n b),
-    Typeable (TermTy n a),
-    SBV.SymVal as,
-    TermTy n a ~ SBV.SBV as,
-    Show as
-  ) =>
-  GrisetteSMTConfig n ->
-  tag ->
-  (TermTy n a -> TermTy n b) ->
-  Assertion
-testUnaryOpLowering' config t = testUnaryOpLowering @a @b @as config (constructUnary t) (show t)
+-- testUnaryOpLowering' ::
+--   forall a b as n tag.
+--   ( HasCallStack,
+--     UnaryOp tag a b,
+--     SBV.EqSymbolic (TermTy n b),
+--     Typeable (TermTy n a),
+--     SBV.SymVal as,
+--     TermTy n a ~ SBV.SBV as,
+--     Show as
+--   ) =>
+--   GrisetteSMTConfig n ->
+--   tag ->
+--   (TermTy n a -> TermTy n b) ->
+--   Assertion
+-- testUnaryOpLowering' config t = testUnaryOpLowering @a @b @as config (constructUnary t) (show t)
 
 testBinaryOpLowering ::
   forall a b c as bs n.
@@ -139,25 +139,25 @@ testBinaryOpLowering config f name sbvfun = do
           _ -> lift $ assertFailure $ "Lowering for " ++ name ++ " generated unknown formula"
       _ -> lift $ assertFailure "Failed to extract the term"
 
-testBinaryOpLowering' ::
-  forall a b c as bs n tag.
-  ( HasCallStack,
-    BinaryOp tag a b c,
-    SBV.EqSymbolic (TermTy n c),
-    Typeable (TermTy n a),
-    Typeable (TermTy n b),
-    SBV.SymVal as,
-    SBV.SymVal bs,
-    Show as,
-    Show bs,
-    TermTy n a ~ SBV.SBV as,
-    TermTy n b ~ SBV.SBV bs
-  ) =>
-  GrisetteSMTConfig n ->
-  tag ->
-  (TermTy n a -> TermTy n b -> TermTy n c) ->
-  Assertion
-testBinaryOpLowering' config t = testBinaryOpLowering @a @b @c @as @bs config (constructBinary t) (show t)
+-- testBinaryOpLowering' ::
+--   forall a b c as bs n tag.
+--   ( HasCallStack,
+--     BinaryOp tag a b c,
+--     SBV.EqSymbolic (TermTy n c),
+--     Typeable (TermTy n a),
+--     Typeable (TermTy n b),
+--     SBV.SymVal as,
+--     SBV.SymVal bs,
+--     Show as,
+--     Show bs,
+--     TermTy n a ~ SBV.SBV as,
+--     TermTy n b ~ SBV.SBV bs
+--   ) =>
+--   GrisetteSMTConfig n ->
+--   tag ->
+--   (TermTy n a -> TermTy n b -> TermTy n c) ->
+--   Assertion
+-- testBinaryOpLowering' config t = testBinaryOpLowering @a @b @c @as @bs config (constructBinary t) (show t)
 
 testTernaryOpLowering ::
   forall a b c d as bs cs n.
@@ -224,29 +224,29 @@ testTernaryOpLowering config f name sbvfun = do
           _ -> lift $ assertFailure $ "Lowering for " ++ name ++ " generated unknown formula"
       _ -> lift $ assertFailure "Failed to extract the term"
 
-testTernaryOpLowering' ::
-  forall a b c d as bs cs n tag.
-  ( HasCallStack,
-    TernaryOp tag a b c d,
-    SBV.EqSymbolic (TermTy n d),
-    Typeable (TermTy n a),
-    Typeable (TermTy n b),
-    Typeable (TermTy n c),
-    SBV.SymVal as,
-    SBV.SymVal bs,
-    SBV.SymVal cs,
-    Show as,
-    Show bs,
-    Show cs,
-    TermTy n a ~ SBV.SBV as,
-    TermTy n b ~ SBV.SBV bs,
-    TermTy n c ~ SBV.SBV cs
-  ) =>
-  GrisetteSMTConfig n ->
-  tag ->
-  (TermTy n a -> TermTy n b -> TermTy n c -> TermTy n d) ->
-  Assertion
-testTernaryOpLowering' config t = testTernaryOpLowering @a @b @c @d @as @bs @cs config (constructTernary t) (show t)
+-- testTernaryOpLowering' ::
+--   forall a b c d as bs cs n tag.
+--   ( HasCallStack,
+--     TernaryOp tag a b c d,
+--     SBV.EqSymbolic (TermTy n d),
+--     Typeable (TermTy n a),
+--     Typeable (TermTy n b),
+--     Typeable (TermTy n c),
+--     SBV.SymVal as,
+--     SBV.SymVal bs,
+--     SBV.SymVal cs,
+--     Show as,
+--     Show bs,
+--     Show cs,
+--     TermTy n a ~ SBV.SBV as,
+--     TermTy n b ~ SBV.SBV bs,
+--     TermTy n c ~ SBV.SBV cs
+--   ) =>
+--   GrisetteSMTConfig n ->
+--   tag ->
+--   (TermTy n a -> TermTy n b -> TermTy n c -> TermTy n d) ->
+--   Assertion
+-- testTernaryOpLowering' config t = testTernaryOpLowering @a @b @c @d @as @bs @cs config (constructTernary t) (show t)
 
 loweringTests :: TestTree
 loweringTests =

--- a/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
@@ -9,22 +9,75 @@
 
 module Grisette.Backend.SBV.Data.SMT.LoweringTests (loweringTests) where
 
-import Control.Monad.Trans
+import Control.Monad.Trans (MonadTrans (lift))
 import Data.Bits
-import Data.Dynamic
+  ( Bits (complement, rotate, shift, xor, (.&.), (.|.)),
+  )
+import Data.Dynamic (Typeable, fromDynamic)
 import qualified Data.HashMap.Strict as M
-import Data.Proxy
+import Data.Proxy (Proxy (Proxy))
 import qualified Data.SBV as SBV
 import qualified Data.SBV.Control as SBV
-import Grisette.Backend.SBV.Data.SMT.Lowering
+import Grisette.Backend.SBV.Data.SMT.Lowering (lowerSinglePrim)
 import Grisette.Backend.SBV.Data.SMT.Solving
+  ( GrisetteSMTConfig (sbvConfig),
+    TermTy,
+    approx,
+    precise,
+  )
 import Grisette.Backend.SBV.Data.SMT.SymBiMap
-import Grisette.Core.Data.BV
+  ( SymBiMap (biMapToSBV),
+  )
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( absNumTerm,
+    addNumTerm,
+    andBitsTerm,
+    andTerm,
+    bvToSignedTerm,
+    bvToUnsignedTerm,
+    bvconcatTerm,
+    bvselectTerm,
+    bvsignExtendTerm,
+    bvzeroExtendTerm,
+    complementBitsTerm,
+    divBoundedIntegralTerm,
+    divIntegralTerm,
+    eqvTerm,
+    iteTerm,
+    leNumTerm,
+    ltNumTerm,
+    modBoundedIntegralTerm,
+    modIntegralTerm,
+    notTerm,
+    orBitsTerm,
+    orTerm,
+    quotBoundedIntegralTerm,
+    quotIntegralTerm,
+    remBoundedIntegralTerm,
+    remIntegralTerm,
+    rotateBitsTerm,
+    shiftBitsTerm,
+    signumNumTerm,
+    ssymTerm,
+    timesNumTerm,
+    uminusNumTerm,
+    xorBitsTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.SomeTerm
+  ( SomeTerm (SomeTerm),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Test.Tasty
+  ( SupportedPrim,
+    Term,
+  )
+import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
+  ( Assertion,
+    HasCallStack,
+    assertFailure,
+    testCase,
+  )
 
 testUnaryOpLowering ::
   forall a b as n.

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
@@ -12,7 +12,35 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Grisette.Backend.SBV.Data.SMT.TermRewritingGen where
+module Grisette.Backend.SBV.Data.SMT.TermRewritingGen
+  ( TermRewritingSpec (..),
+    GeneralSpec (..),
+    DifferentSizeBVSpec (..),
+    FixedSizedBVWithBoolSpec (..),
+    BoolWithLIASpec (..),
+    LIAWithBoolSpec (..),
+    BoolOnlySpec (..),
+    constructUnarySpec',
+    constructBinarySpec',
+    constructTernarySpec',
+    divIntegralSpec,
+    modIntegralSpec,
+    quotIntegralSpec,
+    remIntegralSpec,
+    divBoundedIntegralSpec,
+    modBoundedIntegralSpec,
+    quotBoundedIntegralSpec,
+    remBoundedIntegralSpec,
+    uminusNumSpec,
+    timesNumSpec,
+    addNumSpec,
+    iteSpec,
+    eqvSpec,
+    notSpec,
+    andSpec,
+    orSpec,
+  )
+where
 
 import Data.Bits
 import Data.Data

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
@@ -42,20 +42,103 @@ module Grisette.Backend.SBV.Data.SMT.TermRewritingGen
   )
 where
 
-import Data.Bits
-import Data.Data
-import Data.Kind
-import GHC.TypeLits
-import Grisette.Core.Data.Class.BitVector
+import Data.Bits (Bits)
+import Data.Data (Proxy (Proxy), Typeable)
+import Data.Kind (Type)
+import GHC.TypeLits (KnownNat, Nat, type (+), type (<=))
+import Grisette.Core.Data.Class.BitVector (SizedBV)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( absNumTerm,
+    addNumTerm,
+    andBitsTerm,
+    andTerm,
+    bvconcatTerm,
+    bvextendTerm,
+    bvselectTerm,
+    complementBitsTerm,
+    conTerm,
+    constructBinary,
+    constructTernary,
+    constructUnary,
+    divBoundedIntegralTerm,
+    divIntegralTerm,
+    eqvTerm,
+    iteTerm,
+    leNumTerm,
+    ltNumTerm,
+    modBoundedIntegralTerm,
+    modIntegralTerm,
+    notTerm,
+    orBitsTerm,
+    orTerm,
+    quotBoundedIntegralTerm,
+    quotIntegralTerm,
+    remBoundedIntegralTerm,
+    remIntegralTerm,
+    rotateBitsTerm,
+    shiftBitsTerm,
+    signumNumTerm,
+    ssymTerm,
+    timesNumTerm,
+    uminusNumTerm,
+    xorBitsTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( BinaryOp (partialEvalBinary),
+    SupportedPrim,
+    Term,
+    TernaryOp (partialEvalTernary),
+    UnaryOp (partialEvalUnary),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
+  ( pformat,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
+  ( pevalBVConcatTerm,
+    pevalBVExtendTerm,
+    pevalBVSelectTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
+  ( pevalAndBitsTerm,
+    pevalComplementBitsTerm,
+    pevalOrBitsTerm,
+    pevalRotateBitsTerm,
+    pevalShiftBitsTerm,
+    pevalXorBitsTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalAndTerm,
+    pevalEqvTerm,
+    pevalITETerm,
+    pevalNotTerm,
+    pevalOrTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Integral
+  ( pevalDivBoundedIntegralTerm,
+    pevalDivIntegralTerm,
+    pevalModBoundedIntegralTerm,
+    pevalModIntegralTerm,
+    pevalQuotBoundedIntegralTerm,
+    pevalQuotIntegralTerm,
+    pevalRemBoundedIntegralTerm,
+    pevalRemIntegralTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
+  ( pevalAbsNumTerm,
+    pevalAddNumTerm,
+    pevalLeNumTerm,
+    pevalLtNumTerm,
+    pevalSignumNumTerm,
+    pevalTimesNumTerm,
+    pevalUMinusNumTerm,
+  )
 import Test.Tasty.QuickCheck
+  ( Arbitrary (arbitrary),
+    Gen,
+    frequency,
+    oneof,
+    sized,
+  )
 
 class (SupportedPrim b) => TermRewritingSpec a b | a -> b where
   norewriteVer :: a -> Term b

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
@@ -9,18 +9,56 @@ module Grisette.Backend.SBV.Data.SMT.TermRewritingTests
   )
 where
 
-import Data.Foldable
+import Data.Foldable (traverse_)
 import qualified Data.SBV as SBV
 import Grisette.Backend.SBV.Data.SMT.Solving
+  ( GrisetteSMTConfig,
+    precise,
+  )
 import Grisette.Backend.SBV.Data.SMT.TermRewritingGen
-import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.Solver
+  ( BoolOnlySpec,
+    BoolWithLIASpec,
+    DifferentSizeBVSpec,
+    FixedSizedBVWithBoolSpec,
+    GeneralSpec,
+    LIAWithBoolSpec,
+    TermRewritingSpec
+      ( conSpec,
+        counterExample,
+        norewriteVer,
+        rewriteVer,
+        same,
+        symSpec
+      ),
+    addNumSpec,
+    andSpec,
+    divBoundedIntegralSpec,
+    divIntegralSpec,
+    eqvSpec,
+    iteSpec,
+    modBoundedIntegralSpec,
+    modIntegralSpec,
+    notSpec,
+    orSpec,
+    quotBoundedIntegralSpec,
+    quotIntegralSpec,
+    remBoundedIntegralSpec,
+    remIntegralSpec,
+    timesNumSpec,
+    uminusNumSpec,
+  )
+import Grisette.Core.Data.BV (IntN, WordN)
+import Grisette.Core.Data.Class.Solver (Solver (solve))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermUtils
-import Grisette.IR.SymPrim.Data.SymPrim
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck
+  ( pformat,
+  )
+import Grisette.IR.SymPrim.Data.SymPrim (SymBool (SymBool))
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, assertFailure, testCase)
+import Test.Tasty.QuickCheck (ioProperty, mapSize, testProperty)
 
 validateSpec :: (TermRewritingSpec a av, Show a, SupportedPrim av) => GrisetteSMTConfig n -> a -> Assertion
 validateSpec config a = do

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
@@ -4,7 +4,10 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Grisette.Backend.SBV.Data.SMT.TermRewritingTests where
+module Grisette.Backend.SBV.Data.SMT.TermRewritingTests
+  ( termRewritingTests,
+  )
+where
 
 import Data.Foldable
 import qualified Data.SBV as SBV

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Grisette.Core.Control.Monad.UnionMTests where
+module Grisette.Core.Control.Monad.UnionMTests (unionMTests) where
 
 import Grisette.Core.Control.Monad.UnionM
 import Grisette.Core.Data.Class.GenSym

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -2,12 +2,15 @@
 
 module Grisette.Core.Control.Monad.UnionMTests (unionMTests) where
 
-import Grisette.Core.Control.Monad.UnionM
-import Grisette.Core.Data.Class.GenSym
+import Grisette.Core.Control.Monad.UnionM (UnionM, unionSize)
+import Grisette.Core.Data.Class.GenSym (choose)
 import Grisette.Core.Data.Class.SimpleMergeable
-import Grisette.Core.Data.Class.Solvable
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( UnionLike (single),
+    mrgIf,
+  )
+import Grisette.Core.Data.Class.Solvable (Solvable (ssym))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 unionMTests :: TestTree
 unionMTests =

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -206,7 +206,7 @@ divLikeTest ::
   TestTree
 divLikeTest name a2b fa fb =
   testGroup
-    "name"
+    name
     [ testCase "divided by zero" $ do
         sameDiv 1 0 a2b fa fb
         sameDiv 0 0 a2b fa fb
@@ -228,7 +228,7 @@ divModLikeTest ::
   TestTree
 divModLikeTest name a2b fa fb =
   testGroup
-    "name"
+    name
     [ testCase "divided by zero" $ do
         sameDivMod 1 0 a2b fa fb
         sameDivMod 0 0 a2b fa fb

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Grisette.Core.Data.BVTests where
+module Grisette.Core.Data.BVTests (bvTests) where
 
 import Control.DeepSeq
 import Control.Exception

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -6,20 +6,67 @@
 
 module Grisette.Core.Data.BVTests (bvTests) where
 
-import Control.DeepSeq
+import Control.DeepSeq (NFData (rnf), deepseq, force)
 import Control.Exception
-import Control.Monad
-import Data.Bifunctor
+  ( ArithException,
+    SomeException,
+    catch,
+    evaluate,
+  )
+import Control.Monad (when)
+import Data.Bifunctor (Bifunctor (bimap))
 import Data.Bits
-import Data.Int
-import Data.Proxy
-import Data.Typeable
-import Data.Word
-import Grisette.Core.Data.BV
+  ( Bits
+      ( bit,
+        bitSizeMaybe,
+        clearBit,
+        complement,
+        complementBit,
+        isSigned,
+        popCount,
+        rotate,
+        rotateL,
+        rotateR,
+        setBit,
+        shift,
+        shiftL,
+        shiftR,
+        testBit,
+        xor,
+        zeroBits,
+        (.&.),
+        (.|.)
+      ),
+    FiniteBits (countLeadingZeros, countTrailingZeros, finiteBitSize),
+  )
+import Data.Int (Int8)
+import Data.Proxy (Proxy (Proxy))
+import Data.Typeable (Typeable, typeRep)
+import Data.Word (Word8)
+import Grisette.Core.Data.BV (IntN (IntN), WordN (unWordN))
 import Grisette.Core.Data.Class.BitVector
-import Test.Tasty
+  ( SizedBV
+      ( sizedBVConcat,
+        sizedBVExt,
+        sizedBVSelect,
+        sizedBVSext,
+        sizedBVZext
+      ),
+  )
+import Test.Tasty (TestName, TestTree, testGroup)
 import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck hiding ((.&.))
+  ( Assertion,
+    HasCallStack,
+    assertFailure,
+    testCase,
+    (@=?),
+  )
+import Test.Tasty.QuickCheck
+  ( Arbitrary,
+    Property,
+    ioProperty,
+    testProperty,
+  )
 
 unaryConform :: forall a b c d. (Show c, Eq c, HasCallStack) => (a -> b) -> (d -> c) -> (a -> c) -> (b -> d) -> a -> Property
 unaryConform a2b d2c f g x = ioProperty $ f x @=? d2c (g (a2b x))

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Grisette.Core.Data.Class.GPrettyTests where
+module Grisette.Core.Data.Class.GPrettyTests (gprettyTests) where
 
 import Data.Int
 import Data.Text as T

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -40,7 +40,7 @@ testGPretty n i a s =
       @=? s
 
 propertyGPrettyShow ::
-  forall proxy a.
+  forall a.
   (HasCallStack, GPretty a, Show a) =>
   String ->
   Gen a ->
@@ -50,7 +50,7 @@ propertyGPrettyShow n g =
     renderStrict (layoutPretty (LayoutOptions Unbounded) (gpretty a)) == T.pack (show a)
 
 propertyGPrettyRead ::
-  forall proxy a.
+  forall a.
   (HasCallStack, GPretty a, Read a, Show a, Eq a) =>
   String ->
   Gen a ->
@@ -69,7 +69,7 @@ propertyGPrettyRead n g =
       == a
 
 propertyGPretty ::
-  forall proxy a.
+  forall a.
   (HasCallStack, GPretty a, Read a, Show a, Eq a) =>
   String ->
   Gen a ->

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -7,26 +7,45 @@
 
 module Grisette.Core.Data.Class.GPrettyTests (gprettyTests) where
 
-import Data.Int
-import Data.Text as T
-import Data.Word
-import GHC.Generics
-import GHC.Stack
-import Generics.Deriving
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Text as T (Text, pack, unpack)
+import Data.Word (Word16, Word32, Word64, Word8)
+import GHC.Generics (Generic)
+import GHC.Stack (HasCallStack)
+import Generics.Deriving (Default (Default))
 import Grisette.Core.Data.BV
-import Grisette.Core.Data.Class.Bool
-import Grisette.Core.Data.Class.GPretty
-import Grisette.IR.SymPrim.Data.SymPrim
-import Test.Tasty
-import Test.Tasty.HUnit
-import Test.Tasty.QuickCheck hiding ((.&.))
+  ( IntN,
+    SomeIntN (SomeIntN),
+    SomeWordN (SomeWordN),
+    WordN,
+  )
+import Grisette.Core.Data.Class.Bool (LogicalOp ((&&~)))
+import Grisette.Core.Data.Class.GPretty (GPretty (gpretty))
+import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
+import Test.Tasty.QuickCheck
+  ( Arbitrary (arbitrary),
+    Gen,
+    forAll,
+    oneof,
+    testProperty,
+  )
 
 #if MIN_VERSION_prettyprinter(1,7,0)
 import Prettyprinter
-import Prettyprinter.Render.Text
+  ( PageWidth(AvailablePerLine, Unbounded),
+    layoutPretty,
+    LayoutOptions(LayoutOptions),
+  )
+import Prettyprinter.Render.Text (renderStrict)
 #else
 import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Text
+  ( PageWidth(AvailablePerLine, Unbounded),
+    layoutPretty,
+    LayoutOptions(LayoutOptions),
+  )
+import Data.Text.Prettyprint.Doc.Render.Text (renderStrict)
 #endif
 
 testGPretty :: (HasCallStack, GPretty a) => String -> Int -> a -> T.Text -> TestTree

--- a/test/Grisette/IR/SymPrim/Data/Prim/BVTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BVTests.hs
@@ -5,13 +5,23 @@
 
 module Grisette.IR.SymPrim.Data.Prim.BVTests (bvTests) where
 
-import Data.Proxy
-import Grisette.Core.Data.BV
+import Data.Proxy (Proxy (Proxy))
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( bvconcatTerm,
+    bvextendTerm,
+    bvselectTerm,
+    conTerm,
+    ssymTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalBVConcatTerm,
+    pevalBVExtendTerm,
+    pevalBVSelectTerm,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 bvTests :: TestTree
 bvTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/BVTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BVTests.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Grisette.IR.SymPrim.Data.Prim.BVTests where
+module Grisette.IR.SymPrim.Data.Prim.BVTests (bvTests) where
 
 import Data.Proxy
 import Grisette.Core.Data.BV

--- a/test/Grisette/IR/SymPrim/Data/Prim/BitsTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BitsTests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Grisette.IR.SymPrim.Data.Prim.BitsTests where
+module Grisette.IR.SymPrim.Data.Prim.BitsTests (bitsTests) where
 
 import Grisette.Core.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors

--- a/test/Grisette/IR/SymPrim/Data/Prim/BitsTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BitsTests.hs
@@ -3,12 +3,28 @@
 
 module Grisette.IR.SymPrim.Data.Prim.BitsTests (bitsTests) where
 
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( andBitsTerm,
+    complementBitsTerm,
+    conTerm,
+    orBitsTerm,
+    rotateBitsTerm,
+    shiftBitsTerm,
+    ssymTerm,
+    xorBitsTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalAndBitsTerm,
+    pevalComplementBitsTerm,
+    pevalOrBitsTerm,
+    pevalRotateBitsTerm,
+    pevalShiftBitsTerm,
+    pevalXorBitsTerm,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 bitsTests :: TestTree
 bitsTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/BoolTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BoolTests.hs
@@ -4,13 +4,31 @@
 
 module Grisette.IR.SymPrim.Data.Prim.BoolTests (boolTests) where
 
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( andTerm,
+    conTerm,
+    eqvTerm,
+    notTerm,
+    orTerm,
+    ssymTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalAndTerm,
+    pevalEqvTerm,
+    pevalITETerm,
+    pevalImplyTerm,
+    pevalNotEqvTerm,
+    pevalNotTerm,
+    pevalOrTerm,
+    pevalXorTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalAddNumTerm,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 boolTests :: TestTree
 boolTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/BoolTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/BoolTests.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Grisette.IR.SymPrim.Data.Prim.BoolTests where
+module Grisette.IR.SymPrim.Data.Prim.BoolTests (boolTests) where
 
 import Grisette.Core.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors

--- a/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
@@ -5,16 +5,39 @@
 
 module Grisette.IR.SymPrim.Data.Prim.IntegralTests (integralTests) where
 
-import Control.DeepSeq
-import Control.Exception
-import Data.Proxy
-import Grisette.Core.Data.BV
+import Control.DeepSeq (NFData (rnf), force)
+import Control.Exception (ArithException, catch, evaluate)
+import Data.Proxy (Proxy (Proxy))
+import Grisette.Core.Data.BV (IntN (IntN), WordN (WordN))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( conTerm,
+    divBoundedIntegralTerm,
+    divIntegralTerm,
+    modIntegralTerm,
+    quotBoundedIntegralTerm,
+    quotIntegralTerm,
+    remIntegralTerm,
+    ssymTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( SupportedPrim,
+    Term,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Integral
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalDivBoundedIntegralTerm,
+    pevalDivIntegralTerm,
+    pevalModIntegralTerm,
+    pevalQuotBoundedIntegralTerm,
+    pevalQuotIntegralTerm,
+    pevalRemIntegralTerm,
+  )
+import Test.Tasty (TestName, TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 import Test.Tasty.QuickCheck
+  ( Arbitrary,
+    ioProperty,
+    testProperty,
+  )
 
 newtype AEWrapper = AEWrapper ArithException deriving (Eq)
 

--- a/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
@@ -34,22 +34,21 @@ sameDivPeval ::
   (Term t -> Term t -> Term t) ->
   IO ()
 sameDivPeval i j pf cf consf = do
-  cx <- evaluate (force $ Right $ cf i j) `catch` \(e :: ArithException) -> return $ Left AEWrapper
+  cx <- evaluate (force $ Right $ cf i j) `catch` \(_ :: ArithException) -> return $ Left AEWrapper
   case cx of
-    Left f -> pf (conTerm i) (conTerm j) @=? consf (conTerm i) (conTerm j)
+    Left _ -> pf (conTerm i) (conTerm j) @=? consf (conTerm i) (conTerm j)
     Right t -> pf (conTerm i) (conTerm j) @=? conTerm t
 
 divisionPevalBoundedTests ::
-  forall p t0 t.
-  (Num t, Eq t, Arbitrary t0, Show t0, Bounded t, SupportedPrim t, Integral t) =>
+  forall p t.
+  (Num t, Eq t, Bounded t, SupportedPrim t, Integral t) =>
   p t ->
   TestName ->
-  (t0 -> t) ->
   (Term t -> Term t -> Term t) ->
   (t -> t -> t) ->
   (Term t -> Term t -> Term t) ->
   TestTree
-divisionPevalBoundedTests _ name transform pf cf consf =
+divisionPevalBoundedTests _ name pf cf consf =
   testGroup
     name
     [ testCase "On concrete min divide by -1" $
@@ -66,7 +65,7 @@ divisionPevalTests ::
   (t -> t -> t) ->
   (Term t -> Term t -> Term t) ->
   TestTree
-divisionPevalTests p name transform pf cf consf =
+divisionPevalTests _ name transform pf cf consf =
   testGroup
     name
     [ testProperty "On concrete prop" $
@@ -95,7 +94,7 @@ divisionPevalBoundedTestGroup name pf cf consf =
   testGroup
     name
     [ divisionPevalTests (Proxy @(IntN 4)) "IntN" IntN pf cf consf,
-      divisionPevalBoundedTests (Proxy @(IntN 4)) "IntN Bounded" IntN pf cf consf
+      divisionPevalBoundedTests (Proxy @(IntN 4)) "IntN Bounded" pf cf consf
     ]
 
 divisionPevalUnboundedTestGroup ::
@@ -109,7 +108,7 @@ divisionPevalUnboundedTestGroup name pf cf consf =
     name
     [ divisionPevalTests (Proxy @Integer) "Integer" id pf cf consf,
       divisionPevalTests (Proxy @(WordN 4)) "WordN" WordN pf cf consf,
-      divisionPevalBoundedTests (Proxy @(WordN 4)) "WordN Bounded" WordN pf cf consf
+      divisionPevalBoundedTests (Proxy @(WordN 4)) "WordN Bounded" pf cf consf
     ]
 
 moduloPevalTests ::
@@ -122,7 +121,7 @@ moduloPevalTests ::
   (t -> t -> t) ->
   (Term t -> Term t -> Term t) ->
   TestTree
-moduloPevalTests p name transform pf cf consf =
+moduloPevalTests _ name transform pf cf consf =
   testGroup
     name
     [ testProperty "On concrete" $

--- a/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/IntegralTests.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Grisette.IR.SymPrim.Data.Prim.IntegralTests where
+module Grisette.IR.SymPrim.Data.Prim.IntegralTests (integralTests) where
 
 import Control.DeepSeq
 import Control.Exception

--- a/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
@@ -3,18 +3,48 @@
 
 module Grisette.IR.SymPrim.Data.Prim.ModelTests (modelTests) where
 
-import Data.HashMap.Strict as M
+import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.ModelOps
+  ( ModelOps
+      ( emptyModel,
+        exact,
+        exceptFor,
+        extendTo,
+        insertValue,
+        restrictTo,
+        valueOf
+      ),
+    ModelRep (buildModel),
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
+  ( conTerm,
+    ssymTerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
-import Grisette.IR.SymPrim.Data.Prim.Model as Model
-import Grisette.IR.SymPrim.Data.Prim.ModelValue
+  ( Term,
+    TypedSymbol (SimpleSymbol),
+    someTypedSymbol,
+  )
+import Grisette.IR.SymPrim.Data.Prim.Model
+  ( Model (Model),
+    ModelValuePair ((::=)),
+    SymbolSet (SymbolSet),
+    equation,
+    evaluateTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.ModelValue (toModelValue)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalEqvTerm,
+    pevalITETerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalAddNumTerm,
+    pevalUMinusNumTerm,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 modelTests :: TestTree
 modelTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Grisette.IR.SymPrim.Data.Prim.ModelTests where
+module Grisette.IR.SymPrim.Data.Prim.ModelTests (modelTests) where
 
 import Data.HashMap.Strict as M
 import qualified Data.HashSet as S

--- a/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/ModelTests.hs
@@ -15,7 +15,6 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
 import Test.Tasty
 import Test.Tasty.HUnit
-import Type.Reflection
 
 modelTests :: TestTree
 modelTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Grisette.IR.SymPrim.Data.Prim.NumTests where
+module Grisette.IR.SymPrim.Data.Prim.NumTests (numTests) where
 
 import Grisette.Core.Data.BV
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors

--- a/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
@@ -3,13 +3,36 @@
 
 module Grisette.IR.SymPrim.Data.Prim.NumTests (numTests) where
 
-import Grisette.Core.Data.BV
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( absNumTerm,
+    addNumTerm,
+    conTerm,
+    leNumTerm,
+    ltNumTerm,
+    signumNumTerm,
+    ssymTerm,
+    timesNumTerm,
+    uminusNumTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalITETerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( pevalAbsNumTerm,
+    pevalAddNumTerm,
+    pevalGeNumTerm,
+    pevalGtNumTerm,
+    pevalLeNumTerm,
+    pevalLtNumTerm,
+    pevalMinusNumTerm,
+    pevalSignumNumTerm,
+    pevalTimesNumTerm,
+    pevalUMinusNumTerm,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 numTests :: TestTree
 numTests =

--- a/test/Grisette/IR/SymPrim/Data/Prim/TabularFunTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/TabularFunTests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Grisette.IR.SymPrim.Data.Prim.TabularFunTests where
+module Grisette.IR.SymPrim.Data.Prim.TabularFunTests (tabularFunTests) where
 
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term

--- a/test/Grisette/IR/SymPrim/Data/Prim/TabularFunTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/TabularFunTests.hs
@@ -4,12 +4,23 @@
 module Grisette.IR.SymPrim.Data.Prim.TabularFunTests (tabularFunTests) where
 
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
-import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
+  ( conTerm,
+    ssymTerm,
+    tabularFunApplyTerm,
+  )
+import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (Term)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool
+  ( pevalEqvTerm,
+    pevalITETerm,
+  )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
+  ( pevalTabularFunApplyTerm,
+  )
 import Grisette.IR.SymPrim.Data.TabularFun
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( type (=->) (TabularFun),
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 tabularFunTests :: TestTree
 tabularFunTests =

--- a/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Grisette.IR.SymPrim.Data.SymPrimTests where
+module Grisette.IR.SymPrim.Data.SymPrimTests (symPrimTests) where
 
 import Control.DeepSeq
 import Control.Exception

--- a/test/Grisette/IR/SymPrim/Data/TabularFunTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/TabularFunTests.hs
@@ -3,10 +3,12 @@
 
 module Grisette.IR.SymPrim.Data.TabularFunTests (tabularFunTests) where
 
-import Grisette.Core.Data.Class.Function
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Grisette.IR.SymPrim.Data.TabularFun
-import Test.Tasty
-import Test.Tasty.HUnit
+  ( type (=->) (TabularFun),
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 tabularFunTests :: TestTree
 tabularFunTests =

--- a/test/Grisette/IR/SymPrim/Data/TabularFunTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/TabularFunTests.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
-module Grisette.IR.SymPrim.Data.TabularFunTests where
+module Grisette.IR.SymPrim.Data.TabularFunTests (tabularFunTests) where
 
 import Grisette.Core.Data.Class.Function
 import Grisette.IR.SymPrim.Data.TabularFun

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -22,28 +22,42 @@ import Grisette.Lib.Data.FoldableTests
 import Grisette.Lib.Data.TraversableTests
 -}
 
-import Grisette.Backend.SBV.Data.SMT.CEGISTests
+import Grisette.Backend.SBV.Data.SMT.CEGISTests (cegisTests)
 import Grisette.Backend.SBV.Data.SMT.LoweringTests
+  ( loweringTests,
+  )
 import Grisette.Backend.SBV.Data.SMT.TermRewritingTests
-import Grisette.Core.Control.Monad.UnionMTests
+  ( termRewritingTests,
+  )
+import Grisette.Core.Control.Monad.UnionMTests (unionMTests)
 import qualified Grisette.Core.Data.BVTests
-import Grisette.Core.Data.Class.GPrettyTests
+import Grisette.Core.Data.Class.GPrettyTests (gprettyTests)
 import qualified Grisette.IR.SymPrim.Data.Prim.BVTests
-import Grisette.IR.SymPrim.Data.Prim.BitsTests
-import Grisette.IR.SymPrim.Data.Prim.BoolTests
+import Grisette.IR.SymPrim.Data.Prim.BitsTests (bitsTests)
+import Grisette.IR.SymPrim.Data.Prim.BoolTests (boolTests)
 import Grisette.IR.SymPrim.Data.Prim.IntegralTests
-import Grisette.IR.SymPrim.Data.Prim.ModelTests
-import Grisette.IR.SymPrim.Data.Prim.NumTests
+  ( integralTests,
+  )
+import Grisette.IR.SymPrim.Data.Prim.ModelTests (modelTests)
+import Grisette.IR.SymPrim.Data.Prim.NumTests (numTests)
 import qualified Grisette.IR.SymPrim.Data.Prim.TabularFunTests
-import Grisette.IR.SymPrim.Data.SymPrimTests
+import Grisette.IR.SymPrim.Data.SymPrimTests (symPrimTests)
 import qualified Grisette.IR.SymPrim.Data.TabularFunTests
 import Test.Tasty
-import Test.Tasty.Ingredients
+  ( TestTree,
+    defaultMainWithIngredients,
+    testGroup,
+  )
+import Test.Tasty.Ingredients (composeReporters)
 import qualified Test.Tasty.Ingredients.ConsoleReporter as ConsoleReporter
 import qualified Test.Tasty.Runners.Reporter as Reporter
 
 main :: IO ()
-main = defaultMainWithIngredients [composeReporters Reporter.ingredient ConsoleReporter.consoleTestReporter] tests
+main =
+  defaultMainWithIngredients
+    [ composeReporters Reporter.ingredient ConsoleReporter.consoleTestReporter
+    ]
+    tests
 
 tests :: TestTree
 tests =

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,4 @@
-module Main where
+module Main (main) where
 
 {-
 import Grisette.Core.Control.ExceptionTests


### PR DESCRIPTION
This pull request adds some warning flags and fixed all the warnings.

The flags added are:

- `-Wextra`
- `-Werror`
- `-Wcompat`
- `-Widentities`
- `-Wincomplete-record-updates`
- `-Wmissing-export-lists`
- `-Wmissing-home-modules`
- `-Wmissing-import-lists`
- `-Wpartial-fields`
- `-Wunused-type-patterns`

Tried to add the following flag, but it is blocked by a Cabal bug that is fixed recently (but not in older stackage LTS snapshot versions) (see https://github.com/haskell/cabal/pull/7352).
- `-Wprepositive-qualified-module`