### PR TITLE
Pin the ormolu version to 0.5.3.0 for the run-ormolu plugin

### DIFF
--- a/.github/workflows/ormolu.yml
+++ b/.github/workflows/ormolu.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: haskell-actions/run-ormolu@v14
       with:
         mode: inplace
+        version: 0.5.3.0
     - name: apply formatting changes
       uses: stefanzweifel/git-auto-commit-action@v5
       if: ${{ always() }}

--- a/src/Grisette/Core/Data/Union.hs
+++ b/src/Grisette/Core/Data/Union.hs
@@ -83,16 +83,16 @@ data Union a
     UnionSingle a
   | -- | A if value
     UnionIf
-      -- | Cached leftmost value
       a
-      -- | Is merged invariant already maintained?
+      -- ^ Cached leftmost value
       !Bool
-      -- | If condition
+      -- ^ Is merged invariant already maintained?
       !SymBool
-      -- | True branch
+      -- ^ If condition
       (Union a)
-      -- | False branch
+      -- ^ True branch
       (Union a)
+      -- ^ False branch
   deriving (Generic, Eq, Lift, Generic1)
 
 instance Eq1 Union where

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -144,10 +144,10 @@ unionMTests =
             let v :: UnionM Integer = mrgIf "b" (mrgSingle 1) (mrgSingle 3)
             f
               <*> v
-                @?= unionIf
-                  "a"
-                  (unionIf "b" (single 1) (single 3))
-                  (unionIf "b" (single 2) (single 4))
+              @?= unionIf
+                "a"
+                (unionIf "b" (single 1) (single 3))
+                (unionIf "b" (single 2) (single 4))
         ],
       testGroup
         "Monad"
@@ -295,28 +295,28 @@ unionMTests =
             [ testCase "Single/Single" $
                 (mrgSingle a :: UnionM SymBool)
                   ==~ mrgSingle b
-                    @?= (a ==~ b),
+                  @?= (a ==~ b),
               testCase "If/Single" $ do
                 g1
                   ==~ mrgSingle (Left d)
-                    @?= ites a (b ==~ d) (con False)
+                  @?= ites a (b ==~ d) (con False)
                 g1
                   ==~ mrgSingle (Right d)
-                    @?= ites a (con False) (c ==~ d),
+                  @?= ites a (con False) (c ==~ d),
               testCase "Single/If" $ do
                 mrgSingle (Left d)
                   ==~ g1
-                    @?= ites a (d ==~ b) (con False)
+                  @?= ites a (d ==~ b) (con False)
                 mrgSingle (Right d)
                   ==~ g1
-                    @?= ites a (con False) (d ==~ c),
+                  @?= ites a (con False) (d ==~ c),
               testCase "If/If" $
                 g1
                   ==~ g2
-                    @?= ites
-                      a
-                      (ites d (b ==~ e) (con False))
-                      (ites d (con False) (c ==~ f))
+                  @?= ites
+                    a
+                    (ites d (b ==~ e) (con False))
+                    (ites d (con False) (c ==~ f))
             ],
       let a :: SymBool = "a"
           b :: SymBool = "b"
@@ -334,32 +334,32 @@ unionMTests =
             [ testCase "Single/Single" $ do
                 (mrgSingle a :: UnionM SymBool)
                   <=~ mrgSingle b
-                    @?= (a <=~ b :: SymBool)
+                  @?= (a <=~ b :: SymBool)
                 (mrgSingle a :: UnionM SymBool)
                   <~ mrgSingle b
-                    @?= (a <~ b :: SymBool)
+                  @?= (a <~ b :: SymBool)
                 (mrgSingle a :: UnionM SymBool)
                   >=~ mrgSingle b
-                    @?= (a >=~ b :: SymBool)
+                  @?= (a >=~ b :: SymBool)
                 (mrgSingle a :: UnionM SymBool)
                   >~ mrgSingle b
-                    @?= (a >~ b :: SymBool)
+                  @?= (a >~ b :: SymBool)
                 (mrgSingle a :: UnionM SymBool)
                   `symCompare` mrgSingle b
                   @?= (a `symCompare` b :: UnionM Ordering),
               testCase "If/Single" $ do
                 g1
                   <=~ mrgSingle (Left d)
-                    @?= ites a (b <=~ d) (con False)
+                  @?= ites a (b <=~ d) (con False)
                 g1
                   <~ mrgSingle (Left d)
-                    @?= ites a (b <~ d) (con False)
+                  @?= ites a (b <~ d) (con False)
                 g1
                   >=~ mrgSingle (Left d)
-                    @?= ites a (b >=~ d) (con True)
+                  @?= ites a (b >=~ d) (con True)
                 g1
                   >~ mrgSingle (Left d)
-                    @?= ites a (b >~ d) (con True)
+                  @?= ites a (b >~ d) (con True)
 
                 g1
                   `symCompare` mrgSingle (Left d)
@@ -369,16 +369,16 @@ unionMTests =
 
                 g1
                   <=~ mrgSingle (Right d)
-                    @?= ites a (con True) (c <=~ d)
+                  @?= ites a (con True) (c <=~ d)
                 g1
                   <~ mrgSingle (Right d)
-                    @?= ites a (con True) (c <~ d)
+                  @?= ites a (con True) (c <~ d)
                 g1
                   >=~ mrgSingle (Right d)
-                    @?= ites a (con False) (c >=~ d)
+                  @?= ites a (con False) (c >=~ d)
                 g1
                   >~ mrgSingle (Right d)
-                    @?= ites a (con False) (c >~ d)
+                  @?= ites a (con False) (c >~ d)
 
                 g1
                   `symCompare` mrgSingle (Right d)
@@ -388,16 +388,16 @@ unionMTests =
               testCase "Single/If" $ do
                 mrgSingle (Left d)
                   <=~ g1
-                    @?= ites a (d <=~ b) (con True)
+                  @?= ites a (d <=~ b) (con True)
                 mrgSingle (Left d)
                   <~ g1
-                    @?= ites a (d <~ b) (con True)
+                  @?= ites a (d <~ b) (con True)
                 mrgSingle (Left d)
                   >=~ g1
-                    @?= ites a (d >=~ b) (con False)
+                  @?= ites a (d >=~ b) (con False)
                 mrgSingle (Left d)
                   >~ g1
-                    @?= ites a (d >~ b) (con False)
+                  @?= ites a (d >~ b) (con False)
 
                 mrgSingle (Left d)
                   `symCompare` g1
@@ -407,16 +407,16 @@ unionMTests =
 
                 mrgSingle (Right d)
                   <=~ g1
-                    @?= ites a (con False) (d <=~ c)
+                  @?= ites a (con False) (d <=~ c)
                 mrgSingle (Right d)
                   <~ g1
-                    @?= ites a (con False) (d <~ c)
+                  @?= ites a (con False) (d <~ c)
                 mrgSingle (Right d)
                   >=~ g1
-                    @?= ites a (con True) (d >=~ c)
+                  @?= ites a (con True) (d >=~ c)
                 mrgSingle (Right d)
                   >~ g1
-                    @?= ites a (con True) (d >~ c)
+                  @?= ites a (con True) (d >~ c)
 
                 mrgSingle (Right d)
                   `symCompare` g1
@@ -426,28 +426,28 @@ unionMTests =
               testCase "If/If" $ do
                 g1
                   <=~ g2
-                    @?= ites
-                      a
-                      (ites d (b <=~ e) (con True))
-                      (ites d (con False) (c <=~ f))
+                  @?= ites
+                    a
+                    (ites d (b <=~ e) (con True))
+                    (ites d (con False) (c <=~ f))
                 g1
                   <~ g2
-                    @?= ites
-                      a
-                      (ites d (b <~ e) (con True))
-                      (ites d (con False) (c <~ f))
+                  @?= ites
+                    a
+                    (ites d (b <~ e) (con True))
+                    (ites d (con False) (c <~ f))
                 g1
                   >=~ g2
-                    @?= ites
-                      a
-                      (ites d (b >=~ e) (con False))
-                      (ites d (con True) (c >=~ f))
+                  @?= ites
+                    a
+                    (ites d (b >=~ e) (con False))
+                    (ites d (con True) (c >=~ f))
                 g1
                   >~ g2
-                    @?= ites
-                      a
-                      (ites d (b >~ e) (con False))
-                      (ites d (con True) (c >~ f))
+                  @?= ites
+                    a
+                    (ites d (b >~ e) (con False))
+                    (ites d (con True) (c >~ f))
                 g1
                   `symCompare` g2
                   @?= ( mrgIf
@@ -624,24 +624,24 @@ unionMTests =
           testCase "plus" $
             (mrgIf "a" (mrgSingle 0) (mrgSingle 1) :: UnionM Integer)
               + mrgIf "b" (mrgSingle 1) (mrgSingle 3)
-                @?= mrgIf
-                  "a"
-                  (mrgIf "b" (mrgSingle 1) (mrgSingle 3))
-                  (mrgIf "b" (mrgSingle 2) (mrgSingle 4)),
+              @?= mrgIf
+                "a"
+                (mrgIf "b" (mrgSingle 1) (mrgSingle 3))
+                (mrgIf "b" (mrgSingle 2) (mrgSingle 4)),
           testCase "minus" $
             (mrgIf "a" (mrgSingle 0) (mrgSingle 1) :: UnionM Integer)
               - mrgIf "b" (mrgSingle $ -3) (mrgSingle $ -1)
-                @?= mrgIf
-                  "a"
-                  (mrgIf (nots "b") (mrgSingle 1) (mrgSingle 3))
-                  (mrgIf (nots "b") (mrgSingle 2) (mrgSingle 4)),
+              @?= mrgIf
+                "a"
+                (mrgIf (nots "b") (mrgSingle 1) (mrgSingle 3))
+                (mrgIf (nots "b") (mrgSingle 2) (mrgSingle 4)),
           testCase "times" $
             (mrgIf "a" (mrgSingle 1) (mrgSingle 2) :: UnionM Integer)
               * mrgIf "b" (mrgSingle 3) (mrgSingle 4)
-                @?= mrgIf
-                  "a"
-                  (mrgIf "b" (mrgSingle 3) (mrgSingle 4))
-                  (mrgIf "b" (mrgSingle 6) (mrgSingle 8)),
+              @?= mrgIf
+                "a"
+                (mrgIf "b" (mrgSingle 3) (mrgSingle 4))
+                (mrgIf "b" (mrgSingle 6) (mrgSingle 8)),
           testCase "abs" $
             abs (mrgIf "a" (mrgSingle $ -1) (mrgSingle 2) :: UnionM Integer)
               @?= mrgIf "a" (mrgSingle 1) (mrgSingle 2),
@@ -662,21 +662,21 @@ unionMTests =
             [ testCase "||~" $
                 l
                   ||~ r
-                    @?= ( mrgIf
-                            ("a" &&~ "b")
-                            (mrgSingle False)
-                            (mrgSingle True) ::
-                            UnionM Bool
-                        ),
+                  @?= ( mrgIf
+                          ("a" &&~ "b")
+                          (mrgSingle False)
+                          (mrgSingle True) ::
+                          UnionM Bool
+                      ),
               testCase "&&~" $
                 l
                   &&~ r
-                    @?= ( mrgIf
-                            ("a" ||~ "b")
-                            (mrgSingle False)
-                            (mrgSingle True) ::
-                            UnionM Bool
-                        ),
+                  @?= ( mrgIf
+                          ("a" ||~ "b")
+                          (mrgSingle False)
+                          (mrgSingle True) ::
+                          UnionM Bool
+                      ),
               testCase "nots" $
                 nots l
                   @?= mrgIf (nots "a") (mrgSingle False) (mrgSingle True),

--- a/test/Grisette/Core/Data/Class/BoolTests.hs
+++ b/test/Grisette/Core/Data/Class/BoolTests.hs
@@ -42,11 +42,11 @@ boolTests =
               testCase "&&~" $
                 CASBool "a"
                   &&~ CASBool "b"
-                    @?= CAAnd (CASBool "a") (CASBool "b"),
+                  @?= CAAnd (CASBool "a") (CASBool "b"),
               testCase "||~" $
                 CASBool "a"
                   ||~ CASBool "b"
-                    @?= CANot (CAAnd (CANot $ CASBool "a") (CANot $ CASBool "b"))
+                  @?= CANot (CAAnd (CANot $ CASBool "a") (CANot $ CASBool "b"))
             ],
           testGroup
             "Use or"
@@ -55,11 +55,11 @@ boolTests =
               testCase "&&~" $
                 COSBool "a"
                   &&~ COSBool "b"
-                    @?= CONot (COOr (CONot $ COSBool "a") (CONot $ COSBool "b")),
+                  @?= CONot (COOr (CONot $ COSBool "a") (CONot $ COSBool "b")),
               testCase "||~" $
                 COSBool "a"
                   ||~ COSBool "b"
-                    @?= COOr (COSBool "a") (COSBool "b"),
+                  @?= COOr (COSBool "a") (COSBool "b"),
               testCase "xors" $
                 COSBool "a"
                   `xors` COSBool "b"

--- a/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
@@ -66,15 +66,15 @@ evaluateSymTests =
                       testCase "||~" $
                         eval (ssym "a" ||~ ssym "b")
                           @?= ssym "a"
-                          ||~ ssym "b",
+                            ||~ ssym "b",
                       testCase "&&~" $
                         eval (ssym "a" &&~ ssym "b")
                           @?= ssym "a"
-                          &&~ ssym "b",
+                            &&~ ssym "b",
                       testCase "==~" $
                         eval ((ssym "a" :: SymBool) ==~ ssym "b")
                           @?= (ssym "a" :: SymBool)
-                          ==~ ssym "b",
+                            ==~ ssym "b",
                       testCase "nots" $
                         eval (nots (ssym "a"))
                           @?= nots (ssym "a"),

--- a/test/Grisette/Core/Data/Class/SEqTests.hs
+++ b/test/Grisette/Core/Data/Class/SEqTests.hs
@@ -60,7 +60,7 @@ seqTests =
                   ( \(i, j) ->
                       conBool i
                         ==~ conBool j
-                          @=? conBool (i == j)
+                        @=? conBool (i == j)
                   )
                   [(x, y) | x <- bools, y <- bools],
               testCase "conBool True vs SymBool" $ do
@@ -78,7 +78,7 @@ seqTests =
                     SymBool termb = ssymBool "b"
                 ssymBool "a"
                   ==~ ssymBool "b"
-                    @=? SymBool (pevalEqvTerm terma termb)
+                  @=? SymBool (pevalEqvTerm terma termb)
             ],
           testProperty "Bool" (ioProperty . concreteSEqOkProp @Bool),
           testProperty "Integer" (ioProperty . concreteSEqOkProp @Integer),
@@ -102,19 +102,19 @@ seqTests =
                 [ testCase "Same length 1" $
                     [ssymBool "a"]
                       ==~ [ssymBool "b"]
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase "Same length 2" $
                     [ssymBool "a", ssymBool "b"]
                       ==~ [ssymBool "c", ssymBool "d"]
-                        @=? (ssymBool "a" ==~ ssymBool "c")
-                      &&~ (ssymBool "b" ==~ ssymBool "d"),
+                      @=? (ssymBool "a" ==~ ssymBool "c")
+                        &&~ (ssymBool "b" ==~ ssymBool "d"),
                   testCase "length 1 vs length 0" $
                     [ssymBool "a"] ==~ [] @=? conBool False,
                   testCase "length 1 vs length 2" $
                     [ssymBool "a"]
                       ==~ [ssymBool "c", ssymBool "d"]
-                        @=? conBool False
+                      @=? conBool False
                 ]
             ],
           testGroup
@@ -132,8 +132,8 @@ seqTests =
                   testCase "Just vs Just" $
                     Just (ssymBool "a")
                       ==~ Just (ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b"
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b"
                 ]
             ],
           testGroup
@@ -145,21 +145,21 @@ seqTests =
                 [ testCase "Left vs Left" $
                     (Left (ssymBool "a") :: Either SymBool SymBool)
                       ==~ Left (ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase "Right vs Left" $
                     (Right (ssymBool "a") :: Either SymBool SymBool)
                       ==~ Left (ssymBool "b")
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "Left vs Right" $
                     (Left (ssymBool "a") :: Either SymBool SymBool)
                       ==~ Right (ssymBool "b")
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "Right vs Right" $
                     (Right (ssymBool "a") :: Either SymBool SymBool)
                       ==~ Right (ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b"
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b"
                 ]
             ],
           testGroup
@@ -173,44 +173,44 @@ seqTests =
                 [ testCase "MaybeT Nothing vs MaybeT Nothing" $
                     (MaybeT Nothing :: MaybeT Maybe SymBool)
                       ==~ MaybeT Nothing
-                        @=? conBool True,
+                      @=? conBool True,
                   testCase "MaybeT Nothing vs MaybeT (Just Nothing)" $
                     (MaybeT Nothing :: MaybeT Maybe SymBool)
                       ==~ MaybeT (Just Nothing)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT Nothing vs MaybeT (Just (Just v))" $
                     (MaybeT Nothing :: MaybeT Maybe SymBool)
                       ==~ MaybeT (Just (Just (ssymBool "a")))
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT (Just Nothing) vs MaybeT Nothing" $
                     MaybeT (Just Nothing)
                       ==~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT (Just (Just v)) vs MaybeT Nothing" $
                     MaybeT (Just (Just (ssymBool "a")))
                       ==~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT (Just Nothing) vs MaybeT (Just Nothing)" $
                     MaybeT (Just Nothing)
                       ==~ (MaybeT (Just Nothing) :: MaybeT Maybe SymBool)
-                        @=? conBool True,
+                      @=? conBool True,
                   testCase "MaybeT (Just (Just v)) vs MaybeT (Just Nothing)" $
                     MaybeT (Just (Just (ssymBool "a")))
                       ==~ (MaybeT (Just Nothing) :: MaybeT Maybe SymBool)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT (Just Nothing) vs MaybeT (Just (Just v))" $
                     MaybeT (Just Nothing)
                       ==~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                               MaybeT Maybe SymBool
                           )
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "MaybeT (Just (Just v)) vs MaybeT (Just (Just v))" $
                     MaybeT (Just (Just (ssymBool "a")))
                       ==~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                               MaybeT Maybe SymBool
                           )
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b"
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b"
                 ]
             ],
           testGroup
@@ -224,53 +224,53 @@ seqTests =
                 [ testCase "ExceptT Nothing vs ExceptT Nothing" $
                     (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                       ==~ ExceptT Nothing
-                        @=? conBool True,
+                      @=? conBool True,
                   testCase "ExceptT Nothing vs ExceptT (Just (Left v))" $
                     (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                       ==~ ExceptT (Just (Left (ssymBool "a")))
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "ExceptT Nothing vs ExceptT (Just (Right v))" $
                     (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                       ==~ ExceptT (Just (Right (ssymBool "a")))
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "ExceptT (Just (Left v)) vs ExceptT Nothing" $
                     ExceptT (Just (Left (ssymBool "a")))
                       ==~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "ExceptT (Just (Right v)) vs ExceptT Nothing" $
                     ExceptT (Just (Right (ssymBool "a")))
                       ==~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase
                     "ExceptT (Just (Left v)) vs ExceptT (Just (Left v))"
                     $ ExceptT (Just (Left (ssymBool "a")))
                       ==~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                               ExceptT SymBool Maybe SymBool
                           )
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase
                     "ExceptT (Just (Right v)) vs ExceptT (Just (Left v))"
                     $ ExceptT (Just (Right (ssymBool "a")))
                       ==~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                               ExceptT SymBool Maybe SymBool
                           )
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase
                     "ExceptT (Just (Left v)) vs ExceptT (Just (Right v))"
                     $ ExceptT (Just (Left (ssymBool "a")))
                       ==~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                               ExceptT SymBool Maybe SymBool
                           )
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase
                     "ExceptT (Just (Right v)) vs ExceptT (Just (Right v))"
                     $ ExceptT (Just (Right (ssymBool "a")))
                       ==~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                               ExceptT SymBool Maybe SymBool
                           )
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b"
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b"
                 ]
             ],
           testProperty "()" (ioProperty . concreteSEqOkProp @()),
@@ -281,9 +281,9 @@ seqTests =
               testCase "(SymBool, SymBool)" $ do
                 (ssymBool "a", ssymBool "c")
                   ==~ (ssymBool "b", ssymBool "d")
-                    @=? ssymBool "a"
-                  ==~ ssymBool "b"
-                  &&~ ssymBool "c"
+                  @=? ssymBool "a"
+                    ==~ ssymBool "b"
+                    &&~ ssymBool "c"
                     ==~ ssymBool "d"
             ],
           testGroup
@@ -293,10 +293,10 @@ seqTests =
               testCase "(SymBool, SymBool, SymBool)" $
                 (ssymBool "a", ssymBool "c", ssymBool "e")
                   ==~ (ssymBool "b", ssymBool "d", ssymBool "f")
-                    @=? (ssymBool "a" ==~ ssymBool "b")
-                  &&~ ( (ssymBool "c" ==~ ssymBool "d")
-                          &&~ (ssymBool "e" ==~ ssymBool "f")
-                      )
+                  @=? (ssymBool "a" ==~ ssymBool "b")
+                    &&~ ( (ssymBool "c" ==~ ssymBool "d")
+                            &&~ (ssymBool "e" ==~ ssymBool "f")
+                        )
             ],
           testGroup
             "(,,,)"
@@ -307,12 +307,12 @@ seqTests =
               testCase "(SymBool, SymBool, SymBool, SymBool)" $ do
                 (ssymBool "a", ssymBool "c", ssymBool "e", ssymBool "g")
                   ==~ (ssymBool "b", ssymBool "d", ssymBool "f", ssymBool "h")
-                    @=? ( (ssymBool "a" ==~ ssymBool "b")
-                            &&~ (ssymBool "c" ==~ ssymBool "d")
-                        )
-                  &&~ ( (ssymBool "e" ==~ ssymBool "f")
-                          &&~ (ssymBool "g" ==~ ssymBool "h")
+                  @=? ( (ssymBool "a" ==~ ssymBool "b")
+                          &&~ (ssymBool "c" ==~ ssymBool "d")
                       )
+                    &&~ ( (ssymBool "e" ==~ ssymBool "f")
+                            &&~ (ssymBool "g" ==~ ssymBool "h")
+                        )
             ],
           testGroup
             "(,,,,)"
@@ -334,14 +334,14 @@ seqTests =
                         ssymBool "h",
                         ssymBool "j"
                       )
-                    @=? ( (ssymBool "a" ==~ ssymBool "b")
-                            &&~ (ssymBool "c" ==~ ssymBool "d")
-                        )
-                  &&~ ( (ssymBool "e" ==~ ssymBool "f")
-                          &&~ ( (ssymBool "g" ==~ ssymBool "h")
-                                  &&~ (ssymBool "i" ==~ ssymBool "j")
-                              )
+                  @=? ( (ssymBool "a" ==~ ssymBool "b")
+                          &&~ (ssymBool "c" ==~ ssymBool "d")
                       )
+                    &&~ ( (ssymBool "e" ==~ ssymBool "f")
+                            &&~ ( (ssymBool "g" ==~ ssymBool "h")
+                                    &&~ (ssymBool "i" ==~ ssymBool "j")
+                                )
+                        )
             ],
           testGroup
             "(,,,,,)"
@@ -372,16 +372,16 @@ seqTests =
                         ssymBool "j",
                         ssymBool "l"
                       )
-                    @=? ( (ssymBool "a" ==~ ssymBool "b")
-                            &&~ ( (ssymBool "c" ==~ ssymBool "d")
-                                    &&~ (ssymBool "e" ==~ ssymBool "f")
-                                )
-                        )
-                  &&~ ( (ssymBool "g" ==~ ssymBool "h")
-                          &&~ ( (ssymBool "i" ==~ ssymBool "j")
-                                  &&~ (ssymBool "k" ==~ ssymBool "l")
+                  @=? ( (ssymBool "a" ==~ ssymBool "b")
+                          &&~ ( (ssymBool "c" ==~ ssymBool "d")
+                                  &&~ (ssymBool "e" ==~ ssymBool "f")
                               )
                       )
+                    &&~ ( (ssymBool "g" ==~ ssymBool "h")
+                            &&~ ( (ssymBool "i" ==~ ssymBool "j")
+                                    &&~ (ssymBool "k" ==~ ssymBool "l")
+                                )
+                        )
             ],
           testGroup
             "(,,,,,,)"
@@ -416,18 +416,18 @@ seqTests =
                           ssymBool "l",
                           ssymBool "n"
                         )
-                      @=? ( (ssymBool "a" ==~ ssymBool "b")
-                              &&~ ( (ssymBool "c" ==~ ssymBool "d")
-                                      &&~ (ssymBool "e" ==~ ssymBool "f")
-                                  )
-                          )
-                    &&~ ( ( (ssymBool "g" ==~ ssymBool "h")
-                              &&~ (ssymBool "i" ==~ ssymBool "j")
-                          )
-                            &&~ ( (ssymBool "k" ==~ ssymBool "l")
-                                    &&~ (ssymBool "m" ==~ ssymBool "n")
+                    @=? ( (ssymBool "a" ==~ ssymBool "b")
+                            &&~ ( (ssymBool "c" ==~ ssymBool "d")
+                                    &&~ (ssymBool "e" ==~ ssymBool "f")
                                 )
                         )
+                      &&~ ( ( (ssymBool "g" ==~ ssymBool "h")
+                                &&~ (ssymBool "i" ==~ ssymBool "j")
+                            )
+                              &&~ ( (ssymBool "k" ==~ ssymBool "l")
+                                      &&~ (ssymBool "m" ==~ ssymBool "n")
+                                  )
+                          )
             ],
           testGroup
             "(,,,,,,,)"
@@ -464,20 +464,20 @@ seqTests =
                         ssymBool "n",
                         ssymBool "p"
                       )
-                    @=? ( ( (ssymBool "a" ==~ ssymBool "b")
-                              &&~ (ssymBool "c" ==~ ssymBool "d")
-                          )
-                            &&~ ( (ssymBool "e" ==~ ssymBool "f")
-                                    &&~ (ssymBool "g" ==~ ssymBool "h")
-                                )
+                  @=? ( ( (ssymBool "a" ==~ ssymBool "b")
+                            &&~ (ssymBool "c" ==~ ssymBool "d")
                         )
-                  &&~ ( ( (ssymBool "i" ==~ ssymBool "j")
-                            &&~ (ssymBool "k" ==~ ssymBool "l")
-                        )
-                          &&~ ( (ssymBool "m" ==~ ssymBool "n")
-                                  &&~ (ssymBool "o" ==~ ssymBool "p")
+                          &&~ ( (ssymBool "e" ==~ ssymBool "f")
+                                  &&~ (ssymBool "g" ==~ ssymBool "h")
                               )
                       )
+                    &&~ ( ( (ssymBool "i" ==~ ssymBool "j")
+                              &&~ (ssymBool "k" ==~ ssymBool "l")
+                          )
+                            &&~ ( (ssymBool "m" ==~ ssymBool "n")
+                                    &&~ (ssymBool "o" ==~ ssymBool "p")
+                                )
+                        )
             ],
           testCase "ByteString" $ do
             let bytestrings :: [B.ByteString] = ["", "a", "ab"]
@@ -501,21 +501,21 @@ seqTests =
                 [ testCase "InL (Just v) vs InL (Just v)" $
                     (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       ==~ InL (Just $ ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase "InL (Just v) vs InR (Just v)" $
                     (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       ==~ InR (Just $ ssymBool "b")
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "InR (Just v) vs InR (Just v)" $
                     (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       ==~ InR (Just $ ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase "InR (Just v) vs InL (Just v)" $
                     (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       ==~ InL (Just $ ssymBool "b")
-                        @=? conBool False
+                      @=? conBool False
                 ]
             ],
           testGroup
@@ -540,22 +540,22 @@ seqTests =
                             WriterLazy.WriterT SymBool (Either SymBool) SymBool
                         )
                           ==~ WriterLazy.WriterT (Left $ ssymBool "b")
-                            @=? ssymBool "a"
-                          ==~ ssymBool "b",
+                          @=? ssymBool "a"
+                            ==~ ssymBool "b",
                       testCase "WriterT (Left v) vs WriterT (Right v)" $
                         ( WriterLazy.WriterT (Left $ ssymBool "a") ::
                             WriterLazy.WriterT SymBool (Either SymBool) SymBool
                         )
                           ==~ WriterLazy.WriterT
                             (Right (ssymBool "b", ssymBool "c"))
-                            @=? conBool False,
+                          @=? conBool False,
                       testCase "WriterT (Right v) vs WriterT (Left v)" $
                         ( WriterLazy.WriterT
                             (Right (ssymBool "b", ssymBool "c")) ::
                             WriterLazy.WriterT SymBool (Either SymBool) SymBool
                         )
                           ==~ WriterLazy.WriterT (Left $ ssymBool "a")
-                            @=? conBool False,
+                          @=? conBool False,
                       testCase "WriterT (Right v) vs WriterT (Right v)" $
                         ( WriterLazy.WriterT
                             (Right (ssymBool "a", ssymBool "b")) ::
@@ -563,8 +563,8 @@ seqTests =
                         )
                           ==~ WriterLazy.WriterT
                             (Right (ssymBool "c", ssymBool "d"))
-                            @=? (ssymBool "a" ==~ ssymBool "c")
-                          &&~ (ssymBool "b" ==~ ssymBool "d")
+                          @=? (ssymBool "a" ==~ ssymBool "c")
+                            &&~ (ssymBool "b" ==~ ssymBool "d")
                     ]
                 ],
               testGroup
@@ -590,8 +590,8 @@ seqTests =
                               SymBool
                         )
                           ==~ WriterStrict.WriterT (Left $ ssymBool "b")
-                            @=? ssymBool "a"
-                          ==~ ssymBool "b",
+                          @=? ssymBool "a"
+                            ==~ ssymBool "b",
                       testCase "WriterT (Left v) vs WriterT (Right v)" $
                         ( WriterStrict.WriterT (Left $ ssymBool "a") ::
                             WriterStrict.WriterT
@@ -601,7 +601,7 @@ seqTests =
                         )
                           ==~ WriterStrict.WriterT
                             (Right (ssymBool "b", ssymBool "c"))
-                            @=? conBool False,
+                          @=? conBool False,
                       testCase "WriterT (Right v) vs WriterT (Left v)" $
                         ( WriterStrict.WriterT
                             (Right (ssymBool "b", ssymBool "c")) ::
@@ -611,7 +611,7 @@ seqTests =
                               SymBool
                         )
                           ==~ WriterStrict.WriterT (Left $ ssymBool "a")
-                            @=? conBool False,
+                          @=? conBool False,
                       testCase "WriterT (Right v) vs WriterT (Right v)" $
                         ( WriterStrict.WriterT
                             (Right (ssymBool "a", ssymBool "b")) ::
@@ -622,9 +622,9 @@ seqTests =
                         )
                           ==~ WriterStrict.WriterT
                             (Right (ssymBool "c", ssymBool "d"))
-                            @=? ssymBool "a"
-                          ==~ ssymBool "c"
-                          &&~ ssymBool "b"
+                          @=? ssymBool "a"
+                            ==~ ssymBool "c"
+                            &&~ ssymBool "b"
                             ==~ ssymBool "d"
                     ]
                 ]
@@ -639,8 +639,8 @@ seqTests =
               testCase "Identity SymBool" $ do
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   ==~ Identity (ssymBool "b")
-                    @=? ssymBool "a"
-                  ==~ ssymBool "b"
+                  @=? ssymBool "a"
+                    ==~ ssymBool "b"
             ],
           testGroup
             "IdentityT"
@@ -656,27 +656,27 @@ seqTests =
                         IdentityT (Either SymBool) SymBool
                     )
                       ==~ IdentityT (Left $ ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b",
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b",
                   testCase "IdentityT (Left v) vs IdentityT (Right v)" $
                     ( IdentityT $ Left $ ssymBool "a" ::
                         IdentityT (Either SymBool) SymBool
                     )
                       ==~ IdentityT (Right $ ssymBool "b")
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "IdentityT (Right v) vs IdentityT (Left v)" $
                     ( IdentityT $ Right $ ssymBool "a" ::
                         IdentityT (Either SymBool) SymBool
                     )
                       ==~ IdentityT (Left $ ssymBool "b")
-                        @=? conBool False,
+                      @=? conBool False,
                   testCase "IdentityT (Right v) vs IdentityT (Right v)" $
                     ( IdentityT $ Right $ ssymBool "a" ::
                         IdentityT (Either SymBool) SymBool
                     )
                       ==~ IdentityT (Right $ ssymBool "b")
-                        @=? ssymBool "a"
-                      ==~ ssymBool "b"
+                      @=? ssymBool "a"
+                        ==~ ssymBool "b"
                 ]
             ]
         ],
@@ -695,23 +695,23 @@ seqTests =
               testCase "A2 vs A2" $
                 A2 (ssymBool "a")
                   ==~ A2 (ssymBool "b")
-                    @=? ssymBool "a"
-                  ==~ ssymBool "b",
+                  @=? ssymBool "a"
+                    ==~ ssymBool "b",
               testCase "A2 vs A3" $
                 A2 (ssymBool "a")
                   ==~ A3 (ssymBool "b") (ssymBool "c")
-                    @=? conBool False,
+                  @=? conBool False,
               testCase "A3 vs A1" $
                 A3 (ssymBool "a") (ssymBool "b") ==~ A1 @=? conBool False,
               testCase "A3 vs A2" $
                 A3 (ssymBool "a") (ssymBool "b")
                   ==~ A2 (ssymBool "c")
-                    @=? conBool False,
+                  @=? conBool False,
               testCase "A3 vs A3" $
                 A3 (ssymBool "a") (ssymBool "b")
                   ==~ A3 (ssymBool "c") (ssymBool "d")
-                    @=? (ssymBool "a" ==~ ssymBool "c")
-                  &&~ (ssymBool "b" ==~ ssymBool "d")
+                  @=? (ssymBool "a" ==~ ssymBool "c")
+                    &&~ (ssymBool "b" ==~ ssymBool "d")
             ]
         ]
     ]

--- a/test/Grisette/Core/Data/Class/SOrdTests.hs
+++ b/test/Grisette/Core/Data/Class/SOrdTests.hs
@@ -103,20 +103,20 @@ sordTests =
               testCase "Symbolic SymBool" $ do
                 ssymBool "a"
                   <=~ ssymBool "b"
-                    @?= (nots (ssymBool "a"))
-                  ||~ (ssymBool "b")
+                  @?= (nots (ssymBool "a"))
+                    ||~ (ssymBool "b")
                 ssymBool "a"
                   <~ ssymBool "b"
-                    @?= (nots (ssymBool "a"))
+                  @?= (nots (ssymBool "a"))
                   &&~ (ssymBool "b")
                 ssymBool "a"
                   >=~ ssymBool "b"
-                    @?= (ssymBool "a")
-                  ||~ (nots (ssymBool "b"))
+                  @?= (ssymBool "a")
+                    ||~ (nots (ssymBool "b"))
                 ssymBool "a"
                   >~ ssymBool "b"
-                    @?= (ssymBool "a")
-                  &&~ (nots (ssymBool "b"))
+                  @?= (ssymBool "a")
+                    &&~ (nots (ssymBool "b"))
                 symCompare (ssymBool "a") (ssymBool "b")
                   @?= ( mrgIf
                           ((nots (ssymBool "a")) &&~ (ssymBool "b"))
@@ -173,44 +173,44 @@ sordTests =
 
                 [ssymBool "a", ssymBool "b"]
                   <=~ [ssymBool "c"]
-                    @?= (ssymBool "a" <~ ssymBool "c" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "c" :: SymBool)
                 [ssymBool "a", ssymBool "b"]
                   <~ [ssymBool "c"]
-                    @?= (ssymBool "a" <~ ssymBool "c" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "c" :: SymBool)
                 [ssymBool "a", ssymBool "b"]
                   >=~ [ssymBool "c"]
-                    @?= ( (ssymBool "a" >~ ssymBool "c")
-                            ||~ (ssymBool "a" ==~ ssymBool "c") ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" >~ ssymBool "c")
+                          ||~ (ssymBool "a" ==~ ssymBool "c") ::
+                          SymBool
+                      )
                 [ssymBool "a", ssymBool "b"]
                   >~ [ssymBool "c"]
-                    @?= ( (ssymBool "a" >~ ssymBool "c")
-                            ||~ (ssymBool "a" ==~ ssymBool "c") ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" >~ ssymBool "c")
+                          ||~ (ssymBool "a" ==~ ssymBool "c") ::
+                          SymBool
+                      )
                 [ssymBool "a"]
                   `symCompare` [ssymBool "b"]
                   @?= (ssymBool "a" `symCompare` ssymBool "b" :: UnionM Ordering)
 
                 [ssymBool "a"]
                   <=~ [ssymBool "b", ssymBool "c"]
-                    @?= ( (ssymBool "a" <~ ssymBool "b")
-                            ||~ (ssymBool "a" ==~ ssymBool "b") ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" <~ ssymBool "b")
+                          ||~ (ssymBool "a" ==~ ssymBool "b") ::
+                          SymBool
+                      )
                 [ssymBool "a"]
                   <~ [ssymBool "b", ssymBool "c"]
-                    @?= ( (ssymBool "a" <~ ssymBool "b")
-                            ||~ (ssymBool "a" ==~ ssymBool "b") ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" <~ ssymBool "b")
+                          ||~ (ssymBool "a" ==~ ssymBool "b") ::
+                          SymBool
+                      )
                 [ssymBool "a"]
                   >=~ [ssymBool "b", ssymBool "c"]
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 [ssymBool "a"]
                   >~ [ssymBool "b", ssymBool "c"]
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 [ssymBool "a"]
                   `symCompare` [ssymBool "b", ssymBool "c"]
                   @?= ( mrgIf
@@ -226,44 +226,44 @@ sordTests =
 
                 [ssymBool "a", ssymBool "b"]
                   <=~ [ssymBool "c", ssymBool "d"]
-                    @?= ( (ssymBool "a" <~ ssymBool "c")
-                            ||~ ( ssymBool "a"
-                                    ==~ ssymBool "c"
-                                    &&~ ( (ssymBool "b" <~ ssymBool "d")
-                                            ||~ (ssymBool "b" ==~ ssymBool "d")
-                                        )
-                                ) ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" <~ ssymBool "c")
+                          ||~ ( ssymBool "a"
+                                  ==~ ssymBool "c"
+                                  &&~ ( (ssymBool "b" <~ ssymBool "d")
+                                          ||~ (ssymBool "b" ==~ ssymBool "d")
+                                      )
+                              ) ::
+                          SymBool
+                      )
                 [ssymBool "a", ssymBool "b"]
                   <~ [ssymBool "c", ssymBool "d"]
-                    @?= ( (ssymBool "a" <~ ssymBool "c")
-                            ||~ ( ssymBool "a"
-                                    ==~ ssymBool "c"
-                                    &&~ (ssymBool "b" <~ ssymBool "d")
-                                ) ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" <~ ssymBool "c")
+                          ||~ ( ssymBool "a"
+                                  ==~ ssymBool "c"
+                                  &&~ (ssymBool "b" <~ ssymBool "d")
+                              ) ::
+                          SymBool
+                      )
                 [ssymBool "a", ssymBool "b"]
                   >=~ [ssymBool "c", ssymBool "d"]
-                    @?= ( (ssymBool "a" >~ ssymBool "c")
-                            ||~ ( ssymBool "a"
-                                    ==~ ssymBool "c"
-                                    &&~ ( (ssymBool "b" >~ ssymBool "d")
-                                            ||~ (ssymBool "b" ==~ ssymBool "d")
-                                        )
-                                ) ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" >~ ssymBool "c")
+                          ||~ ( ssymBool "a"
+                                  ==~ ssymBool "c"
+                                  &&~ ( (ssymBool "b" >~ ssymBool "d")
+                                          ||~ (ssymBool "b" ==~ ssymBool "d")
+                                      )
+                              ) ::
+                          SymBool
+                      )
                 [ssymBool "a", ssymBool "b"]
                   >~ [ssymBool "c", ssymBool "d"]
-                    @?= ( (ssymBool "a" >~ ssymBool "c")
-                            ||~ ( ssymBool "a"
-                                    ==~ ssymBool "c"
-                                    &&~ (ssymBool "b" >~ ssymBool "d")
-                                ) ::
-                            SymBool
-                        )
+                  @?= ( (ssymBool "a" >~ ssymBool "c")
+                          ||~ ( ssymBool "a"
+                                  ==~ ssymBool "c"
+                                  &&~ (ssymBool "b" >~ ssymBool "d")
+                              ) ::
+                          SymBool
+                      )
                 [ssymBool "a", ssymBool "b"]
                   `symCompare` [ssymBool "c", ssymBool "d"]
                   @?= ( mrgIf
@@ -305,16 +305,16 @@ sordTests =
                   @?= (mrgSingle GT :: UnionM Ordering)
                 Just (ssymBool "a")
                   <=~ Just (ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 Just (ssymBool "a")
                   <~ Just (ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 Just (ssymBool "a")
                   >=~ Just (ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 Just (ssymBool "a")
                   >~ Just (ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 Just (ssymBool "a")
                   `symCompare` Just (ssymBool "b")
                   @?= ( ssymBool "a" `symCompare` ssymBool "b" ::
@@ -330,63 +330,63 @@ sordTests =
               testCase "MaybeT Maybe SymBool" $ do
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   <=~ MaybeT Nothing
-                    @?= conBool True
+                  @?= conBool True
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   <=~ MaybeT (Just (Just (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 MaybeT (Just (Just (ssymBool "a")))
                   <=~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 MaybeT (Just (Just (ssymBool "a")))
                   <=~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                           MaybeT Maybe SymBool
                       )
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
 
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   <~ MaybeT Nothing
-                    @?= conBool False
+                  @?= conBool False
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   <~ MaybeT (Just (Just (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 MaybeT (Just (Just (ssymBool "a")))
                   <~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 MaybeT (Just (Just (ssymBool "a")))
                   <~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                          MaybeT Maybe SymBool
                      )
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
 
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   >=~ MaybeT Nothing
-                    @?= conBool True
+                  @?= conBool True
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   >=~ MaybeT (Just (Just (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 MaybeT (Just (Just (ssymBool "a")))
                   >=~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 MaybeT (Just (Just (ssymBool "a")))
                   >=~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                           MaybeT Maybe SymBool
                       )
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
 
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   >~ MaybeT Nothing
-                    @?= conBool False
+                  @?= conBool False
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   >~ MaybeT (Just (Just (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 MaybeT (Just (Just (ssymBool "a")))
                   >~ (MaybeT Nothing :: MaybeT Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 MaybeT (Just (Just (ssymBool "a")))
                   >~ ( MaybeT (Just (Just (ssymBool "b"))) ::
                          MaybeT Maybe SymBool
                      )
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
 
                 (MaybeT Nothing :: MaybeT Maybe SymBool)
                   `symCompare` MaybeT Nothing
@@ -412,61 +412,61 @@ sordTests =
               testCase "Either SymBool SymBool" $ do
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   <=~ Left (ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   <~ Left (ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   >=~ Left (ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   >~ Left (ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   `symCompare` Left (ssymBool "b")
                   @?= (ssymBool "a" `symCompare` ssymBool "b")
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   <=~ Right (ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   <~ Right (ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   >=~ Right (ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   >~ Right (ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (Left (ssymBool "a") :: Either SymBool SymBool)
                   `symCompare` Right (ssymBool "b")
                   @?= (mrgSingle LT :: UnionM Ordering)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   <=~ Left (ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   <~ Left (ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   >=~ Left (ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   >~ Left (ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   `symCompare` Left (ssymBool "b")
                   @?= (mrgSingle GT :: UnionM Ordering)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   <=~ Right (ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   <~ Right (ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   >=~ Right (ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   >~ Right (ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 (Right (ssymBool "a") :: Either SymBool SymBool)
                   `symCompare` Right (ssymBool "b")
                   @?= (ssymBool "a" `symCompare` ssymBool "b")
@@ -481,147 +481,147 @@ sordTests =
               testCase "ExceptT SymBool Maybe SymBool" $ do
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <=~ ExceptT Nothing
-                    @?= conBool True
+                  @?= conBool True
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <=~ ExceptT (Just (Left (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <=~ ExceptT (Just (Right (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   <=~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Right (ssymBool "a")))
                   <=~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   <=~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 ExceptT (Just (Right (ssymBool "a")))
                   <=~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   <=~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Right (ssymBool "a")))
                   <=~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
 
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <~ ExceptT Nothing
-                    @?= conBool False
+                  @?= conBool False
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <~ ExceptT (Just (Left (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   <~ ExceptT (Just (Right (ssymBool "a")))
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   <~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Right (ssymBool "a")))
                   <~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   <~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 ExceptT (Just (Right (ssymBool "a")))
                   <~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   <~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Right (ssymBool "a")))
                   <~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
 
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >=~ ExceptT Nothing
-                    @?= conBool True
+                  @?= conBool True
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >=~ ExceptT (Just (Left (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >=~ ExceptT (Just (Right (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   >=~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Right (ssymBool "a")))
                   >=~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   >=~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 ExceptT (Just (Right (ssymBool "a")))
                   >=~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   >=~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Right (ssymBool "a")))
                   >=~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                           ExceptT SymBool Maybe SymBool
                       )
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
 
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >~ ExceptT Nothing
-                    @?= conBool False
+                  @?= conBool False
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >~ ExceptT (Just (Left (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   >~ ExceptT (Just (Right (ssymBool "a")))
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Left (ssymBool "a")))
                   >~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Right (ssymBool "a")))
                   >~ (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   >~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 ExceptT (Just (Right (ssymBool "a")))
                   >~ ( ExceptT (Just (Left (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= conBool True
+                  @?= conBool True
                 ExceptT (Just (Left (ssymBool "a")))
                   >~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= conBool False
+                  @?= conBool False
                 ExceptT (Just (Right (ssymBool "a")))
                   >~ ( ExceptT (Just (Right (ssymBool "b"))) ::
                          ExceptT SymBool Maybe SymBool
                      )
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
 
                 (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                   `symCompare` ExceptT Nothing
@@ -896,52 +896,52 @@ sordTests =
               testCase "Sum Maybe Maybe SymBool" $ do
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <=~ InL (Just $ ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <~ InL (Just $ ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >=~ InL (Just $ ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >~ InL (Just $ ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <=~ InR (Just $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <~ InR (Just $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >=~ InR (Just $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >~ InR (Just $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <=~ InR (Just $ ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <~ InR (Just $ ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >=~ InR (Just $ ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >~ InR (Just $ ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <=~ InL (Just $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   <~ InL (Just $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >=~ InL (Just $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                   >~ InL (Just $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
             ],
           testGroup
             "WriterT"
@@ -963,22 +963,22 @@ sordTests =
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <=~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -992,24 +992,24 @@ sordTests =
                       )
                       <=~ WriterLazy.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterLazy.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterLazy.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterLazy.WriterT (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterLazy.WriterT $ Left $ ssymBool "a" ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -1021,22 +1021,22 @@ sordTests =
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <=~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterLazy.WriterT (Left $ ssymBool "b")
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -1047,35 +1047,35 @@ sordTests =
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <=~ WriterLazy.WriterT (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                <=~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              <=~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterLazy.WriterT (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                <~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              <~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterLazy.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                >=~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              >=~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterLazy.WriterT (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                >~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              >~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterLazy.WriterT $ Right (ssymBool "a", ssymBool "c") ::
                         WriterLazy.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -1104,22 +1104,22 @@ sordTests =
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <=~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                      @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -1133,25 +1133,25 @@ sordTests =
                       )
                       <=~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterStrict.WriterT $ Left $ ssymBool "a" ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
@@ -1164,25 +1164,25 @@ sordTests =
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <=~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= conBool False
+                      @?= conBool False
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterStrict.WriterT (Left $ ssymBool "b")
-                        @?= conBool True
+                      @?= conBool True
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
@@ -1196,40 +1196,40 @@ sordTests =
                       )
                       <=~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                <=~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              <=~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       <~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                <~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              <~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >=~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                >=~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              >=~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
                       )
                       >~ WriterStrict.WriterT
                         (Right (ssymBool "b", ssymBool "d"))
-                        @?= ( (ssymBool "a", ssymBool "c")
-                                >~ (ssymBool "b", ssymBool "d") ::
-                                SymBool
-                            )
+                      @?= ( (ssymBool "a", ssymBool "c")
+                              >~ (ssymBool "b", ssymBool "d") ::
+                              SymBool
+                          )
                     ( WriterStrict.WriterT $
                         Right (ssymBool "a", ssymBool "c") ::
                         WriterStrict.WriterT SymBool (Either SymBool) SymBool
@@ -1252,16 +1252,16 @@ sordTests =
               testCase "Identity SymBool" $ do
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   <=~ Identity (ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   <~ Identity (ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   >=~ Identity (ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   >~ Identity (ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
             ],
           testGroup
             "IdentityT"
@@ -1275,22 +1275,22 @@ sordTests =
                     IdentityT (Either SymBool) SymBool
                   )
                   <=~ IdentityT (Left $ ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   <~ IdentityT (Left $ ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >=~ IdentityT (Left $ ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >~ IdentityT (Left $ ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
@@ -1301,22 +1301,22 @@ sordTests =
                     IdentityT (Either SymBool) SymBool
                   )
                   <=~ IdentityT (Right $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   <~ IdentityT (Right $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >=~ IdentityT (Right $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >~ IdentityT (Right $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 ( IdentityT $ Left $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
@@ -1327,22 +1327,22 @@ sordTests =
                     IdentityT (Either SymBool) SymBool
                   )
                   <=~ IdentityT (Left $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   <~ IdentityT (Left $ ssymBool "b")
-                    @?= conBool False
+                  @?= conBool False
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >=~ IdentityT (Left $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >~ IdentityT (Left $ ssymBool "b")
-                    @?= conBool True
+                  @?= conBool True
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
@@ -1353,22 +1353,22 @@ sordTests =
                     IdentityT (Either SymBool) SymBool
                   )
                   <=~ IdentityT (Right $ ssymBool "b")
-                    @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <=~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   <~ IdentityT (Right $ ssymBool "b")
-                    @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" <~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >=~ IdentityT (Right $ ssymBool "b")
-                    @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >=~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )
                   >~ IdentityT (Right $ ssymBool "b")
-                    @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
+                  @?= (ssymBool "a" >~ ssymBool "b" :: SymBool)
                 ( IdentityT $ Right $ ssymBool "a" ::
                     IdentityT (Either SymBool) SymBool
                   )


### PR DESCRIPTION
Ormolu does not have a stable format. It is better to pin it to a specific version to avoid extra reformatting.