### PR TITLE
Fix the abs function for WordN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the missing `SubstituteSym` instance for `UnionM`. ([#131](https://github.com/lsrcz/grisette/pull/131))
 - Fixed the symbolic generation order for `Maybe`. ([#131](https://github.com/lsrcz/grisette/pull/131))
 - Fixed the `toInteger` function for `IntN 1`. ([#143](https://github.com/lsrcz/grisette/pull/143))
+- Fixed the `abs` function for `WordN`. ([#144](https://github.com/lsrcz/grisette/pull/143))
 
 ### Changed
 

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingGen.hs
@@ -35,6 +35,7 @@ module Grisette.Backend.SBV.Data.SMT.TermRewritingGen
     uminusNumSpec,
     timesNumSpec,
     addNumSpec,
+    absNumSpec,
     iteSpec,
     eqvSpec,
     notSpec,

--- a/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
+++ b/test/Grisette/Backend/SBV/Data/SMT/TermRewritingTests.hs
@@ -31,6 +31,7 @@ import Grisette.Backend.SBV.Data.SMT.TermRewritingGen
         same,
         symSpec
       ),
+    absNumSpec,
     addNumSpec,
     andSpec,
     divBoundedIntegralSpec,
@@ -157,18 +158,43 @@ termRewritingTests =
               )
         ],
       testGroup
-        "Different sized SignedBV"
-        [ testProperty "Fixed Sized SignedBV random test" $
+        "Different sized signed BV"
+        [ testProperty "random test" $
             mapSize (`min` 10) $
               ioProperty . \(x :: (DifferentSizeBVSpec IntN 4)) -> do
                 validateSpec unboundedConfig x
         ],
       testGroup
-        "Fixed sized SignedBV"
-        [ testProperty "Fixed Sized SignedBV random test" $
+        "Fixed sized signed BV"
+        [ testProperty "random test" $
             mapSize (`min` 10) $
               ioProperty . \(x :: (FixedSizedBVWithBoolSpec IntN)) -> do
                 validateSpec unboundedConfig x
+        ],
+      testGroup
+        "Different sized unsigned BV"
+        [ testProperty "random test" $
+            mapSize (`min` 10) $
+              ioProperty . \(x :: (DifferentSizeBVSpec WordN 4)) -> do
+                validateSpec unboundedConfig x
+        ],
+      testGroup
+        "Fixed sized unsigned BV"
+        [ testProperty "random test" $
+            mapSize (`min` 10) $
+              ioProperty . \(x :: (FixedSizedBVWithBoolSpec WordN)) -> do
+                validateSpec unboundedConfig x
+        ],
+      testGroup
+        "Regression for abs on unsigned BV"
+        [ testCase "abs on negate" $
+            validateSpec @(FixedSizedBVWithBoolSpec WordN)
+              unboundedConfig
+              (absNumSpec (uminusNumSpec (symSpec "a"))),
+          testCase "abs on times negate" $
+            validateSpec @(FixedSizedBVWithBoolSpec WordN)
+              unboundedConfig
+              (absNumSpec (timesNumSpec (symSpec "a") (uminusNumSpec (symSpec "b"))))
         ],
       testGroup
         "timesNumSpec on integer"

--- a/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/Prim/NumTests.hs
@@ -207,10 +207,16 @@ numTests =
         [ testCase "On concrete" $ do
             pevalAbsNumTerm (conTerm 10 :: Term Integer) @=? conTerm 10
             pevalAbsNumTerm (conTerm $ -10 :: Term Integer) @=? conTerm 10,
-          testCase "On UMinus" $ do
+          testCase "On UMinus Integer" $ do
             pevalAbsNumTerm (pevalUMinusNumTerm $ ssymTerm "a" :: Term Integer) @=? pevalAbsNumTerm (ssymTerm "a"),
-          testCase "On Abs" $ do
+          testCase "On UMinus BV" $ do
+            pevalAbsNumTerm (pevalUMinusNumTerm $ ssymTerm "a" :: Term (IntN 5)) @=? pevalAbsNumTerm (ssymTerm "a")
+            pevalAbsNumTerm (pevalUMinusNumTerm $ ssymTerm "a" :: Term (WordN 5)) @=? uminusNumTerm (ssymTerm "a"),
+          testCase "On Abs Integer" $ do
             pevalAbsNumTerm (pevalAbsNumTerm $ ssymTerm "a" :: Term Integer) @=? pevalAbsNumTerm (ssymTerm "a"),
+          testCase "On Abs BV" $ do
+            pevalAbsNumTerm (pevalAbsNumTerm $ ssymTerm "a" :: Term (IntN 5)) @=? pevalAbsNumTerm (ssymTerm "a")
+            pevalAbsNumTerm (pevalAbsNumTerm $ ssymTerm "a" :: Term (WordN 5)) @=? ssymTerm "a",
           testCase "On Times Integer" $ do
             pevalAbsNumTerm (pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b") :: Term Integer)
               @=? pevalTimesNumTerm (pevalAbsNumTerm (ssymTerm "a")) (pevalAbsNumTerm (ssymTerm "b")),
@@ -218,10 +224,13 @@ numTests =
             pevalAbsNumTerm (pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b") :: Term (IntN 5))
               @=? absNumTerm (pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b") :: Term (IntN 5))
             pevalAbsNumTerm (pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b") :: Term (WordN 5))
-              @=? absNumTerm (pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b") :: Term (WordN 5)),
-          testCase "On symbolic" $ do
+              @=? pevalTimesNumTerm (ssymTerm "a") (ssymTerm "b"),
+          testCase "On symbolic Integer" $ do
             pevalAbsNumTerm (ssymTerm "a" :: Term Integer)
-              @=? absNumTerm (ssymTerm "a")
+              @=? absNumTerm (ssymTerm "a"),
+          testCase "On symbolic BV" $ do
+            pevalAbsNumTerm (ssymTerm "a" :: Term (IntN 5)) @=? absNumTerm (ssymTerm "a")
+            pevalAbsNumTerm (ssymTerm "a" :: Term (WordN 5)) @=? ssymTerm "a"
         ],
       testGroup
         "Signum"


### PR DESCRIPTION
This pull request fixes an incorrect rewriting rule for the `abs` function when the arguments are unsigned bitvectors. The function now work as `id`.