### PR TITLE
Fix heap overflow for shiftL for bitvectors by large numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the symbolic generation order for `Maybe`. ([#131](https://github.com/lsrcz/grisette/pull/131))
 - Fixed the `toInteger` function for `IntN 1`. ([#143](https://github.com/lsrcz/grisette/pull/143))
 - Fixed the `abs` function for `WordN`. ([#144](https://github.com/lsrcz/grisette/pull/143))
+- Fixed the QuickCheck shrink function for `WordN 1` and `IntN 1`. ([#149](https://github.com/lsrcz/grisette/pull/149))
+- Fixed the heap overflow bug for `shiftL` for `WordN` and `IntN` by large numbers. ([#150](https://github.com/lsrcz/grisette/pull/150))
 
 ### Changed
 

--- a/src/Grisette/Core/Data/BV.hs
+++ b/src/Grisette/Core/Data/BV.hs
@@ -374,9 +374,11 @@ instance (KnownNat n, 1 <= n) => Bits (WordN n) where
   bitSizeMaybe = Just . finiteBitSize
   bitSize = finiteBitSize
   isSigned _ = False
+  shiftL w i | i >= finiteBitSize w = 0
   shiftL (WordN a) i = WordN (a `shiftL` i) .&. maxBound
 
   -- unsafeShiftL use default implementation
+  shiftR w i | i >= finiteBitSize w = 0
   shiftR (WordN a) i = WordN (a `shiftR` i)
 
   -- unsafeShiftR use default implementation

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -474,6 +474,10 @@ bvTests =
             shouldThrow "quot" $ quot (minBound :: IntN 8) (-1 :: IntN 8),
           testCase "toInteger for IntN 1" $ do
             toInteger (0 :: IntN 1) @=? 0
-            toInteger (1 :: IntN 1) @=? (-1)
+            toInteger (1 :: IntN 1) @=? (-1),
+          testProperty "WordN shiftL by large amount" $ \(x :: WordN 128) ->
+            ioProperty $ shiftL x maxBound @=? 0,
+          testProperty "IntN shiftL by large amount" $ \(x :: IntN 128) ->
+            ioProperty $ shiftL x maxBound @=? 0
         ]
     ]


### PR DESCRIPTION
Currently, the `shiftL` implementation forwards the shift value directly to the underlying `Integer` representation for `WordN` and then do a masking. This is buggy as the `Integer` type can grow very large if the shift amount is large. This pull request fixes this and shifting by large numbers no longer yields an heap overflow error.
