### PR TITLE
Rename the Union constructors and patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Reorganized the files for `MonadTrans`. ([#132](https://github.com/lsrcz/grisette/pull/132))
+- [Breaking] Changed the name of `Union` constructors and patterns. ([#133](https://github.com/lsrcz/grisette/pull/133))
+- The `Union` patterns, when used as constructors, now merges the result. ([#133](https://github.com/lsrcz/grisette/pull/133))
 
 ## [0.3.1.1] -- 2023-09-29
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -600,8 +600,8 @@ module Grisette.Core
     merge,
     mrgSingle,
     UnionPrjOp (..),
-    pattern SingleU,
-    pattern IfU,
+    pattern Single,
+    pattern If,
     MonadUnion,
     MonadParallelUnion (..),
     simpleMerge,
@@ -1165,8 +1165,8 @@ import Grisette.Core.Data.Class.SimpleMergeable
     onUnion3,
     onUnion4,
     simpleMerge,
-    pattern IfU,
-    pattern SingleU,
+    pattern If,
+    pattern Single,
   )
 import Grisette.Core.Data.Class.Solvable (Solvable (..), pattern Con)
 import Grisette.Core.Data.Class.Solver

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -35,8 +35,8 @@ module Grisette.Core.Data.Class.SimpleMergeable
     merge,
     mrgSingle,
     UnionPrjOp (..),
-    pattern SingleU,
-    pattern IfU,
+    pattern Single,
+    pattern If,
     simpleMerge,
     onUnion,
     onUnion2,
@@ -719,22 +719,22 @@ class (UnionLike u) => UnionPrjOp (u :: Type -> Type) where
 
 -- | Pattern match to extract single values with 'singleView'.
 --
--- >>> case (single 1 :: UnionM Integer) of SingleU v -> v
+-- >>> case (single 1 :: UnionM Integer) of Single v -> v
 -- 1
-pattern SingleU :: (UnionPrjOp u) => a -> u a
-pattern SingleU x <-
+pattern Single :: (UnionPrjOp u, Mergeable a) => a -> u a
+pattern Single x <-
   (singleView -> Just x)
   where
-    SingleU x = single x
+    Single x = mrgSingle x
 
 -- | Pattern match to extract guard values with 'ifView'
--- >>> case (unionIf "a" (single 1) (single 2) :: UnionM Integer) of IfU c t f -> (c,t,f)
+-- >>> case (unionIf "a" (single 1) (single 2) :: UnionM Integer) of If c t f -> (c,t,f)
 -- (a,<1>,<2>)
-pattern IfU :: (UnionPrjOp u) => SymBool -> u a -> u a -> u a
-pattern IfU c t f <-
+pattern If :: (UnionPrjOp u, Mergeable a) => SymBool -> u a -> u a -> u a
+pattern If c t f <-
   (ifView -> Just (c, t, f))
   where
-    IfU c t f = unionIf c t f
+    If c t f = unionIf c t f
 
 -- | Merge the simply mergeable values in a union, and extract the merged value.
 --
@@ -747,7 +747,7 @@ pattern IfU c t f <-
 -- (ite a b c)
 simpleMerge :: forall u a. (SimpleMergeable a, UnionLike u, UnionPrjOp u) => u a -> a
 simpleMerge u = case merge u of
-  SingleU x -> x
+  Single x -> x
   _ -> error "Should not happen"
 {-# INLINE simpleMerge #-}
 

--- a/src/Grisette/Core/Data/Union.hs
+++ b/src/Grisette/Core/Data/Union.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -52,7 +53,13 @@ import Grisette.Core.Data.Class.Mergeable
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
     SimpleMergeable1 (liftMrgIte),
-    UnionLike (mergeWithStrategy, mrgIfWithStrategy, mrgSingleWithStrategy, single, unionIf),
+    UnionLike
+      ( mergeWithStrategy,
+        mrgIfWithStrategy,
+        mrgSingleWithStrategy,
+        single,
+        unionIf
+      ),
     UnionPrjOp (ifView, leftMost, singleView),
     mrgIf,
   )
@@ -73,9 +80,9 @@ import Data.Text.Prettyprint.Doc (align, group, nest, vsep)
 -- | The default union implementation.
 data Union a
   = -- | A single value
-    Single a
+    UnionSingle a
   | -- | A if value
-    If
+    UnionIf
       a
       -- ^ Cached leftmost value
       !Bool
@@ -89,8 +96,8 @@ data Union a
   deriving (Generic, Eq, Lift, Generic1)
 
 instance Eq1 Union where
-  liftEq e (Single a) (Single b) = e a b
-  liftEq e (If l1 i1 c1 t1 f1) (If l2 i2 c2 t2 f2) =
+  liftEq e (UnionSingle a) (UnionSingle b) = e a b
+  liftEq e (UnionIf l1 i1 c1 t1 f1) (UnionIf l2 i2 c2 t2 f2) =
     e l1 l2 && i1 == i2 && c1 == c2 && liftEq e t1 t2 && liftEq e f1 f2
   liftEq _ _ _ = False
 
@@ -98,28 +105,34 @@ instance (NFData a) => NFData (Union a) where
   rnf = rnf1
 
 instance NFData1 Union where
-  liftRnf _a (Single a) = _a a
-  liftRnf _a (If a bo b l r) = _a a `seq` rnf bo `seq` rnf b `seq` liftRnf _a l `seq` liftRnf _a r
+  liftRnf _a (UnionSingle a) = _a a
+  liftRnf _a (UnionIf a bo b l r) =
+    _a a `seq`
+      rnf bo `seq`
+        rnf b `seq`
+          liftRnf _a l `seq`
+            liftRnf _a r
 
--- | Build 'If' with leftmost cache correctly maintained.
+-- | Build 'UnionIf' with leftmost cache correctly maintained.
 --
--- Usually you should never directly try to build a 'If' with its constructor.
+-- Usually you should never directly try to build a 'UnionIf' with its
+-- constructor.
 ifWithLeftMost :: Bool -> SymBool -> Union a -> Union a -> Union a
 ifWithLeftMost _ (Con c) t f
   | c = t
   | otherwise = f
-ifWithLeftMost inv cond t f = If (leftMost t) inv cond t f
+ifWithLeftMost inv cond t f = UnionIf (leftMost t) inv cond t f
 {-# INLINE ifWithLeftMost #-}
 
 instance UnionPrjOp Union where
-  singleView (Single a) = Just a
+  singleView (UnionSingle a) = Just a
   singleView _ = Nothing
   {-# INLINE singleView #-}
-  ifView (If _ _ cond ifTrue ifFalse) = Just (cond, ifTrue, ifFalse)
+  ifView (UnionIf _ _ cond ifTrue ifFalse) = Just (cond, ifTrue, ifFalse)
   ifView _ = Nothing
   {-# INLINE ifView #-}
-  leftMost (Single a) = a
-  leftMost (If a _ _ _ _) = a
+  leftMost (UnionSingle a) = a
+  leftMost (UnionIf a _ _ _ _) = a
   {-# INLINE leftMost #-}
 
 instance (Mergeable a) => Mergeable (Union a) where
@@ -139,20 +152,26 @@ instance SimpleMergeable1 Union where
 instance UnionLike Union where
   mergeWithStrategy = fullReconstruct
   {-# INLINE mergeWithStrategy #-}
-  single = Single
+  single = UnionSingle
   {-# INLINE single #-}
   unionIf = ifWithLeftMost False
   {-# INLINE unionIf #-}
   mrgIfWithStrategy = ifWithStrategy
   {-# INLINE mrgIfWithStrategy #-}
-  mrgSingleWithStrategy _ = Single
+  mrgSingleWithStrategy _ = UnionSingle
   {-# INLINE mrgSingleWithStrategy #-}
 
 instance Show1 Union where
-  liftShowsPrec sp _ i (Single a) = showsUnaryWith sp "Single" i a
-  liftShowsPrec sp sl i (If _ _ cond t f) =
+  liftShowsPrec sp _ i (UnionSingle a) = showsUnaryWith sp "Single" i a
+  liftShowsPrec sp sl i (UnionIf _ _ cond t f) =
     showParen (i > 10) $
-      showString "If" . showChar ' ' . showsPrec 11 cond . showChar ' ' . sp1 11 t . showChar ' ' . sp1 11 f
+      showString "If"
+        . showChar ' '
+        . showsPrec 11 cond
+        . showChar ' '
+        . sp1 11 t
+        . showChar ' '
+        . sp1 11 f
     where
       sp1 = liftShowsPrec sp sl
 
@@ -160,8 +179,8 @@ instance (Show a) => Show (Union a) where
   showsPrec = showsPrec1
 
 instance (GPretty a) => GPretty (Union a) where
-  gprettyPrec n (Single a) = gprettyPrec n a
-  gprettyPrec n (If _ _ cond t f) =
+  gprettyPrec n (UnionSingle a) = gprettyPrec n a
+  gprettyPrec n (UnionIf _ _ cond t f) =
     group $
       condEnclose (n > 10) "(" ")" $
         align $
@@ -174,21 +193,31 @@ instance (GPretty a) => GPretty (Union a) where
               ]
 
 instance (Hashable a) => Hashable (Union a) where
-  s `hashWithSalt` (Single a) = s `hashWithSalt` (0 :: Int) `hashWithSalt` a
-  s `hashWithSalt` (If _ _ c l r) = s `hashWithSalt` (1 :: Int) `hashWithSalt` c `hashWithSalt` l `hashWithSalt` r
+  s `hashWithSalt` (UnionSingle a) =
+    s `hashWithSalt` (0 :: Int) `hashWithSalt` a
+  s `hashWithSalt` (UnionIf _ _ c l r) =
+    s
+      `hashWithSalt` (1 :: Int)
+      `hashWithSalt` c
+      `hashWithSalt` l
+      `hashWithSalt` r
 
 instance (AllSyms a) => AllSyms (Union a) where
-  allSymsS (Single v) = allSymsS v
-  allSymsS (If _ _ c t f) = \l -> SomeSym c : (allSymsS t . allSymsS f $ l)
+  allSymsS (UnionSingle v) = allSymsS v
+  allSymsS (UnionIf _ _ c t f) = \l -> SomeSym c : (allSymsS t . allSymsS f $ l)
 
 -- | Fully reconstruct a 'Union' to maintain the merged invariant.
 fullReconstruct :: MergingStrategy a -> Union a -> Union a
-fullReconstruct strategy (If _ False cond t f) =
-  ifWithStrategyInv strategy cond (fullReconstruct strategy t) (fullReconstruct strategy f)
+fullReconstruct strategy (UnionIf _ False cond t f) =
+  ifWithStrategyInv
+    strategy
+    cond
+    (fullReconstruct strategy t)
+    (fullReconstruct strategy f)
 fullReconstruct _ u = u
 {-# INLINE fullReconstruct #-}
 
--- | Use a specific strategy to build a 'If' value.
+-- | Use a specific strategy to build a 'UnionIf' value.
 --
 -- The merged invariant will be maintained in the result.
 ifWithStrategy ::
@@ -197,8 +226,10 @@ ifWithStrategy ::
   Union a ->
   Union a ->
   Union a
-ifWithStrategy strategy cond t@(If _ False _ _ _) f = ifWithStrategy strategy cond (fullReconstruct strategy t) f
-ifWithStrategy strategy cond t f@(If _ False _ _ _) = ifWithStrategy strategy cond t (fullReconstruct strategy f)
+ifWithStrategy strategy cond t@(UnionIf _ False _ _ _) f =
+  ifWithStrategy strategy cond (fullReconstruct strategy t) f
+ifWithStrategy strategy cond t f@(UnionIf _ False _ _ _) =
+  ifWithStrategy strategy cond t (fullReconstruct strategy f)
 ifWithStrategy strategy cond t f = ifWithStrategyInv strategy cond t f
 {-# INLINE ifWithStrategy #-}
 
@@ -211,29 +242,29 @@ ifWithStrategyInv ::
 ifWithStrategyInv _ (Con v) t f
   | v = t
   | otherwise = f
-ifWithStrategyInv strategy cond (If _ True condTrue tt _) f
+ifWithStrategyInv strategy cond (UnionIf _ True condTrue tt _) f
   | cond == condTrue = ifWithStrategyInv strategy cond tt f
 -- {| nots cond == condTrue || cond == nots condTrue = ifWithStrategyInv strategy cond ft f
-ifWithStrategyInv strategy cond t (If _ True condFalse _ ff)
+ifWithStrategyInv strategy cond t (UnionIf _ True condFalse _ ff)
   | cond == condFalse = ifWithStrategyInv strategy cond t ff
 -- {| nots cond == condTrue || cond == nots condTrue = ifWithStrategyInv strategy cond t tf -- buggy here condTrue
-ifWithStrategyInv (SimpleStrategy m) cond (Single l) (Single r) = Single $ m cond l r
+ifWithStrategyInv (SimpleStrategy m) cond (UnionSingle l) (UnionSingle r) = UnionSingle $ m cond l r
 ifWithStrategyInv strategy@(SortedStrategy idxFun substrategy) cond ifTrue ifFalse = case (ifTrue, ifFalse) of
-  (Single _, Single _) -> ssIf cond ifTrue ifFalse
-  (Single _, If {}) -> sgIf cond ifTrue ifFalse
-  (If {}, Single _) -> gsIf cond ifTrue ifFalse
-  _ -> ggIf cond ifTrue ifFalse
+  (UnionSingle _, UnionSingle _) -> ssUnionIf cond ifTrue ifFalse
+  (UnionSingle _, UnionIf {}) -> sgUnionIf cond ifTrue ifFalse
+  (UnionIf {}, UnionSingle _) -> gsUnionIf cond ifTrue ifFalse
+  _ -> ggUnionIf cond ifTrue ifFalse
   where
-    ssIf cond' ifTrue' ifFalse'
+    ssUnionIf cond' ifTrue' ifFalse'
       | idxt < idxf = ifWithLeftMost True cond' ifTrue' ifFalse'
       | idxt == idxf = ifWithStrategyInv (substrategy idxt) cond' ifTrue' ifFalse'
       | otherwise = ifWithLeftMost True (nots cond') ifFalse' ifTrue'
       where
         idxt = idxFun $ leftMost ifTrue'
         idxf = idxFun $ leftMost ifFalse'
-    {-# INLINE ssIf #-}
-    sgIf cond' ifTrue' ifFalse'@(If _ True condf ft ff)
-      | idxft == idxff = ssIf cond' ifTrue' ifFalse'
+    {-# INLINE ssUnionIf #-}
+    sgUnionIf cond' ifTrue' ifFalse'@(UnionIf _ True condf ft ff)
+      | idxft == idxff = ssUnionIf cond' ifTrue' ifFalse'
       | idxt < idxft = ifWithLeftMost True cond' ifTrue' ifFalse'
       | idxt == idxft = ifWithLeftMost True (cond' ||~ condf) (ifWithStrategyInv (substrategy idxt) cond' ifTrue' ft) ff
       | otherwise = ifWithLeftMost True (nots cond' &&~ condf) ft (ifWithStrategyInv strategy cond' ifTrue' ff)
@@ -241,10 +272,10 @@ ifWithStrategyInv strategy@(SortedStrategy idxFun substrategy) cond ifTrue ifFal
         idxft = idxFun $ leftMost ft
         idxff = idxFun $ leftMost ff
         idxt = idxFun $ leftMost ifTrue'
-    sgIf _ _ _ = undefined
-    {-# INLINE sgIf #-}
-    gsIf cond' ifTrue'@(If _ True condt tt tf) ifFalse'
-      | idxtt == idxtf = ssIf cond' ifTrue' ifFalse'
+    sgUnionIf _ _ _ = undefined
+    {-# INLINE sgUnionIf #-}
+    gsUnionIf cond' ifTrue'@(UnionIf _ True condt tt tf) ifFalse'
+      | idxtt == idxtf = ssUnionIf cond' ifTrue' ifFalse'
       | idxtt < idxf = ifWithLeftMost True (cond' &&~ condt) tt $ ifWithStrategyInv strategy cond' tf ifFalse'
       | idxtt == idxf = ifWithLeftMost True (nots cond' ||~ condt) (ifWithStrategyInv (substrategy idxf) cond' tt ifFalse') tf
       | otherwise = ifWithLeftMost True (nots cond') ifFalse' ifTrue'
@@ -252,25 +283,25 @@ ifWithStrategyInv strategy@(SortedStrategy idxFun substrategy) cond ifTrue ifFal
         idxtt = idxFun $ leftMost tt
         idxtf = idxFun $ leftMost tf
         idxf = idxFun $ leftMost ifFalse'
-    gsIf _ _ _ = undefined
-    {-# INLINE gsIf #-}
-    ggIf cond' ifTrue'@(If _ True condt tt tf) ifFalse'@(If _ True condf ft ff)
-      | idxtt == idxtf = sgIf cond' ifTrue' ifFalse'
-      | idxft == idxff = gsIf cond' ifTrue' ifFalse'
+    gsUnionIf _ _ _ = undefined
+    {-# INLINE gsUnionIf #-}
+    ggUnionIf cond' ifTrue'@(UnionIf _ True condt tt tf) ifFalse'@(UnionIf _ True condf ft ff)
+      | idxtt == idxtf = sgUnionIf cond' ifTrue' ifFalse'
+      | idxft == idxff = gsUnionIf cond' ifTrue' ifFalse'
       | idxtt < idxft = ifWithLeftMost True (cond' &&~ condt) tt $ ifWithStrategyInv strategy cond' tf ifFalse'
       | idxtt == idxft =
           let newCond = ites cond' condt condf
-              newIfTrue = ifWithStrategyInv (substrategy idxtt) cond' tt ft
-              newIfFalse = ifWithStrategyInv strategy cond' tf ff
-           in ifWithLeftMost True newCond newIfTrue newIfFalse
+              newUnionIfTrue = ifWithStrategyInv (substrategy idxtt) cond' tt ft
+              newUnionIfFalse = ifWithStrategyInv strategy cond' tf ff
+           in ifWithLeftMost True newCond newUnionIfTrue newUnionIfFalse
       | otherwise = ifWithLeftMost True (nots cond' &&~ condf) ft $ ifWithStrategyInv strategy cond' ifTrue' ff
       where
         idxtt = idxFun $ leftMost tt
         idxtf = idxFun $ leftMost tf
         idxft = idxFun $ leftMost ft
         idxff = idxFun $ leftMost ff
-    ggIf _ _ _ = undefined
-    {-# INLINE ggIf #-}
+    ggUnionIf _ _ _ = undefined
+    {-# INLINE ggUnionIf #-}
 ifWithStrategyInv NoStrategy cond ifTrue ifFalse = ifWithLeftMost True cond ifTrue ifFalse
 ifWithStrategyInv _ _ _ _ = error "Invariant violated"
 {-# INLINE ifWithStrategyInv #-}


### PR DESCRIPTION
This is a breaking change.

- `If` and `Single` are now `UnionIf` and `UnionSingle`.
- `IfU` and `SingleU` are now `If` and `Single`.
- The `If` and `Single`, when used as constructors, now merges the result.