### PR TITLE
Change the name of the optimization flag to avoid confusion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,11 +155,11 @@ jobs:
           set -ex
           case "$BUILD" in
             stack)
-              nix develop --allow-dirty --no-warn-dirty -c stack --no-terminal $ARGS test --fast --flag grisette:-fast --bench --no-run-benchmarks --coverage --haddock --no-haddock-deps --test-arguments "--jxml=test-report.xml"
+              nix develop --allow-dirty --no-warn-dirty -c stack --no-terminal $ARGS test --fast --flag grisette:-optimize --bench --no-run-benchmarks --coverage --haddock --no-haddock-deps --test-arguments "--jxml=test-report.xml"
               ;;
             cabal)
               nix develop --allow-dirty --no-warn-dirty -c cabal update
-              nix develop --allow-dirty --no-warn-dirty -c cabal run --disable-optimization --flags=-fast spec $ARGS -- --jxml=test-report.xml
+              nix develop --allow-dirty --no-warn-dirty -c cabal run --disable-optimization --flags=-optimize spec $ARGS -- --jxml=test-report.xml
               ;;
           esac
           set +ex

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -38,7 +38,7 @@ source-repository head
   type: git
   location: https://github.com/lsrcz/grisette
 
-flag fast
+flag optimize
   description: Compile with O2 optimization
   manual: False
   default: True
@@ -152,7 +152,7 @@ library
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
   default-language: Haskell2010
-  if flag(fast)
+  if flag(optimize)
     ghc-options: -O2
   else
     ghc-options: -O0
@@ -189,7 +189,7 @@ test-suite doctest
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
   default-language: Haskell2010
-  if flag(fast)
+  if flag(optimize)
     ghc-options: -O2
   else
     ghc-options: -O0
@@ -269,7 +269,7 @@ test-suite spec
     , transformers >=0.5.6 && <0.7
     , unordered-containers >=0.2.11 && <0.3
   default-language: Haskell2010
-  if flag(fast)
+  if flag(optimize)
     ghc-options: -O2
   else
     ghc-options: -O0

--- a/package.yaml
+++ b/package.yaml
@@ -50,7 +50,7 @@ dependencies:
 
 flags:
   {
-    fast:
+    optimize:
       {
         description: "Compile with O2 optimization",
         manual: False,
@@ -59,7 +59,7 @@ flags:
   }
 
 when:
-  - condition: flag(fast)
+  - condition: flag(optimize)
     then:
       ghc-options: -O2
     else:


### PR DESCRIPTION
This pull request changes the name of the optimization flag from fast to optimize as stack has a flag `--fast` for disabling optimizations.