### PR TITLE
Add mrgRunFreshT.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added wrappers for state transformers. ([#132](https://github.com/lsrcz/grisette/pull/132))
 - Added `toGuardList` function. ([#137](https://github.com/lsrcz/grisette/pull/137))
 - Exported some previously hidden API (`BVSignConversion`, `runFreshTFromIndex`) that we found useful or forgot to export. ([#138](https://github.com/lsrcz/grisette/pull/138), [#139](https://github.com/lsrcz/grisette/pull/139))
+- Provided `mrgRunFreshT` to run `FreshT` with merging. ([#140](https://github.com/lsrcz/grisette/pull/140))
 
 ### Removed
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -716,6 +716,7 @@ module Grisette.Core
     FreshT (..),
     runFresh,
     runFreshT,
+    mrgRunFreshT,
 
     -- ** Symbolic Generation Class
     GenSym (..),
@@ -1116,6 +1117,7 @@ import Grisette.Core.Data.Class.GenSym
     derivedSameShapeSimpleFresh,
     genSym,
     genSymSimple,
+    mrgRunFreshT,
     name,
     nameWithInfo,
     runFresh,

--- a/src/Grisette/Core/Data/Class/GenSym.hs
+++ b/src/Grisette/Core/Data/Class/GenSym.hs
@@ -40,6 +40,7 @@ module Grisette.Core.Data.Class.GenSym
     Fresh,
     runFreshT,
     runFresh,
+    mrgRunFreshT,
 
     -- * Symbolic value generation
     GenSym (..),
@@ -333,6 +334,13 @@ instance
 -- | Run the symbolic generation with the given identifier and 0 as the initial index.
 runFreshT :: (Monad m) => FreshT m a -> FreshIdent -> m a
 runFreshT m ident = fst <$> runFreshTFromIndex m ident (FreshIndex 0)
+
+mrgRunFreshT ::
+  (Monad m, UnionLike m, Mergeable a) =>
+  FreshT m a ->
+  FreshIdent ->
+  m a
+mrgRunFreshT m ident = merge $ runFreshT m ident
 
 instance (Functor f) => Functor (FreshT f) where
   fmap f (FreshT s) = FreshT $ \ident idx -> first f <$> s ident idx


### PR DESCRIPTION
This pull request resolves #109. Instead of making `runFreshT` merge the results, we instead provide another `mrgRunFreshT` function, which is in line with the APIs for other monad transformers.