### PR TITLE
Add liftFresh to lift a Fresh into MonadFresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `Grisette.Data.Class.SignConversion.SignConversion` for types from `Data.Int` and `Data.Word`. ([#142](https://github.com/lsrcz/grisette/pull/142))
 - Added shift functions by symbolic shift amounts. ([#151](https://github.com/lsrcz/grisette/pull/151))
 - Added `apply` for uninterpreted functions. ([#155](https://github.com/lsrcz/grisette/pull/155))
+- Added `liftFresh` to lift a `Fresh` into `MonadFresh`. ([#156](https://github.com/lsrcz/grisette/pull/156))
 
 ### Removed
 
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Moved `Grisette.Data.Class.Evaluate` to `Grisette.Data.Class.EvaluateSym`. ([#146](https://github.com/lsrcz/grisette/pull/146))
 - [Breaking] Moved `Grisette.Data.Class.Substitute` to `Grisette.Data.Class.SubstituteSym`. ([#146](https://github.com/lsrcz/grisette/pull/146))
 - [Breaking] Split the `Grisette.Data.Class.SafeArith` module to `Grisette.Data.Class.SafeDivision` and `Grisette.Data.Class.SafeLinearArith`. ([#146](https://github.com/lsrcz/grisette/pull/146))
+- [Breaking] Changed the API to `MonadFresh`. ([#156](https://github.com/lsrcz/grisette/pull/156))
 
 ## [0.3.1.1] -- 2023-09-29
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -711,6 +711,8 @@ module Grisette.Core
 
     -- ** Symbolic Generation Monad
     MonadFresh (..),
+    nextFreshIndex,
+    liftFresh,
     Fresh,
     FreshT (..),
     runFresh,
@@ -1109,9 +1111,11 @@ import Grisette.Core.Data.Class.GenSym
     derivedSameShapeSimpleFresh,
     genSym,
     genSymSimple,
+    liftFresh,
     mrgRunFreshT,
     name,
     nameWithInfo,
+    nextFreshIndex,
     runFresh,
     runFreshT,
   )

--- a/test/Grisette/Core/Data/Class/GenSymTests.hs
+++ b/test/Grisette/Core/Data/Class/GenSymTests.hs
@@ -9,6 +9,9 @@ import Grisette.Core.Control.Monad.UnionM (UnionM)
 import Grisette.Core.Data.Class.GenSym
   ( EnumGenBound (EnumGenBound),
     EnumGenUpperBound (EnumGenUpperBound),
+    Fresh,
+    FreshT,
+    GenSymSimple (simpleFresh),
     ListSpec (ListSpec),
     SimpleListSpec (SimpleListSpec),
     choose,
@@ -19,7 +22,9 @@ import Grisette.Core.Data.Class.GenSym
     chooseUnionFresh,
     genSym,
     genSymSimple,
+    liftFresh,
     runFresh,
+    runFreshT,
   )
 import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
 import Grisette.Core.Data.Class.SimpleMergeable
@@ -1242,6 +1247,19 @@ genSymTests =
                     (isymBool "a" 1)
                     (mrgIf (ssymBool "x") 2 3)
                     (mrgIf (ssymBool "x") 3 4)
-                )
+                ),
+          testCase "liftFresh" $ do
+            let orig = simpleFresh () :: Fresh (SymBool, SymBool)
+            let actual = flip runFreshT "a" $ do
+                  r1 <- liftFresh orig
+                  r2 <- liftFresh orig
+                  return (r1, r2) ::
+                    FreshT UnionM ((SymBool, SymBool), (SymBool, SymBool))
+            let expected =
+                  return
+                    ( (isymBool "a" 0, isymBool "a" 1),
+                      (isymBool "a" 2, isymBool "a" 3)
+                    )
+            actual @?= expected
         ]
     ]


### PR DESCRIPTION
This pull request resolves #114. A `liftFresh` function is added to lift a `Fresh` value into any `MonadFresh`.

This pull request also changed the API to `MonadFresh` as the previous API isn't general enough.