### PR TITLE
Changed BVSignConversion to SignConversion, add instances to it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `toGuardList` function. ([#137](https://github.com/lsrcz/grisette/pull/137))
 - Exported some previously hidden API (`BVSignConversion`, `runFreshTFromIndex`) that we found useful or forgot to export. ([#138](https://github.com/lsrcz/grisette/pull/138), [#139](https://github.com/lsrcz/grisette/pull/139))
 - Provided `mrgRunFreshT` to run `FreshT` with merging. ([#140](https://github.com/lsrcz/grisette/pull/140))
+- Added `Grisette.Data.Class.SignConversion.SignConversion` for types from `Data.Int` and `Data.Word`. ([#142](https://github.com/lsrcz/grisette/pull/142))
 
 ### Removed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Changed the name of `Union` constructors and patterns. ([#133](https://github.com/lsrcz/grisette/pull/133))
 - The `Union` patterns, when used as constructors, now merges the result. ([#133](https://github.com/lsrcz/grisette/pull/133))
 - Changed the symbolic identifier type from `String` to `Data.Text.Text`. ([#141](https://github.com/lsrcz/grisette/pull/141))
+- `Grisette.Data.Class.BitVector.BVSignConversion` is now `Grisette.Data.Class.SignConversion.SignConversion`. ([#142](https://github.com/lsrcz/grisette/pull/142))
 
 ## [0.3.1.1] -- 2023-09-29
 

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -70,6 +70,7 @@ library
       Grisette.Core.Data.Class.Mergeable
       Grisette.Core.Data.Class.ModelOps
       Grisette.Core.Data.Class.SafeArith
+      Grisette.Core.Data.Class.SignConversion
       Grisette.Core.Data.Class.SimpleMergeable
       Grisette.Core.Data.Class.Solvable
       Grisette.Core.Data.Class.Solver

--- a/src/Grisette/Backend/SBV/Data/SMT/Lowering.hs
+++ b/src/Grisette/Backend/SBV/Data/SMT/Lowering.hs
@@ -93,8 +93,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         BVConcatTerm,
         BVExtendTerm,
         BVSelectTerm,
-        BVToSignedTerm,
-        BVToUnsignedTerm,
         BinaryTerm,
         ComplementBitsTerm,
         ConTerm,
@@ -121,6 +119,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         TabularFunApplyTerm,
         TernaryTerm,
         TimesNumTerm,
+        ToSignedTerm,
+        ToUnsignedTerm,
         UMinusNumTerm,
         UnaryTerm,
         XorBitsTerm
@@ -783,22 +783,22 @@ lowerSinglePrimImpl config t@(RotateBitsTerm _ arg n) m =
   case (config, R.typeRep @a) of
     ResolvedBitsType -> lowerUnaryTerm config t arg (`rotate` n) m
     _ -> translateBinaryError "rotate" (R.typeRep @a) (R.typeRep @Int) (R.typeRep @a)
-lowerSinglePrimImpl config t@(BVToSignedTerm _ (bv :: Term x)) m =
+lowerSinglePrimImpl config t@(ToSignedTerm _ (bv :: Term x)) m =
   case (R.typeRep @a, R.typeRep @x) of
     (SignedBVType (_ :: Proxy na), UnsignedBVType (_ :: Proxy nx)) ->
       case R.eqTypeRep (R.typeRep @na) (R.typeRep @nx) of
         Just R.HRefl ->
           lowerUnaryTerm config t bv SBV.sFromIntegral m
-        _ -> translateUnaryError "bvu2s" (R.typeRep @x) (R.typeRep @a)
-    _ -> translateUnaryError "bvu2s" (R.typeRep @x) (R.typeRep @a)
-lowerSinglePrimImpl config t@(BVToUnsignedTerm _ (bv :: Term x)) m =
+        _ -> translateUnaryError "u2s" (R.typeRep @x) (R.typeRep @a)
+    _ -> translateUnaryError "u2s" (R.typeRep @x) (R.typeRep @a)
+lowerSinglePrimImpl config t@(ToUnsignedTerm _ (bv :: Term x)) m =
   case (R.typeRep @a, R.typeRep @x) of
     (UnsignedBVType (_ :: Proxy na), SignedBVType (_ :: Proxy nx)) ->
       case R.eqTypeRep (R.typeRep @na) (R.typeRep @nx) of
         Just R.HRefl ->
           lowerUnaryTerm config t bv SBV.sFromIntegral m
-        _ -> translateUnaryError "bvs2u" (R.typeRep @x) (R.typeRep @a)
-    _ -> translateUnaryError "bvs2u" (R.typeRep @x) (R.typeRep @a)
+        _ -> translateUnaryError "s2u" (R.typeRep @x) (R.typeRep @a)
+    _ -> translateUnaryError "s2u" (R.typeRep @x) (R.typeRep @a)
 lowerSinglePrimImpl config t@(BVConcatTerm _ (bv1 :: Term x) (bv2 :: Term y)) m =
   case (R.typeRep @a, R.typeRep @x, R.typeRep @y) of
     (UnsignedBVType (_ :: Proxy na), UnsignedBVType (_ :: Proxy nx), UnsignedBVType (_ :: Proxy ny)) ->

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -187,7 +187,7 @@ module Grisette.Core
     bvExtract,
     SizedBV (..),
     sizedBVExtract,
-    BVSignConversion (..),
+    SignConversion (..),
     SafeDivision (..),
     SafeLinearArith (..),
     SymIntegerOp,
@@ -1055,7 +1055,6 @@ import Grisette.Core.Control.Monad.UnionM
   )
 import Grisette.Core.Data.Class.BitVector
   ( BV (..),
-    BVSignConversion (..),
     SizedBV (..),
     bvExtract,
     sizedBVExtract,
@@ -1153,6 +1152,7 @@ import Grisette.Core.Data.Class.SafeArith
     SafeLinearArith (..),
     SymIntegerOp,
   )
+import Grisette.Core.Data.Class.SignConversion (SignConversion (..))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (..),
     SimpleMergeable1 (..),

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -108,8 +108,10 @@ import GHC.TypeNats
   )
 import Grisette.Core.Data.Class.BitVector
   ( BV (bvConcat, bvExt, bvSelect, bvSext, bvZext),
-    BVSignConversion (toSigned, toUnsigned),
     SizedBV (sizedBVConcat, sizedBVExt, sizedBVSelect, sizedBVSext, sizedBVZext),
+  )
+import Grisette.Core.Data.Class.SignConversion
+  ( SignConversion (toSigned, toUnsigned),
   )
 import Grisette.Utils.Parameterized
   ( KnownProof (KnownProof),
@@ -784,10 +786,10 @@ instance BV SomeIntN where
   bvSelect ix w = toSigned . bvSelect ix w . toUnsigned
   {-# INLINE bvSelect #-}
 
-instance (KnownNat n, 1 <= n) => BVSignConversion (WordN n) (IntN n) where
+instance (KnownNat n, 1 <= n) => SignConversion (WordN n) (IntN n) where
   toSigned (WordN i) = IntN i
   toUnsigned (IntN i) = WordN i
 
-instance BVSignConversion SomeWordN SomeIntN where
+instance SignConversion SomeWordN SomeIntN where
   toSigned (SomeWordN i) = SomeIntN $ toSigned i
   toUnsigned (SomeIntN i) = SomeWordN $ toUnsigned i

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
@@ -24,7 +23,6 @@ module Grisette.Core.Data.Class.BitVector
     bvExtract,
     SizedBV (..),
     sizedBVExtract,
-    BVSignConversion (..),
   )
 where
 
@@ -234,11 +232,3 @@ sizedBVExtract _ _ =
     (KnownProof, LeqProof, LeqProof) ->
       sizedBVSelect (Proxy @j) (Proxy @(i - j + 1))
 {-# INLINE sizedBVExtract #-}
-
--- | Convert bitvectors from and to signed
-class BVSignConversion ubv sbv | ubv -> sbv, sbv -> ubv where
-  -- | Convert unsigned bitvector to signed
-  toSigned :: ubv -> sbv
-
-  -- | Convert signed bitvector to unsigned
-  toUnsigned :: sbv -> ubv

--- a/src/Grisette/Core/Data/Class/SignConversion.hs
+++ b/src/Grisette/Core/Data/Class/SignConversion.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FunctionalDependencies #-}
+
+module Grisette.Core.Data.Class.SignConversion
+  ( SignConversion (..),
+  )
+where
+
+import Data.Int (Int16, Int32, Int64, Int8)
+import Data.Word (Word16, Word32, Word64, Word8)
+
+-- | Convert values between signed and unsigned.
+class SignConversion ubv sbv | ubv -> sbv, sbv -> ubv where
+  -- | Convert unsigned value to the corresponding signed value.
+  toSigned :: ubv -> sbv
+
+  -- | Convert signed value to the corresponding unsigned value.
+  toUnsigned :: sbv -> ubv
+
+instance SignConversion Word8 Int8 where
+  toSigned = fromIntegral
+  toUnsigned = fromIntegral
+
+instance SignConversion Word16 Int16 where
+  toSigned = fromIntegral
+  toUnsigned = fromIntegral
+
+instance SignConversion Word32 Int32 where
+  toSigned = fromIntegral
+  toUnsigned = fromIntegral
+
+instance SignConversion Word64 Int64 where
+  toSigned = fromIntegral
+  toUnsigned = fromIntegral
+
+instance SignConversion Word Int where
+  toSigned = fromIntegral
+  toUnsigned = fromIntegral

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
@@ -45,8 +45,8 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     complementBitsTerm,
     shiftBitsTerm,
     rotateBitsTerm,
-    bvToSignedTerm,
-    bvToUnsignedTerm,
+    toSignedTerm,
+    toUnsignedTerm,
     bvconcatTerm,
     bvselectTerm,
     bvextendTerm,
@@ -82,9 +82,9 @@ import qualified Data.Text as T
 import GHC.IO (unsafeDupablePerformIO)
 import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
-  ( BVSignConversion,
-    SizedBV,
+  ( SizedBV,
   )
+import Grisette.Core.Data.Class.SignConversion (SignConversion)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( BinaryOp,
     SupportedPrim,
@@ -99,8 +99,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         UBVConcatTerm,
         UBVExtendTerm,
         UBVSelectTerm,
-        UBVToSignedTerm,
-        UBVToUnsignedTerm,
         UBinaryTerm,
         UComplementBitsTerm,
         UConTerm,
@@ -127,6 +125,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         UTabularFunApplyTerm,
         UTernaryTerm,
         UTimesNumTerm,
+        UToSignedTerm,
+        UToUnsignedTerm,
         UUMinusNumTerm,
         UUnaryTerm,
         UXorBitsTerm
@@ -287,31 +287,23 @@ rotateBitsTerm :: (SupportedPrim a, Bits a) => Term a -> Int -> Term a
 rotateBitsTerm t n = internTerm $ URotateBitsTerm t n
 {-# INLINE rotateBitsTerm #-}
 
-bvToSignedTerm ::
-  ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-    forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-    Typeable ubv,
-    Typeable sbv,
-    KnownNat n,
-    1 <= n,
-    BVSignConversion (ubv n) (sbv n)
+toSignedTerm ::
+  ( SupportedPrim u,
+    SupportedPrim s,
+    SignConversion u s
   ) =>
-  Term (ubv n) ->
-  Term (sbv n)
-bvToSignedTerm = internTerm . UBVToSignedTerm
+  Term u ->
+  Term s
+toSignedTerm = internTerm . UToSignedTerm
 
-bvToUnsignedTerm ::
-  ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-    forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-    Typeable ubv,
-    Typeable sbv,
-    KnownNat n,
-    1 <= n,
-    BVSignConversion (ubv n) (sbv n)
+toUnsignedTerm ::
+  ( SupportedPrim u,
+    SupportedPrim s,
+    SignConversion u s
   ) =>
-  Term (sbv n) ->
-  Term (ubv n)
-bvToUnsignedTerm = internTerm . UBVToUnsignedTerm
+  Term s ->
+  Term u
+toUnsignedTerm = internTerm . UToUnsignedTerm
 
 bvconcatTerm ::
   ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (bv n),

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
@@ -34,8 +34,8 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     complementBitsTerm,
     shiftBitsTerm,
     rotateBitsTerm,
-    bvToSignedTerm,
-    bvToUnsignedTerm,
+    toSignedTerm,
+    toUnsignedTerm,
     bvconcatTerm,
     bvselectTerm,
     bvextendTerm,
@@ -61,9 +61,9 @@ import qualified Data.Text as T
 import Data.Typeable (Typeable)
 import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
-  ( BVSignConversion,
-    SizedBV,
+  ( SizedBV,
   )
+import Grisette.Core.Data.Class.SignConversion (SignConversion)
 import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( BinaryOp,
     SupportedPrim,
@@ -132,28 +132,20 @@ xorBitsTerm :: (SupportedPrim a, Bits a) => Term a -> Term a -> Term a
 complementBitsTerm :: (SupportedPrim a, Bits a) => Term a -> Term a
 shiftBitsTerm :: (SupportedPrim a, Bits a) => Term a -> Int -> Term a
 rotateBitsTerm :: (SupportedPrim a, Bits a) => Term a -> Int -> Term a
-bvToSignedTerm ::
-  ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-    forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-    Typeable ubv,
-    Typeable sbv,
-    KnownNat n,
-    1 <= n,
-    BVSignConversion (ubv n) (sbv n)
+toSignedTerm ::
+  ( SupportedPrim u,
+    SupportedPrim s,
+    SignConversion u s
   ) =>
-  Term (ubv n) ->
-  Term (sbv n)
-bvToUnsignedTerm ::
-  ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-    forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-    Typeable ubv,
-    Typeable sbv,
-    KnownNat n,
-    1 <= n,
-    BVSignConversion (ubv n) (sbv n)
+  Term u ->
+  Term s
+toUnsignedTerm ::
+  ( SupportedPrim u,
+    SupportedPrim s,
+    SignConversion u s
   ) =>
-  Term (sbv n) ->
-  Term (ubv n)
+  Term s ->
+  Term u
 bvconcatTerm ::
   ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (bv n),
     Typeable bv,

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -36,9 +36,9 @@ import Data.Kind (Constraint)
 import qualified Data.Text as T
 import GHC.TypeNats (KnownNat, type (+), type (<=))
 import Grisette.Core.Data.Class.BitVector
-  ( BVSignConversion,
-    SizedBV,
+  ( SizedBV,
   )
+import Grisette.Core.Data.Class.SignConversion (SignConversion)
 import Grisette.IR.SymPrim.Data.Prim.ModelValue
   ( ModelValue,
     toModelValue,
@@ -186,30 +186,22 @@ data Term t where
   ComplementBitsTerm :: (SupportedPrim t, Bits t) => {-# UNPACK #-} !Id -> !(Term t) -> Term t
   ShiftBitsTerm :: (SupportedPrim t, Bits t) => {-# UNPACK #-} !Id -> !(Term t) -> {-# UNPACK #-} !Int -> Term t
   RotateBitsTerm :: (SupportedPrim t, Bits t) => {-# UNPACK #-} !Id -> !(Term t) -> {-# UNPACK #-} !Int -> Term t
-  BVToSignedTerm ::
-    ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-      forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-      Typeable ubv,
-      Typeable sbv,
-      KnownNat n,
-      1 <= n,
-      BVSignConversion (ubv n) (sbv n)
+  ToSignedTerm ::
+    ( SupportedPrim u,
+      SupportedPrim s,
+      SignConversion u s
     ) =>
     {-# UNPACK #-} !Id ->
-    !(Term (ubv n)) ->
-    Term (sbv n)
-  BVToUnsignedTerm ::
-    ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-      forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-      Typeable ubv,
-      Typeable sbv,
-      KnownNat n,
-      1 <= n,
-      BVSignConversion (ubv n) (sbv n)
+    !(Term u) ->
+    Term s
+  ToUnsignedTerm ::
+    ( SupportedPrim u,
+      SupportedPrim s,
+      SignConversion u s
     ) =>
     {-# UNPACK #-} !Id ->
-    !(Term (sbv n)) ->
-    Term (ubv n)
+    !(Term s) ->
+    Term u
   BVConcatTerm ::
     ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (bv n),
       Typeable bv,
@@ -316,28 +308,20 @@ data UTerm t where
   UComplementBitsTerm :: (SupportedPrim t, Bits t) => !(Term t) -> UTerm t
   UShiftBitsTerm :: (SupportedPrim t, Bits t) => !(Term t) -> {-# UNPACK #-} !Int -> UTerm t
   URotateBitsTerm :: (SupportedPrim t, Bits t) => !(Term t) -> {-# UNPACK #-} !Int -> UTerm t
-  UBVToSignedTerm ::
-    ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-      forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-      Typeable ubv,
-      Typeable sbv,
-      KnownNat n,
-      1 <= n,
-      BVSignConversion (ubv n) (sbv n)
+  UToSignedTerm ::
+    ( SupportedPrim u,
+      SupportedPrim s,
+      SignConversion u s
     ) =>
-    !(Term (ubv n)) ->
-    UTerm (sbv n)
-  UBVToUnsignedTerm ::
-    ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (ubv n),
-      forall n. (KnownNat n, 1 <= n) => SupportedPrim (sbv n),
-      Typeable ubv,
-      Typeable sbv,
-      KnownNat n,
-      1 <= n,
-      BVSignConversion (ubv n) (sbv n)
+    !(Term u) ->
+    UTerm s
+  UToUnsignedTerm ::
+    ( SupportedPrim u,
+      SupportedPrim s,
+      SignConversion u s
     ) =>
-    !(Term (sbv n)) ->
-    UTerm (ubv n)
+    !(Term s) ->
+    UTerm u
   UBVConcatTerm ::
     ( forall n. (KnownNat n, 1 <= n) => SupportedPrim (bv n),
       Typeable bv,

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermSubstitution.hs
@@ -36,8 +36,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         BVConcatTerm,
         BVExtendTerm,
         BVSelectTerm,
-        BVToSignedTerm,
-        BVToUnsignedTerm,
         BinaryTerm,
         ComplementBitsTerm,
         ConTerm,
@@ -64,6 +62,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         TabularFunApplyTerm,
         TernaryTerm,
         TimesNumTerm,
+        ToSignedTerm,
+        ToUnsignedTerm,
         UMinusNumTerm,
         UnaryTerm,
         XorBitsTerm
@@ -78,8 +78,8 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
   ( pevalBVConcatTerm,
     pevalBVExtendTerm,
     pevalBVSelectTerm,
-    pevalBVToSignedTerm,
-    pevalBVToUnsignedTerm,
+    pevalToSignedTerm,
+    pevalToUnsignedTerm,
   )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
   ( pevalAndBitsTerm,
@@ -171,8 +171,8 @@ substTerm sym term = gov
         ComplementBitsTerm _ op -> SomeTerm $ pevalComplementBitsTerm (gov op)
         ShiftBitsTerm _ op n -> SomeTerm $ pevalShiftBitsTerm (gov op) n
         RotateBitsTerm _ op n -> SomeTerm $ pevalRotateBitsTerm (gov op) n
-        BVToSignedTerm _ op -> SomeTerm $ pevalBVToSignedTerm op
-        BVToUnsignedTerm _ op -> SomeTerm $ pevalBVToUnsignedTerm op
+        ToSignedTerm _ op -> SomeTerm $ pevalToSignedTerm op
+        ToUnsignedTerm _ op -> SomeTerm $ pevalToUnsignedTerm op
         BVConcatTerm _ op1 op2 -> SomeTerm $ pevalBVConcatTerm (gov op1) (gov op2)
         BVSelectTerm _ ix w op -> SomeTerm $ pevalBVSelectTerm ix w (gov op)
         BVExtendTerm _ n signed op -> SomeTerm $ pevalBVExtendTerm n signed (gov op)

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/TermUtils.hs
@@ -59,8 +59,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         BVConcatTerm,
         BVExtendTerm,
         BVSelectTerm,
-        BVToSignedTerm,
-        BVToUnsignedTerm,
         BinaryTerm,
         ComplementBitsTerm,
         ConTerm,
@@ -87,6 +85,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         TabularFunApplyTerm,
         TernaryTerm,
         TimesNumTerm,
+        ToSignedTerm,
+        ToUnsignedTerm,
         UMinusNumTerm,
         UnaryTerm,
         XorBitsTerm
@@ -125,8 +125,8 @@ identityWithTypeRep (XorBitsTerm i _ _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (ComplementBitsTerm i _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (ShiftBitsTerm i _ _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (RotateBitsTerm i _ _) = (typeRep (Proxy @t), i)
-identityWithTypeRep (BVToSignedTerm i _) = (typeRep (Proxy @t), i)
-identityWithTypeRep (BVToUnsignedTerm i _) = (typeRep (Proxy @t), i)
+identityWithTypeRep (ToSignedTerm i _) = (typeRep (Proxy @t), i)
+identityWithTypeRep (ToUnsignedTerm i _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (BVConcatTerm i _ _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (BVSelectTerm i _ _ _) = (typeRep (Proxy @t), i)
 identityWithTypeRep (BVExtendTerm i _ _ _) = (typeRep (Proxy @t), i)
@@ -166,8 +166,8 @@ introSupportedPrimConstraint XorBitsTerm {} x = x
 introSupportedPrimConstraint ComplementBitsTerm {} x = x
 introSupportedPrimConstraint ShiftBitsTerm {} x = x
 introSupportedPrimConstraint RotateBitsTerm {} x = x
-introSupportedPrimConstraint BVToSignedTerm {} x = x
-introSupportedPrimConstraint BVToUnsignedTerm {} x = x
+introSupportedPrimConstraint ToSignedTerm {} x = x
+introSupportedPrimConstraint ToUnsignedTerm {} x = x
 introSupportedPrimConstraint BVConcatTerm {} x = x
 introSupportedPrimConstraint BVSelectTerm {} x = x
 introSupportedPrimConstraint BVExtendTerm {} x = x
@@ -220,8 +220,8 @@ extractSymbolicsSomeTerm t1 = evalState (gocached t1) M.empty
     go (SomeTerm (ComplementBitsTerm _ arg)) = goUnary arg
     go (SomeTerm (ShiftBitsTerm _ arg _)) = goUnary arg
     go (SomeTerm (RotateBitsTerm _ arg _)) = goUnary arg
-    go (SomeTerm (BVToSignedTerm _ arg)) = goUnary arg
-    go (SomeTerm (BVToUnsignedTerm _ arg)) = goUnary arg
+    go (SomeTerm (ToSignedTerm _ arg)) = goUnary arg
+    go (SomeTerm (ToUnsignedTerm _ arg)) = goUnary arg
     go (SomeTerm (BVConcatTerm _ arg1 arg2)) = goBinary arg1 arg2
     go (SomeTerm (BVSelectTerm _ _ _ arg)) = goUnary arg
     go (SomeTerm (BVExtendTerm _ _ _ arg)) = goUnary arg
@@ -275,8 +275,8 @@ castTerm t@XorBitsTerm {} = cast t
 castTerm t@ComplementBitsTerm {} = cast t
 castTerm t@ShiftBitsTerm {} = cast t
 castTerm t@RotateBitsTerm {} = cast t
-castTerm t@BVToSignedTerm {} = cast t
-castTerm t@BVToUnsignedTerm {} = cast t
+castTerm t@ToSignedTerm {} = cast t
+castTerm t@ToUnsignedTerm {} = cast t
 castTerm t@BVConcatTerm {} = cast t
 castTerm t@BVSelectTerm {} = cast t
 castTerm t@BVExtendTerm {} = cast t
@@ -316,8 +316,8 @@ pformat (XorBitsTerm _ arg1 arg2) = "(^ " ++ pformat arg1 ++ " " ++ pformat arg2
 pformat (ComplementBitsTerm _ arg) = "(~ " ++ pformat arg ++ ")"
 pformat (ShiftBitsTerm _ arg n) = "(shift " ++ pformat arg ++ " " ++ show n ++ ")"
 pformat (RotateBitsTerm _ arg n) = "(rotate " ++ pformat arg ++ " " ++ show n ++ ")"
-pformat (BVToSignedTerm _ arg) = "(bvu2s " ++ pformat arg ++ " " ++ ")"
-pformat (BVToUnsignedTerm _ arg) = "(bvs2u " ++ pformat arg ++ " " ++ ")"
+pformat (ToSignedTerm _ arg) = "(u2s " ++ pformat arg ++ " " ++ ")"
+pformat (ToUnsignedTerm _ arg) = "(s2u " ++ pformat arg ++ " " ++ ")"
 pformat (BVConcatTerm _ arg1 arg2) = "(bvconcat " ++ pformat arg1 ++ " " ++ pformat arg2 ++ ")"
 pformat (BVSelectTerm _ ix w arg) = "(bvselect " ++ show ix ++ " " ++ show w ++ " " ++ pformat arg ++ ")"
 pformat (BVExtendTerm _ signed n arg) =
@@ -365,8 +365,8 @@ someTermsSize terms = S.size $ execState (traverse goSome terms) S.empty
     go t@(ComplementBitsTerm _ arg) = goUnary t arg
     go t@(ShiftBitsTerm _ arg _) = goUnary t arg
     go t@(RotateBitsTerm _ arg _) = goUnary t arg
-    go t@(BVToSignedTerm _ arg) = goUnary t arg
-    go t@(BVToUnsignedTerm _ arg) = goUnary t arg
+    go t@(ToSignedTerm _ arg) = goUnary t arg
+    go t@(ToUnsignedTerm _ arg) = goUnary t arg
     go t@(BVConcatTerm _ arg1 arg2) = goBinary t arg1 arg2
     go t@(BVSelectTerm _ _ _ arg) = goUnary t arg
     go t@(BVExtendTerm _ _ _ arg) = goUnary t arg

--- a/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/Model.hs
@@ -81,8 +81,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         BVConcatTerm,
         BVExtendTerm,
         BVSelectTerm,
-        BVToSignedTerm,
-        BVToUnsignedTerm,
         BinaryTerm,
         ComplementBitsTerm,
         ConTerm,
@@ -109,6 +107,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
         TabularFunApplyTerm,
         TernaryTerm,
         TimesNumTerm,
+        ToSignedTerm,
+        ToUnsignedTerm,
         UMinusNumTerm,
         UnaryTerm,
         XorBitsTerm
@@ -130,8 +130,8 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
   ( pevalBVConcatTerm,
     pevalBVExtendTerm,
     pevalBVSelectTerm,
-    pevalBVToSignedTerm,
-    pevalBVToUnsignedTerm,
+    pevalToSignedTerm,
+    pevalToUnsignedTerm,
   )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
   ( pevalAndBitsTerm,
@@ -464,10 +464,10 @@ evaluateSomeTerm fillDefault m@(Model ma) = gomemo
       goUnary (`pevalShiftBitsTerm` n) arg
     go (SomeTerm (RotateBitsTerm _ arg n)) =
       goUnary (`pevalRotateBitsTerm` n) arg
-    go (SomeTerm (BVToSignedTerm _ arg)) =
-      goUnary pevalBVToSignedTerm arg
-    go (SomeTerm (BVToUnsignedTerm _ arg)) =
-      goUnary pevalBVToUnsignedTerm arg
+    go (SomeTerm (ToSignedTerm _ arg)) =
+      goUnary pevalToSignedTerm arg
+    go (SomeTerm (ToUnsignedTerm _ arg)) =
+      goUnary pevalToUnsignedTerm arg
     go (SomeTerm (BVConcatTerm _ arg1 arg2)) =
       goBinary pevalBVConcatTerm arg1 arg2
     go (SomeTerm (BVSelectTerm _ ix w arg)) =

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -131,7 +131,6 @@ import Grisette.Core.Data.BV
   )
 import Grisette.Core.Data.Class.BitVector
   ( BV (bvConcat, bvExt, bvSelect, bvSext, bvZext),
-    BVSignConversion (toSigned, toUnsigned),
     SizedBV (sizedBVConcat, sizedBVExt, sizedBVSelect, sizedBVSext, sizedBVZext),
   )
 import Grisette.Core.Data.Class.Bool
@@ -175,6 +174,7 @@ import Grisette.Core.Data.Class.SafeArith
       ),
     SymIntegerOp,
   )
+import Grisette.Core.Data.Class.SignConversion (SignConversion (toSigned, toUnsigned))
 import Grisette.Core.Data.Class.SimpleMergeable (mrgIf)
 import Grisette.Core.Data.Class.Solvable
   ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
@@ -224,8 +224,8 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.BV
   ( pevalBVConcatTerm,
     pevalBVExtendTerm,
     pevalBVSelectTerm,
-    pevalBVToSignedTerm,
-    pevalBVToUnsignedTerm,
+    pevalToSignedTerm,
+    pevalToUnsignedTerm,
   )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
   ( pevalAndBitsTerm,
@@ -1559,11 +1559,11 @@ instance BV SomeSymWordN where
 
 -- BVSignConversion
 
-instance (KnownNat n, 1 <= n) => BVSignConversion (SymWordN n) (SymIntN n) where
-  toSigned (SymWordN n) = SymIntN $ pevalBVToSignedTerm n
-  toUnsigned (SymIntN n) = SymWordN $ pevalBVToUnsignedTerm n
+instance (KnownNat n, 1 <= n) => SignConversion (SymWordN n) (SymIntN n) where
+  toSigned (SymWordN n) = SymIntN $ pevalToSignedTerm n
+  toUnsigned (SymIntN n) = SymWordN $ pevalToUnsignedTerm n
 
-instance BVSignConversion SomeSymWordN SomeSymIntN where
+instance SignConversion SomeSymWordN SomeSymIntN where
   toSigned (SomeSymWordN n) = SomeSymIntN $ toSigned n
   toUnsigned (SomeSymIntN n) = SomeSymWordN $ toUnsigned n
 

--- a/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/LoweringTests.hs
@@ -37,8 +37,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     addNumTerm,
     andBitsTerm,
     andTerm,
-    bvToSignedTerm,
-    bvToUnsignedTerm,
     bvconcatTerm,
     bvselectTerm,
     bvsignExtendTerm,
@@ -64,6 +62,8 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     signumNumTerm,
     ssymTerm,
     timesNumTerm,
+    toSignedTerm,
+    toUnsignedTerm,
     uminusNumTerm,
     xorBitsTerm,
   )
@@ -626,8 +626,8 @@ loweringTests =
                 testBinaryOpLowering @(IntN 5) @(IntN 5) @(IntN 5) unboundedConfig remBoundedIntegralTerm "rem" SBV.sRem
                 testBinaryOpLowering @(IntN 5) @(IntN 5) @(IntN 5) boundedConfig remBoundedIntegralTerm "rem" SBV.sRem,
               testCase "ToUnsigned" $ do
-                testUnaryOpLowering @(IntN 5) @(WordN 5) unboundedConfig bvToUnsignedTerm "toUnsigned" SBV.sFromIntegral
-                testUnaryOpLowering @(IntN 5) @(WordN 5) boundedConfig bvToUnsignedTerm "toUnsigned" SBV.sFromIntegral
+                testUnaryOpLowering @(IntN 5) @(WordN 5) unboundedConfig toUnsignedTerm "toUnsigned" SBV.sFromIntegral
+                testUnaryOpLowering @(IntN 5) @(WordN 5) boundedConfig toUnsignedTerm "toUnsigned" SBV.sFromIntegral
             ],
           testGroup
             "WordN"
@@ -830,7 +830,7 @@ loweringTests =
                 testBinaryOpLowering @(WordN 5) @(WordN 5) @(WordN 5) unboundedConfig remIntegralTerm "rem" SBV.sRem
                 testBinaryOpLowering @(WordN 5) @(WordN 5) @(WordN 5) boundedConfig remIntegralTerm "rem" SBV.sRem,
               testCase "ToSigned" $ do
-                testUnaryOpLowering @(WordN 5) @(IntN 5) unboundedConfig bvToSignedTerm "toSigned" SBV.sFromIntegral
-                testUnaryOpLowering @(WordN 5) @(IntN 5) boundedConfig bvToSignedTerm "toSigned" SBV.sFromIntegral
+                testUnaryOpLowering @(WordN 5) @(IntN 5) unboundedConfig toSignedTerm "toSigned" SBV.sFromIntegral
+                testUnaryOpLowering @(WordN 5) @(IntN 5) boundedConfig toSignedTerm "toSigned" SBV.sFromIntegral
             ]
         ]


### PR DESCRIPTION
This pull request renamed the `BVSignConversion` type to `SignConversion` type and added instances for `Data.Word` and `Data.Int` types. Resolves #111.