### PR TITLE
Export the BVSignConversion type

### DIFF
--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -187,6 +187,7 @@ module Grisette.Core
     bvExtract,
     SizedBV (..),
     sizedBVExtract,
+    BVSignConversion (..),
     SafeDivision (..),
     SafeLinearArith (..),
     SymIntegerOp,
@@ -1053,6 +1054,7 @@ import Grisette.Core.Control.Monad.UnionM
   )
 import Grisette.Core.Data.Class.BitVector
   ( BV (..),
+    BVSignConversion (..),
     SizedBV (..),
     bvExtract,
     sizedBVExtract,


### PR DESCRIPTION
This pull request exports the `BVSignConversion` type class and its functions in `Grisette` package. Fixes #106.