### PR TITLE
Fix toInteger for (-1 :: IntN 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the `SOrd` instance for `VerificationConditions`. ([#131](https://github.com/lsrcz/grisette/pull/131))
 - Fixed the missing `SubstituteSym` instance for `UnionM`. ([#131](https://github.com/lsrcz/grisette/pull/131))
 - Fixed the symbolic generation order for `Maybe`. ([#131](https://github.com/lsrcz/grisette/pull/131))
+- Fixed the `toInteger` function for `IntN 1`. ([#143](https://github.com/lsrcz/grisette/pull/143))
 
 ### Changed
 

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -636,10 +636,10 @@ instance (KnownNat n, 1 <= n) => Integral (IntN n) where
         (q, r) -> (fromInteger q, fromInteger r)
   toInteger i@(IntN n) = case signum i of
     0 -> 0
-    1 -> n
     -1 ->
       let x = negate i
        in if signum x == -1 then -n else negate (toInteger x)
+    1 -> n
     _ -> undefined
 
 instance Integral SomeIntN where

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -471,6 +471,9 @@ bvTests =
             shouldThrow "divMod" $ divMod (minBound :: IntN 8) (-1 :: IntN 8)
             shouldThrow "div" $ div (minBound :: IntN 8) (-1 :: IntN 8)
             shouldThrow "quotRem" $ quotRem (minBound :: IntN 8) (-1 :: IntN 8)
-            shouldThrow "quot" $ quot (minBound :: IntN 8) (-1 :: IntN 8)
+            shouldThrow "quot" $ quot (minBound :: IntN 8) (-1 :: IntN 8),
+          testCase "toInteger for IntN 1" $ do
+            toInteger (0 :: IntN 1) @=? 0
+            toInteger (1 :: IntN 1) @=? (-1)
         ]
     ]


### PR DESCRIPTION
`toInteger` for `(-1 :: IntN 1)` should be `-1` rather than `1`. This pull request fixes this.