### PR TITLE
Rename symbolic operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Moved `Grisette.Data.Class.Substitute` to `Grisette.Data.Class.SubstituteSym`. ([#146](https://github.com/lsrcz/grisette/pull/146))
 - [Breaking] Split the `Grisette.Data.Class.SafeArith` module to `Grisette.Data.Class.SafeDivision` and `Grisette.Data.Class.SafeLinearArith`. ([#146](https://github.com/lsrcz/grisette/pull/146))
 - [Breaking] Changed the API to `MonadFresh`. ([#156](https://github.com/lsrcz/grisette/pull/156))
+- [Breaking] Renamed multiple symbolic operators. ([#158](https://github.com/lsrcz/grisette/pull/158))
 
 ## [0.3.1.1] -- 2023-09-29
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -166,7 +166,7 @@ module Grisette.Core
     --
     -- >>> let a = "a" :: SymInteger
     -- >>> let b = "b" :: SymInteger
-    -- >>> a ==~ b
+    -- >>> a .== b
     -- (= a b)
 
     -- *** Creation of solvable type values
@@ -609,7 +609,7 @@ module Grisette.Core
     onUnion2,
     onUnion3,
     onUnion4,
-    (#~),
+    (.#),
 
     -- * Conversion between Concrete and Symbolic values
     ToCon (..),
@@ -842,9 +842,9 @@ module Grisette.Core
     -- >>> import Grisette.Backend.SBV
     -- >>> let x = "x" :: SymInteger
     -- >>> let y = "y" :: SymInteger
-    -- >>> solve (precise z3) (x + y ==~ 6 &&~ x - y ==~ 20)
+    -- >>> solve (precise z3) (x + y .== 6 .&& x - y .== 20)
     -- Right (Model {x -> 13 :: Integer, y -> -7 :: Integer})
-    -- >>> solve (precise z3) (x + y ==~ 6 &&~ x - y ==~ 19)
+    -- >>> solve (precise z3) (x + y .== 6 .&& x - y .== 19)
     -- Left Unsat
     --
     -- The first parameter of 'solve' is the solver configuration.
@@ -863,7 +863,7 @@ module Grisette.Core
     -- evaluate symbolic values. The following code evaluates the product of
     -- x and y under the solution of the equation system.
     --
-    -- >>> Right m <- solve (precise z3) (x + y ==~ 6 &&~ x - y ==~ 20)
+    -- >>> Right m <- solve (precise z3) (x + y .== 6 .&& x - y .== 20)
     -- >>> evaluateSym False m (x * y)
     -- -91
     --
@@ -921,7 +921,7 @@ module Grisette.Core
     --   res :: ExceptT Error UnionM ()
     --   res = do
     --     z <- x `sdiv` y
-    --     mrgIf (z >~ 0) (assert (x >=~ y)) (return ())
+    --     mrgIf (z .> 0) (assert (x .>= y)) (return ())
     -- :}
     --
     -- Then we can ask the solver to find a counter-example that would lead to
@@ -933,7 +933,7 @@ module Grisette.Core
     -- >>> res
     -- ExceptT {If (|| (= y 0) (&& (< 0 (div x y)) (! (<= y x)))) (If (= y 0) (Left Arith) (Left Assert)) (Right ())}
     --
-    -- > >>> solveExcept (UnboundedReasoning z3) (==~ Left Assert) res
+    -- > >>> solveExcept (UnboundedReasoning z3) (.== Left Assert) res
     -- > Right (Model {x -> -6 :: Integer, y -> -3 :: Integer}) -- possible output
     --
     -- Grisette also provide implementation for counter-example guided inductive
@@ -1050,7 +1050,7 @@ import Grisette.Core.Control.Monad.UnionM
     UnionM,
     liftToMonadUnion,
     unionSize,
-    (#~),
+    (.#),
   )
 import Grisette.Core.Data.Class.BitVector
   ( BV (..),

--- a/src/Grisette/Core/Control/Monad/CBMCExcept.hs
+++ b/src/Grisette/Core/Control/Monad/CBMCExcept.hs
@@ -82,8 +82,8 @@ import Grisette.Core.Data.Class.Mergeable
     rootStrategy1,
     wrapStrategy,
   )
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
-import Grisette.Core.Data.Class.SOrd (SOrd (symCompare, (<=~), (<~), (>=~), (>~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
+import Grisette.Core.Data.Class.SOrd (SOrd (symCompare, (.<), (.<=), (.>), (.>=)))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
     SimpleMergeable1 (liftMrgIte),
@@ -351,8 +351,8 @@ instance (Monad m) => OrigExcept.MonadError e (CBMCExceptT e m) where
   {-# INLINE catchError #-}
 
 instance (SEq (m (CBMCEither e a))) => SEq (CBMCExceptT e m a) where
-  (CBMCExceptT a) ==~ (CBMCExceptT b) = a ==~ b
-  {-# INLINE (==~) #-}
+  (CBMCExceptT a) .== (CBMCExceptT b) = a .== b
+  {-# INLINE (.==) #-}
 
 instance (EvaluateSym (m (CBMCEither e a))) => EvaluateSym (CBMCExceptT e m a) where
   evaluateSym fillDefault model (CBMCExceptT v) = CBMCExceptT $ evaluateSym fillDefault model v
@@ -441,10 +441,10 @@ instance
   {-# INLINE unionIf #-}
 
 instance (SOrd (m (CBMCEither e a))) => SOrd (CBMCExceptT e m a) where
-  (CBMCExceptT l) <=~ (CBMCExceptT r) = l <=~ r
-  (CBMCExceptT l) <~ (CBMCExceptT r) = l <~ r
-  (CBMCExceptT l) >=~ (CBMCExceptT r) = l >=~ r
-  (CBMCExceptT l) >~ (CBMCExceptT r) = l >~ r
+  (CBMCExceptT l) .<= (CBMCExceptT r) = l .<= r
+  (CBMCExceptT l) .< (CBMCExceptT r) = l .< r
+  (CBMCExceptT l) .>= (CBMCExceptT r) = l .>= r
+  (CBMCExceptT l) .> (CBMCExceptT r) = l .> r
   symCompare (CBMCExceptT l) (CBMCExceptT r) = symCompare l r
 
 instance

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -33,7 +33,7 @@ module Grisette.Core.Control.Monad.UnionM
     liftToMonadUnion,
     underlyingUnion,
     isMerged,
-    (#~),
+    (.#),
     IsConcrete,
     unionSize,
   )
@@ -64,16 +64,16 @@ import Grisette.Core.Data.Class.GPretty
   ( GPretty (gpretty),
     groupedEnclose,
   )
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.LogicalOp
-  ( LogicalOp (implies, nots, xors, (&&~), (||~)),
+  ( LogicalOp (symImplies, symNot, symXor, (.&&), (.||)),
   )
 import Grisette.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
     Mergeable1 (liftRootStrategy),
     MergingStrategy (SimpleStrategy),
   )
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
     SimpleMergeable1 (liftMrgIte),
@@ -83,7 +83,7 @@ import Grisette.Core.Data.Class.SimpleMergeable
     mrgIf,
     mrgSingle,
     simpleMerge,
-    (#~),
+    (.#),
   )
 import Grisette.Core.Data.Class.Solvable
   ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
@@ -385,10 +385,10 @@ instance UnionLike UnionM where
   {-# INLINE unionIf #-}
 
 instance (SEq a) => SEq (UnionM a) where
-  x ==~ y = simpleMerge $ do
+  x .== y = simpleMerge $ do
     x1 <- x
     y1 <- y
-    mrgSingle $ x1 ==~ y1
+    mrgSingle $ x1 .== y1
 
 -- | Lift the 'UnionM' to any 'MonadUnion'.
 liftToMonadUnion :: (Mergeable a, MonadUnion u) => UnionM a -> u a
@@ -498,28 +498,28 @@ instance (Num a, Mergeable a) => Num (UnionM a) where
   signum x = x >>= mrgSingle . signum
 
 instance (ITEOp a, Mergeable a) => ITEOp (UnionM a) where
-  ites = mrgIf
+  symIte = mrgIf
 
 instance (LogicalOp a, Mergeable a) => LogicalOp (UnionM a) where
-  a ||~ b = do
+  a .|| b = do
     a1 <- a
     b1 <- b
-    mrgSingle $ a1 ||~ b1
-  a &&~ b = do
+    mrgSingle $ a1 .|| b1
+  a .&& b = do
     a1 <- a
     b1 <- b
-    mrgSingle $ a1 &&~ b1
-  nots x = do
+    mrgSingle $ a1 .&& b1
+  symNot x = do
     x1 <- x
-    mrgSingle $ nots x1
-  xors a b = do
+    mrgSingle $ symNot x1
+  symXor a b = do
     a1 <- a
     b1 <- b
-    mrgSingle $ a1 `xors` b1
-  implies a b = do
+    mrgSingle $ a1 `symXor` b1
+  symImplies a b = do
     a1 <- a
     b1 <- b
-    mrgSingle $ a1 `implies` b1
+    mrgSingle $ a1 `symImplies` b1
 
 instance (Solvable c t, Mergeable t) => Solvable c (UnionM t) where
   con = mrgSingle . con

--- a/src/Grisette/Core/Data/Class/CEGISSolver.hs
+++ b/src/Grisette/Core/Data/Class/CEGISSolver.hs
@@ -137,12 +137,12 @@ class
 -- CEGIS with a single symbolic input to represent a set of inputs.
 --
 -- The following example tries to find the value of @c@ such that for all
--- positive @x@, @x * c < 0 && c > -2@. The @c >~ -2@ clause is used to make
+-- positive @x@, @x * c < 0 && c > -2@. The @c .> -2@ clause is used to make
 -- the solution unique.
 --
 -- >>> :set -XOverloadedStrings
 -- >>> let [x,c] = ["x","c"] :: [SymInteger]
--- >>> cegis (precise z3) x (cegisPrePost (x >~ 0) (x * c <~ 0 &&~ c >~ -2))
+-- >>> cegis (precise z3) x (cegisPrePost (x .> 0) (x * c .< 0 .&& c .> -2))
 -- ([],Right (Model {c -> -1 :: Integer}))
 cegis ::
   ( CEGISSolver config failure,
@@ -251,7 +251,7 @@ cegisExceptStdVCMultiInputs config cexes =
 -- readability and modularity of the code.
 --
 -- The following example tries to find the value of @c@ such that for all
--- positive @x@, @x * c < 0 && c > -2@. The @c >~ -2@ assertion is used to make
+-- positive @x@, @x * c < 0 && c > -2@. The @c .> -2@ assertion is used to make
 -- the solution unique.
 --
 -- >>> :set -XOverloadedStrings
@@ -260,9 +260,9 @@ cegisExceptStdVCMultiInputs config cexes =
 -- >>> :{
 --   res :: ExceptT VerificationConditions UnionM ()
 --   res = do
---     symAssume $ x >~ 0
---     symAssert $ x * c <~ 0
---     symAssert $ c >~ -2
+--     symAssume $ x .> 0
+--     symAssert $ x * c .< 0
+--     symAssert $ c .> -2
 -- :}
 --
 -- >>> :{
@@ -327,7 +327,7 @@ cegisExceptVC config inputs f v =
 -- The '()' result will not fail any conditions.
 --
 -- The following example tries to find the value of @c@ such that for all
--- positive @x@, @x * c < 0 && c > -2@. The @c >~ -2@ assertion is used to make
+-- positive @x@, @x * c < 0 && c > -2@. The @c .> -2@ assertion is used to make
 -- the solution unique.
 --
 -- >>> :set -XOverloadedStrings
@@ -336,9 +336,9 @@ cegisExceptVC config inputs f v =
 -- >>> :{
 --   res :: ExceptT VerificationConditions UnionM ()
 --   res = do
---     symAssume $ x >~ 0
---     symAssert $ x * c <~ 0
---     symAssert $ c >~ -2
+--     symAssume $ x .> 0
+--     symAssert $ x * c .< 0
+--     symAssert $ c .> -2
 -- :}
 --
 -- >>> cegisExceptStdVC (precise z3) x res

--- a/src/Grisette/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Core/Data/Class/ITEOp.hs
@@ -50,31 +50,31 @@ import Grisette.IR.SymPrim.Data.SymPrim
 -- >>> let a = "a" :: SymBool
 -- >>> let b = "b" :: SymBool
 -- >>> let c = "c" :: SymBool
--- >>> ites a b c
+-- >>> symIte a b c
 -- (ite a b c)
 class ITEOp v where
-  ites :: SymBool -> v -> v -> v
+  symIte :: SymBool -> v -> v -> v
 
 -- ITEOp instances
 #define ITEOP_SIMPLE(type) \
 instance ITEOp type where \
-  ites (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
-  {-# INLINE ites #-}
+  symIte (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
+  {-# INLINE symIte #-}
 
 #define ITEOP_BV(type) \
 instance (KnownNat n, 1 <= n) => ITEOp (type n) where \
-  ites (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
-  {-# INLINE ites #-}
+  symIte (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
+  {-# INLINE symIte #-}
 
 #define ITEOP_BV_SOME(symtype, bf) \
 instance ITEOp symtype where \
-  ites c = bf (ites c) "ites"; \
-  {-# INLINE ites #-}
+  symIte c = bf (symIte c) "symIte"; \
+  {-# INLINE symIte #-}
 
 #define ITEOP_FUN(op, cons) \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ITEOp (sa op sb) where \
-  ites (SymBool c) (cons t) (cons f) = cons $ pevalITETerm c t f; \
-  {-# INLINE ites #-}
+  symIte (SymBool c) (cons t) (cons f) = cons $ pevalITETerm c t f; \
+  {-# INLINE symIte #-}
 
 #if 1
 ITEOP_SIMPLE(SymBool)

--- a/src/Grisette/Core/Data/Class/LogicalOp.hs
+++ b/src/Grisette/Core/Data/Class/LogicalOp.hs
@@ -27,80 +27,80 @@ import Grisette.IR.SymPrim.Data.SymPrim (SymBool (SymBool))
 -- >>> let f = con False :: SymBool
 -- >>> let a = "a" :: SymBool
 -- >>> let b = "b" :: SymBool
--- >>> t ||~ f
+-- >>> t .|| f
 -- true
--- >>> a ||~ t
+-- >>> a .|| t
 -- true
--- >>> a ||~ f
+-- >>> a .|| f
 -- a
--- >>> a ||~ b
+-- >>> a .|| b
 -- (|| a b)
--- >>> t &&~ f
+-- >>> t .&& f
 -- false
--- >>> a &&~ t
+-- >>> a .&& t
 -- a
--- >>> a &&~ f
+-- >>> a .&& f
 -- false
--- >>> a &&~ b
+-- >>> a .&& b
 -- (&& a b)
--- >>> nots t
+-- >>> symNot t
 -- false
--- >>> nots f
+-- >>> symNot f
 -- true
--- >>> nots a
+-- >>> symNot a
 -- (! a)
--- >>> t `xors` f
+-- >>> t `symXor` f
 -- true
--- >>> t `xors` t
+-- >>> t `symXor` t
 -- false
--- >>> a `xors` t
+-- >>> a `symXor` t
 -- (! a)
--- >>> a `xors` f
+-- >>> a `symXor` f
 -- a
--- >>> a `xors` b
+-- >>> a `symXor` b
 -- (|| (&& (! a) b) (&& a (! b)))
 class LogicalOp b where
   -- | Symbolic disjunction
-  (||~) :: b -> b -> b
-  a ||~ b = nots $ nots a &&~ nots b
-  {-# INLINE (||~) #-}
+  (.||) :: b -> b -> b
+  a .|| b = symNot $ symNot a .&& symNot b
+  {-# INLINE (.||) #-}
 
-  infixr 2 ||~
+  infixr 2 .||
 
   -- | Symbolic conjunction
-  (&&~) :: b -> b -> b
-  a &&~ b = nots $ nots a ||~ nots b
-  {-# INLINE (&&~) #-}
+  (.&&) :: b -> b -> b
+  a .&& b = symNot $ symNot a .|| symNot b
+  {-# INLINE (.&&) #-}
 
-  infixr 3 &&~
+  infixr 3 .&&
 
   -- | Symbolic negation
-  nots :: b -> b
+  symNot :: b -> b
 
   -- | Symbolic exclusive disjunction
-  xors :: b -> b -> b
-  a `xors` b = (a &&~ nots b) ||~ (nots a &&~ b)
-  {-# INLINE xors #-}
+  symXor :: b -> b -> b
+  a `symXor` b = (a .&& symNot b) .|| (symNot a .&& b)
+  {-# INLINE symXor #-}
 
   -- | Symbolic implication
-  implies :: b -> b -> b
-  a `implies` b = nots a ||~ b
-  {-# INLINE implies #-}
+  symImplies :: b -> b -> b
+  a `symImplies` b = symNot a .|| b
+  {-# INLINE symImplies #-}
 
-  {-# MINIMAL (||~), nots | (&&~), nots #-}
+  {-# MINIMAL (.||), symNot | (.&&), symNot #-}
 
 -- LogicalOp instances
 instance LogicalOp Bool where
-  (||~) = (||)
-  {-# INLINE (||~) #-}
-  (&&~) = (&&)
-  {-# INLINE (&&~) #-}
-  nots = not
-  {-# INLINE nots #-}
+  (.||) = (||)
+  {-# INLINE (.||) #-}
+  (.&&) = (&&)
+  {-# INLINE (.&&) #-}
+  symNot = not
+  {-# INLINE symNot #-}
 
 instance LogicalOp SymBool where
-  (SymBool l) ||~ (SymBool r) = SymBool $ pevalOrTerm l r
-  (SymBool l) &&~ (SymBool r) = SymBool $ pevalAndTerm l r
-  nots (SymBool v) = SymBool $ pevalNotTerm v
-  (SymBool l) `xors` (SymBool r) = SymBool $ pevalXorTerm l r
-  (SymBool l) `implies` (SymBool r) = SymBool $ pevalImplyTerm l r
+  (SymBool l) .|| (SymBool r) = SymBool $ pevalOrTerm l r
+  (SymBool l) .&& (SymBool r) = SymBool $ pevalAndTerm l r
+  symNot (SymBool v) = SymBool $ pevalNotTerm v
+  (SymBool l) `symXor` (SymBool r) = SymBool $ pevalXorTerm l r
+  (SymBool l) `symImplies` (SymBool r) = SymBool $ pevalImplyTerm l r

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -119,7 +119,7 @@ import Grisette.Core.Data.BV
     SomeWordN (SomeWordN),
     WordN (WordN),
   )
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( LinkedRep,
     SupportedPrim,
@@ -194,13 +194,13 @@ resolveStrategy' x = go
 -- The 'SimpleStrategy' merges values with a simple merge function.
 -- For example,
 --
---    * the symbolic boolean values can be directly merged with 'ites'.
+--    * the symbolic boolean values can be directly merged with 'symIte'.
 --
 --    * the set @{1}@, which is a subset of the values of the type @Integer@,
 --        can be simply merged as the set contains only a single value.
 --
 --    * all the 'Just' values of the type @Maybe SymBool@ can be simply merged
---        by merging the wrapped symbolic boolean with 'ites'.
+--        by merging the wrapped symbolic boolean with 'symIte'.
 --
 -- The 'SortedStrategy' merges values by first grouping the values with an
 -- indexing function, and the values with the same index will be organized as
@@ -243,7 +243,7 @@ data MergingStrategy a where
   --
   -- For symbolic booleans, we can implement its merge strategy as follows:
   --
-  -- > SimpleStrategy ites :: MergingStrategy SymBool
+  -- > SimpleStrategy symIte :: MergingStrategy SymBool
   SimpleStrategy ::
     -- | Merge function.
     (SymBool -> a -> a -> a) ->
@@ -261,7 +261,7 @@ data MergingStrategy a where
   -- >   (\idx ->
   -- >      if idx
   -- >        then SimpleStrategy $ \_ t _ -> t
-  -- >        else SimpleStrategy $ \cond (Just l) (Just r) -> Just $ ites cond l r)
+  -- >        else SimpleStrategy $ \cond (Just l) (Just r) -> Just $ symIte cond l r)
   SortedStrategy ::
     (Ord idx, Typeable idx, Show idx) =>
     -- | Indexing function
@@ -925,15 +925,15 @@ deriving via (Default1 Monoid.Sum) instance Mergeable1 Monoid.Sum
 
 #define MERGEABLE_SIMPLE(symtype) \
 instance Mergeable symtype where \
-  rootStrategy = SimpleStrategy ites
+  rootStrategy = SimpleStrategy symIte
 
 #define MERGEABLE_BV(symtype) \
 instance (KnownNat n, 1 <= n) => Mergeable (symtype n) where \
-  rootStrategy = SimpleStrategy ites
+  rootStrategy = SimpleStrategy symIte
 
 #define MERGEABLE_FUN(op) \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Mergeable (sa op sb) where \
-  rootStrategy = SimpleStrategy ites
+  rootStrategy = SimpleStrategy symIte
 
 #if 1
 MERGEABLE_SIMPLE(SymBool)
@@ -952,7 +952,7 @@ instance Mergeable SomeSymIntN where
           SimpleStrategy
             ( \c (SomeSymIntN (l :: SymIntN l)) (SomeSymIntN (r :: SymIntN r)) ->
                 case unsafeAxiom @l @r of
-                  Refl -> SomeSymIntN $ ites c l r
+                  Refl -> SomeSymIntN $ symIte c l r
             )
       )
 
@@ -964,7 +964,7 @@ instance Mergeable SomeSymWordN where
           SimpleStrategy
             ( \c (SomeSymWordN (l :: SymWordN l)) (SomeSymWordN (r :: SymWordN r)) ->
                 case unsafeAxiom @l @r of
-                  Refl -> SomeSymWordN $ ites c l r
+                  Refl -> SomeSymWordN $ symIte c l r
             )
       )
 

--- a/src/Grisette/Core/Data/Class/SOrd.hs
+++ b/src/Grisette/Core/Data/Class/SOrd.hs
@@ -54,8 +54,8 @@ import Generics.Deriving
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
 import Grisette.Core.Control.Monad.UnionM (UnionM, liftToMonadUnion)
 import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
-import Grisette.Core.Data.Class.SEq (SEq ((/=~), (==~)), SEq' ((==~~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
+import Grisette.Core.Data.Class.SEq (SEq ((./=), (.==)), SEq' ((..==)))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( mrgIf,
     mrgSingle,
@@ -94,20 +94,20 @@ import Grisette.IR.SymPrim.Data.SymPrim
 --
 -- >>> let a = 1 :: SymInteger
 -- >>> let b = 2 :: SymInteger
--- >>> a <~ b
+-- >>> a .< b
 -- true
--- >>> a >~ b
+-- >>> a .> b
 -- false
 --
 -- >>> let a = "a" :: SymInteger
 -- >>> let b = "b" :: SymInteger
--- >>> a <~ b
+-- >>> a .< b
 -- (< a b)
--- >>> a <=~ b
+-- >>> a .<= b
 -- (<= a b)
--- >>> a >~ b
+-- >>> a .> b
 -- (< b a)
--- >>> a >=~ b
+-- >>> a .>= b
 -- (<= b a)
 --
 -- For `symCompare`, `Ordering` is not a solvable type, and the result would
@@ -122,46 +122,46 @@ import Grisette.IR.SymPrim.Data.SymPrim
 --
 -- > data X = ... deriving Generic deriving SOrd via (Default X)
 class (SEq a) => SOrd a where
-  (<~) :: a -> a -> SymBool
-  infix 4 <~
-  (<=~) :: a -> a -> SymBool
-  infix 4 <=~
-  (>~) :: a -> a -> SymBool
-  infix 4 >~
-  (>=~) :: a -> a -> SymBool
-  infix 4 >=~
-  x <~ y = x <=~ y &&~ x /=~ y
-  x >~ y = y <~ x
-  x >=~ y = y <=~ x
+  (.<) :: a -> a -> SymBool
+  infix 4 .<
+  (.<=) :: a -> a -> SymBool
+  infix 4 .<=
+  (.>) :: a -> a -> SymBool
+  infix 4 .>
+  (.>=) :: a -> a -> SymBool
+  infix 4 .>=
+  x .< y = x .<= y .&& x ./= y
+  x .> y = y .< x
+  x .>= y = y .<= x
   symCompare :: a -> a -> UnionM Ordering
   symCompare l r =
     mrgIf
-      (l <~ r)
+      (l .< r)
       (mrgSingle LT)
-      (mrgIf (l ==~ r) (mrgSingle EQ) (mrgSingle GT))
-  {-# MINIMAL (<=~) #-}
+      (mrgIf (l .== r) (mrgSingle EQ) (mrgSingle GT))
+  {-# MINIMAL (.<=) #-}
 
 instance (SEq a, Generic a, SOrd' (Rep a)) => SOrd (Default a) where
-  (Default l) <=~ (Default r) = l `derivedSymLe` r
-  (Default l) <~ (Default r) = l `derivedSymLt` r
-  (Default l) >=~ (Default r) = l `derivedSymGe` r
-  (Default l) >~ (Default r) = l `derivedSymGt` r
+  (Default l) .<= (Default r) = l `derivedSymLe` r
+  (Default l) .< (Default r) = l `derivedSymLt` r
+  (Default l) .>= (Default r) = l `derivedSymGe` r
+  (Default l) .> (Default r) = l `derivedSymGt` r
   symCompare (Default l) (Default r) = derivedSymCompare l r
 
 #define CONCRETE_SORD(type) \
 instance SOrd type where \
-  l <=~ r = con $ l <= r; \
-  l <~ r = con $ l < r; \
-  l >=~ r = con $ l >= r; \
-  l >~ r = con $ l > r; \
+  l .<= r = con $ l <= r; \
+  l .< r = con $ l < r; \
+  l .>= r = con $ l >= r; \
+  l .> r = con $ l > r; \
   symCompare l r = mrgSingle $ compare l r
 
 #define CONCRETE_SORD_BV(type) \
 instance (KnownNat n, 1 <= n) => SOrd (type n) where \
-  l <=~ r = con $ l <= r; \
-  l <~ r = con $ l < r; \
-  l >=~ r = con $ l >= r; \
-  l >~ r = con $ l > r; \
+  l .<= r = con $ l <= r; \
+  l .< r = con $ l < r; \
+  l .>= r = con $ l >= r; \
+  l .> r = con $ l > r; \
   symCompare l r = mrgSingle $ compare l r
 
 #if 1
@@ -190,7 +190,7 @@ symCompareSingleList :: (SOrd a) => Bool -> Bool -> [a] -> [a] -> SymBool
 symCompareSingleList isLess isStrict = go
   where
     go [] [] = con (not isStrict)
-    go (x : xs) (y : ys) = (if isLess then x <~ y else x >~ y) ||~ (x ==~ y &&~ go xs ys)
+    go (x : xs) (y : ys) = (if isLess then x .< y else x .> y) .|| (x .== y .&& go xs ys)
     go [] _ = if isLess then con True else con False
     go _ [] = if isLess then con False else con True
 
@@ -206,10 +206,10 @@ symCompareList [] _ = mrgSingle LT
 symCompareList _ [] = mrgSingle GT
 
 instance (SOrd a) => SOrd [a] where
-  (<=~) = symCompareSingleList True False
-  (<~) = symCompareSingleList True True
-  (>=~) = symCompareSingleList False False
-  (>~) = symCompareSingleList False True
+  (.<=) = symCompareSingleList True False
+  (.<) = symCompareSingleList True True
+  (.>=) = symCompareSingleList False False
+  (.>) = symCompareSingleList False True
   symCompare = symCompareList
 
 deriving via (Default (Maybe a)) instance (SOrd a) => SOrd (Maybe a)
@@ -266,93 +266,93 @@ deriving via
     (SOrd (f a), SOrd (g a)) => SOrd (Sum f g a)
 
 instance (SOrd (m (Maybe a))) => SOrd (MaybeT m a) where
-  (MaybeT l) <=~ (MaybeT r) = l <=~ r
-  (MaybeT l) <~ (MaybeT r) = l <~ r
-  (MaybeT l) >=~ (MaybeT r) = l >=~ r
-  (MaybeT l) >~ (MaybeT r) = l >~ r
+  (MaybeT l) .<= (MaybeT r) = l .<= r
+  (MaybeT l) .< (MaybeT r) = l .< r
+  (MaybeT l) .>= (MaybeT r) = l .>= r
+  (MaybeT l) .> (MaybeT r) = l .> r
   symCompare (MaybeT l) (MaybeT r) = symCompare l r
 
 instance (SOrd (m (Either e a))) => SOrd (ExceptT e m a) where
-  (ExceptT l) <=~ (ExceptT r) = l <=~ r
-  (ExceptT l) <~ (ExceptT r) = l <~ r
-  (ExceptT l) >=~ (ExceptT r) = l >=~ r
-  (ExceptT l) >~ (ExceptT r) = l >~ r
+  (ExceptT l) .<= (ExceptT r) = l .<= r
+  (ExceptT l) .< (ExceptT r) = l .< r
+  (ExceptT l) .>= (ExceptT r) = l .>= r
+  (ExceptT l) .> (ExceptT r) = l .> r
   symCompare (ExceptT l) (ExceptT r) = symCompare l r
 
 instance (SOrd (m (a, s))) => SOrd (WriterLazy.WriterT s m a) where
-  (WriterLazy.WriterT l) <=~ (WriterLazy.WriterT r) = l <=~ r
-  (WriterLazy.WriterT l) <~ (WriterLazy.WriterT r) = l <~ r
-  (WriterLazy.WriterT l) >=~ (WriterLazy.WriterT r) = l >=~ r
-  (WriterLazy.WriterT l) >~ (WriterLazy.WriterT r) = l >~ r
+  (WriterLazy.WriterT l) .<= (WriterLazy.WriterT r) = l .<= r
+  (WriterLazy.WriterT l) .< (WriterLazy.WriterT r) = l .< r
+  (WriterLazy.WriterT l) .>= (WriterLazy.WriterT r) = l .>= r
+  (WriterLazy.WriterT l) .> (WriterLazy.WriterT r) = l .> r
   symCompare (WriterLazy.WriterT l) (WriterLazy.WriterT r) = symCompare l r
 
 instance (SOrd (m (a, s))) => SOrd (WriterStrict.WriterT s m a) where
-  (WriterStrict.WriterT l) <=~ (WriterStrict.WriterT r) = l <=~ r
-  (WriterStrict.WriterT l) <~ (WriterStrict.WriterT r) = l <~ r
-  (WriterStrict.WriterT l) >=~ (WriterStrict.WriterT r) = l >=~ r
-  (WriterStrict.WriterT l) >~ (WriterStrict.WriterT r) = l >~ r
+  (WriterStrict.WriterT l) .<= (WriterStrict.WriterT r) = l .<= r
+  (WriterStrict.WriterT l) .< (WriterStrict.WriterT r) = l .< r
+  (WriterStrict.WriterT l) .>= (WriterStrict.WriterT r) = l .>= r
+  (WriterStrict.WriterT l) .> (WriterStrict.WriterT r) = l .> r
   symCompare (WriterStrict.WriterT l) (WriterStrict.WriterT r) = symCompare l r
 
 instance (SOrd a) => SOrd (Identity a) where
-  (Identity l) <=~ (Identity r) = l <=~ r
-  (Identity l) <~ (Identity r) = l <~ r
-  (Identity l) >=~ (Identity r) = l >=~ r
-  (Identity l) >~ (Identity r) = l >~ r
+  (Identity l) .<= (Identity r) = l .<= r
+  (Identity l) .< (Identity r) = l .< r
+  (Identity l) .>= (Identity r) = l .>= r
+  (Identity l) .> (Identity r) = l .> r
   (Identity l) `symCompare` (Identity r) = l `symCompare` r
 
 instance (SOrd (m a)) => SOrd (IdentityT m a) where
-  (IdentityT l) <=~ (IdentityT r) = l <=~ r
-  (IdentityT l) <~ (IdentityT r) = l <~ r
-  (IdentityT l) >=~ (IdentityT r) = l >=~ r
-  (IdentityT l) >~ (IdentityT r) = l >~ r
+  (IdentityT l) .<= (IdentityT r) = l .<= r
+  (IdentityT l) .< (IdentityT r) = l .< r
+  (IdentityT l) .>= (IdentityT r) = l .>= r
+  (IdentityT l) .> (IdentityT r) = l .> r
   (IdentityT l) `symCompare` (IdentityT r) = l `symCompare` r
 
 -- SOrd
 #define SORD_SIMPLE(symtype) \
 instance SOrd symtype where \
-  (symtype a) <=~ (symtype b) = SymBool $ pevalLeNumTerm a b; \
-  (symtype a) <~ (symtype b) = SymBool $ pevalLtNumTerm a b; \
-  (symtype a) >=~ (symtype b) = SymBool $ pevalGeNumTerm a b; \
-  (symtype a) >~ (symtype b) = SymBool $ pevalGtNumTerm a b; \
+  (symtype a) .<= (symtype b) = SymBool $ pevalLeNumTerm a b; \
+  (symtype a) .< (symtype b) = SymBool $ pevalLtNumTerm a b; \
+  (symtype a) .>= (symtype b) = SymBool $ pevalGeNumTerm a b; \
+  (symtype a) .> (symtype b) = SymBool $ pevalGtNumTerm a b; \
   a `symCompare` b = mrgIf \
-    (a <~ b) \
+    (a .< b) \
     (mrgSingle LT) \
-    (mrgIf (a ==~ b) (mrgSingle EQ) (mrgSingle GT))
+    (mrgIf (a .== b) (mrgSingle EQ) (mrgSingle GT))
 
 #define SORD_BV(symtype) \
 instance (KnownNat n, 1 <= n) => SOrd (symtype n) where \
-  (symtype a) <=~ (symtype b) = SymBool $ pevalLeNumTerm a b; \
-  (symtype a) <~ (symtype b) = SymBool $ pevalLtNumTerm a b; \
-  (symtype a) >=~ (symtype b) = SymBool $ pevalGeNumTerm a b; \
-  (symtype a) >~ (symtype b) = SymBool $ pevalGtNumTerm a b; \
+  (symtype a) .<= (symtype b) = SymBool $ pevalLeNumTerm a b; \
+  (symtype a) .< (symtype b) = SymBool $ pevalLtNumTerm a b; \
+  (symtype a) .>= (symtype b) = SymBool $ pevalGeNumTerm a b; \
+  (symtype a) .> (symtype b) = SymBool $ pevalGtNumTerm a b; \
   a `symCompare` b = mrgIf \
-    (a <~ b) \
+    (a .< b) \
     (mrgSingle LT) \
-    (mrgIf (a ==~ b) (mrgSingle EQ) (mrgSingle GT))
+    (mrgIf (a .== b) (mrgSingle EQ) (mrgSingle GT))
 
 #define SORD_BV_SOME(somety, bf) \
 instance SOrd somety where \
-  (<=~) = bf (<=~) "<=~"; \
-  {-# INLINE (<=~) #-}; \
-  (<~) = bf (<~) "<~"; \
-  {-# INLINE (<~) #-}; \
-  (>=~) = bf (>=~) ">=~"; \
-  {-# INLINE (>=~) #-}; \
-  (>~) = bf (>~) ">~"; \
-  {-# INLINE (>~) #-}; \
+  (.<=) = bf (.<=) ".<="; \
+  {-# INLINE (.<=) #-}; \
+  (.<) = bf (.<) ".<"; \
+  {-# INLINE (.<) #-}; \
+  (.>=) = bf (.>=) ".>="; \
+  {-# INLINE (.>=) #-}; \
+  (.>) = bf (.>) ".>"; \
+  {-# INLINE (.>) #-}; \
   symCompare = bf symCompare "symCompare"; \
   {-# INLINE symCompare #-}
 
 instance SOrd SymBool where
-  l <=~ r = nots l ||~ r
-  l <~ r = nots l &&~ r
-  l >=~ r = l ||~ nots r
-  l >~ r = l &&~ nots r
+  l .<= r = symNot l .|| r
+  l .< r = symNot l .&& r
+  l .>= r = l .|| symNot r
+  l .> r = l .&& symNot r
   symCompare l r =
     mrgIf
-      (nots l &&~ r)
+      (symNot l .&& r)
       (mrgSingle LT)
-      (mrgIf (l ==~ r) (mrgSingle EQ) (mrgSingle GT))
+      (mrgIf (l .== r) (mrgSingle EQ) (mrgSingle GT))
 
 #if 1
 SORD_SIMPLE(SymInteger)
@@ -364,37 +364,37 @@ SORD_BV_SOME(SomeSymWordN, binSomeSymWordN)
 
 -- Exception
 instance SOrd AssertionError where
-  _ <=~ _ = con True
-  _ <~ _ = con False
-  _ >=~ _ = con True
-  _ >~ _ = con False
+  _ .<= _ = con True
+  _ .< _ = con False
+  _ .>= _ = con True
+  _ .> _ = con False
   _ `symCompare` _ = mrgSingle EQ
 
 instance SOrd VerificationConditions where
-  l >=~ r = con $ l >= r
-  l >~ r = con $ l > r
-  l <=~ r = con $ l <= r
-  l <~ r = con $ l < r
+  l .>= r = con $ l >= r
+  l .> r = con $ l > r
+  l .<= r = con $ l <= r
+  l .< r = con $ l < r
   l `symCompare` r = mrgSingle $ l `compare` r
 
 -- UnionM
 instance (SOrd a) => SOrd (UnionM a) where
-  x <=~ y = simpleMerge $ do
+  x .<= y = simpleMerge $ do
     x1 <- x
     y1 <- y
-    mrgSingle $ x1 <=~ y1
-  x <~ y = simpleMerge $ do
+    mrgSingle $ x1 .<= y1
+  x .< y = simpleMerge $ do
     x1 <- x
     y1 <- y
-    mrgSingle $ x1 <~ y1
-  x >=~ y = simpleMerge $ do
+    mrgSingle $ x1 .< y1
+  x .>= y = simpleMerge $ do
     x1 <- x
     y1 <- y
-    mrgSingle $ x1 >=~ y1
-  x >~ y = simpleMerge $ do
+    mrgSingle $ x1 .>= y1
+  x .> y = simpleMerge $ do
     x1 <- x
     y1 <- y
-    mrgSingle $ x1 >~ y1
+    mrgSingle $ x1 .> y1
   x `symCompare` y = liftToMonadUnion $ do
     x1 <- x
     y1 <- y
@@ -402,75 +402,75 @@ instance (SOrd a) => SOrd (UnionM a) where
 
 -- | Auxiliary class for 'SOrd' instance derivation
 class (SEq' f) => SOrd' f where
-  -- | Auxiliary function for '(<~~) derivation
-  (<~~) :: f a -> f a -> SymBool
+  -- | Auxiliary function for '(..<) derivation
+  (..<) :: f a -> f a -> SymBool
 
-  infix 4 <~~
+  infix 4 ..<
 
-  -- | Auxiliary function for '(<=~~) derivation
-  (<=~~) :: f a -> f a -> SymBool
+  -- | Auxiliary function for '(..<=) derivation
+  (..<=) :: f a -> f a -> SymBool
 
-  infix 4 <=~~
+  infix 4 ..<=
 
-  -- | Auxiliary function for '(>~~) derivation
-  (>~~) :: f a -> f a -> SymBool
+  -- | Auxiliary function for '(..>) derivation
+  (..>) :: f a -> f a -> SymBool
 
-  infix 4 >~~
+  infix 4 ..>
 
-  -- | Auxiliary function for '(>=~~) derivation
-  (>=~~) :: f a -> f a -> SymBool
+  -- | Auxiliary function for '(..>=) derivation
+  (..>=) :: f a -> f a -> SymBool
 
-  infix 4 >=~~
+  infix 4 ..>=
 
   -- | Auxiliary function for 'symCompare' derivation
   symCompare' :: f a -> f a -> UnionM Ordering
 
 instance SOrd' U1 where
-  _ <~~ _ = con False
-  _ <=~~ _ = con True
-  _ >~~ _ = con False
-  _ >=~~ _ = con True
+  _ ..< _ = con False
+  _ ..<= _ = con True
+  _ ..> _ = con False
+  _ ..>= _ = con True
   symCompare' _ _ = mrgSingle EQ
 
 instance SOrd' V1 where
-  _ <~~ _ = con False
-  _ <=~~ _ = con True
-  _ >~~ _ = con False
-  _ >=~~ _ = con True
+  _ ..< _ = con False
+  _ ..<= _ = con True
+  _ ..> _ = con False
+  _ ..>= _ = con True
   symCompare' _ _ = mrgSingle EQ
 
 instance (SOrd c) => SOrd' (K1 i c) where
-  (K1 a) <~~ (K1 b) = a <~ b
-  (K1 a) <=~~ (K1 b) = a <=~ b
-  (K1 a) >~~ (K1 b) = a >~ b
-  (K1 a) >=~~ (K1 b) = a >=~ b
+  (K1 a) ..< (K1 b) = a .< b
+  (K1 a) ..<= (K1 b) = a .<= b
+  (K1 a) ..> (K1 b) = a .> b
+  (K1 a) ..>= (K1 b) = a .>= b
   symCompare' (K1 a) (K1 b) = symCompare a b
 
 instance (SOrd' a) => SOrd' (M1 i c a) where
-  (M1 a) <~~ (M1 b) = a <~~ b
-  (M1 a) <=~~ (M1 b) = a <=~~ b
-  (M1 a) >~~ (M1 b) = a >~~ b
-  (M1 a) >=~~ (M1 b) = a >=~~ b
+  (M1 a) ..< (M1 b) = a ..< b
+  (M1 a) ..<= (M1 b) = a ..<= b
+  (M1 a) ..> (M1 b) = a ..> b
+  (M1 a) ..>= (M1 b) = a ..>= b
   symCompare' (M1 a) (M1 b) = symCompare' a b
 
 instance (SOrd' a, SOrd' b) => SOrd' (a :+: b) where
-  (L1 _) <~~ (R1 _) = con True
-  (L1 a) <~~ (L1 b) = a <~~ b
-  (R1 _) <~~ (L1 _) = con False
-  (R1 a) <~~ (R1 b) = a <~~ b
-  (L1 _) <=~~ (R1 _) = con True
-  (L1 a) <=~~ (L1 b) = a <=~~ b
-  (R1 _) <=~~ (L1 _) = con False
-  (R1 a) <=~~ (R1 b) = a <=~~ b
+  (L1 _) ..< (R1 _) = con True
+  (L1 a) ..< (L1 b) = a ..< b
+  (R1 _) ..< (L1 _) = con False
+  (R1 a) ..< (R1 b) = a ..< b
+  (L1 _) ..<= (R1 _) = con True
+  (L1 a) ..<= (L1 b) = a ..<= b
+  (R1 _) ..<= (L1 _) = con False
+  (R1 a) ..<= (R1 b) = a ..<= b
 
-  (L1 _) >~~ (R1 _) = con False
-  (L1 a) >~~ (L1 b) = a >~~ b
-  (R1 _) >~~ (L1 _) = con True
-  (R1 a) >~~ (R1 b) = a >~~ b
-  (L1 _) >=~~ (R1 _) = con False
-  (L1 a) >=~~ (L1 b) = a >=~~ b
-  (R1 _) >=~~ (L1 _) = con True
-  (R1 a) >=~~ (R1 b) = a >=~~ b
+  (L1 _) ..> (R1 _) = con False
+  (L1 a) ..> (L1 b) = a ..> b
+  (R1 _) ..> (L1 _) = con True
+  (R1 a) ..> (R1 b) = a ..> b
+  (L1 _) ..>= (R1 _) = con False
+  (L1 a) ..>= (L1 b) = a ..>= b
+  (R1 _) ..>= (L1 _) = con True
+  (R1 a) ..>= (R1 b) = a ..>= b
 
   symCompare' (L1 a) (L1 b) = symCompare' a b
   symCompare' (L1 _) (R1 _) = mrgSingle LT
@@ -478,10 +478,10 @@ instance (SOrd' a, SOrd' b) => SOrd' (a :+: b) where
   symCompare' (R1 _) (L1 _) = mrgSingle GT
 
 instance (SOrd' a, SOrd' b) => SOrd' (a :*: b) where
-  (a1 :*: b1) <~~ (a2 :*: b2) = (a1 <~~ a2) ||~ ((a1 ==~~ a2) &&~ (b1 <~~ b2))
-  (a1 :*: b1) <=~~ (a2 :*: b2) = (a1 <~~ a2) ||~ ((a1 ==~~ a2) &&~ (b1 <=~~ b2))
-  (a1 :*: b1) >~~ (a2 :*: b2) = (a1 >~~ a2) ||~ ((a1 ==~~ a2) &&~ (b1 >~~ b2))
-  (a1 :*: b1) >=~~ (a2 :*: b2) = (a1 >~~ a2) ||~ ((a1 ==~~ a2) &&~ (b1 >=~~ b2))
+  (a1 :*: b1) ..< (a2 :*: b2) = (a1 ..< a2) .|| ((a1 ..== a2) .&& (b1 ..< b2))
+  (a1 :*: b1) ..<= (a2 :*: b2) = (a1 ..< a2) .|| ((a1 ..== a2) .&& (b1 ..<= b2))
+  (a1 :*: b1) ..> (a2 :*: b2) = (a1 ..> a2) .|| ((a1 ..== a2) .&& (b1 ..> b2))
+  (a1 :*: b1) ..>= (a2 :*: b2) = (a1 ..> a2) .|| ((a1 ..== a2) .&& (b1 ..>= b2))
   symCompare' (a1 :*: b1) (a2 :*: b2) = do
     l <- symCompare' a1 a2
     case l of
@@ -489,16 +489,16 @@ instance (SOrd' a, SOrd' b) => SOrd' (a :*: b) where
       _ -> mrgSingle l
 
 derivedSymLt :: (Generic a, SOrd' (Rep a)) => a -> a -> SymBool
-derivedSymLt x y = from x <~~ from y
+derivedSymLt x y = from x ..< from y
 
 derivedSymLe :: (Generic a, SOrd' (Rep a)) => a -> a -> SymBool
-derivedSymLe x y = from x <=~~ from y
+derivedSymLe x y = from x ..<= from y
 
 derivedSymGt :: (Generic a, SOrd' (Rep a)) => a -> a -> SymBool
-derivedSymGt x y = from x >~~ from y
+derivedSymGt x y = from x ..> from y
 
 derivedSymGe :: (Generic a, SOrd' (Rep a)) => a -> a -> SymBool
-derivedSymGe x y = from x >=~~ from y
+derivedSymGe x y = from x ..>= from y
 
 derivedSymCompare :: (Generic a, SOrd' (Rep a)) => a -> a -> UnionM Ordering
 derivedSymCompare x y = symCompare' (from x) (from y)

--- a/src/Grisette/Core/Data/Class/SafeDivision.hs
+++ b/src/Grisette/Core/Data/Class/SafeDivision.hs
@@ -39,11 +39,11 @@ import Grisette.Core.Data.BV
     SomeWordN (SomeWordN),
     WordN,
   )
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((&&~), (||~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.&&), (.||)))
 import Grisette.Core.Data.Class.Mergeable (Mergeable)
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.SOrd
-  ( SOrd ((<=~), (<~), (>=~), (>~)),
+  ( SOrd ((.<), (.<=), (.>), (.>=)),
   )
 import Grisette.Core.Data.Class.SimpleMergeable
   ( merge,
@@ -110,7 +110,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeQuot l r = do
     (d, m) <- safeDivMod l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle d)
       (mrgSingle $ d + 1)
 
@@ -119,7 +119,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeRem l r = do
     (_, m) <- safeDivMod l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle m)
       (mrgSingle $ m - r)
 
@@ -128,7 +128,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeQuotRem l r = do
     (d, m) <- safeDivMod l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle (d, m))
       (mrgSingle (d + 1, m - r))
 
@@ -169,7 +169,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeQuot' t l r = do
     (d, m) <- safeDivMod' t l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle d)
       (mrgSingle $ d + 1)
 
@@ -179,7 +179,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeRem' t l r = do
     (_, m) <- safeDivMod' t l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle m)
       (mrgSingle $ m - r)
 
@@ -189,7 +189,7 @@ class (SOrd a, Num a, Mergeable a, Mergeable e) => SafeDivision e a | a -> e whe
   safeQuotRem' t l r = do
     (d, m) <- safeDivMod' t l r
     mrgIf
-      ((l >=~ 0 &&~ r >~ 0) ||~ (l <=~ 0 &&~ r <~ 0) ||~ m ==~ 0)
+      ((l .>= 0 .&& r .> 0) .|| (l .<= 0 .&& r .< 0) .|| m .== 0)
       (mrgSingle (d, m))
       (mrgSingle (d + 1, m - r))
 
@@ -295,24 +295,24 @@ instance SafeDivision (Either BitwidthMismatch ArithException) SomeWordN where
 #define SAFE_DIVISION_SYMBOLIC_FUNC(name, type, op) \
 name (type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError DivideByZero) \
     (mrgSingle $ type $ op l r); \
 QRIGHT(name) t (type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError (t DivideByZero)) \
     (mrgSingle $ type $ op l r)
 
 #define SAFE_DIVISION_SYMBOLIC_FUNC2(name, type, op1, op2) \
 name (type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError DivideByZero) \
     (mrgSingle (type $ op1 l r, type $ op2 l r)); \
 QRIGHT(name) t (type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError (t DivideByZero)) \
     (mrgSingle (type $ op1 l r, type $ op2 l r))
 
@@ -329,32 +329,32 @@ instance SafeDivision ArithException SymInteger where
 #define SAFE_DIVISION_SYMBOLIC_FUNC_BOUNDED_SIGNED(name, type, op) \
 name ls@(type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError DivideByZero) \
-    (mrgIf (rs ==~ con (-1) &&~ ls ==~ con minBound) \
+    (mrgIf (rs .== con (-1) .&& ls .== con minBound) \
       (throwError Overflow) \
       (mrgSingle $ type $ op l r)); \
 QRIGHT(name) t ls@(type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError (t DivideByZero)) \
-    (mrgIf (rs ==~ con (-1) &&~ ls ==~ con minBound) \
+    (mrgIf (rs .== con (-1) .&& ls .== con minBound) \
       (throwError (t Overflow)) \
       (mrgSingle $ type $ op l r))
 
 #define SAFE_DIVISION_SYMBOLIC_FUNC2_BOUNDED_SIGNED(name, type, op1, op2) \
 name ls@(type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError DivideByZero) \
-    (mrgIf (rs ==~ con (-1) &&~ ls ==~ con minBound) \
+    (mrgIf (rs .== con (-1) .&& ls .== con minBound) \
       (throwError Overflow) \
       (mrgSingle (type $ op1 l r, type $ op2 l r))); \
 QRIGHT(name) t ls@(type l) rs@(type r) = \
   mrgIf \
-    (rs ==~ con 0) \
+    (rs .== con 0) \
     (throwError (t DivideByZero)) \
-    (mrgIf (rs ==~ con (-1) &&~ ls ==~ con minBound) \
+    (mrgIf (rs .== con (-1) .&& ls .== con minBound) \
       (throwError (t Overflow)) \
       (mrgSingle (type $ op1 l r, type $ op2 l r)))
 

--- a/src/Grisette/Core/Data/Class/SafeSymRotate.hs
+++ b/src/Grisette/Core/Data/Class/SafeSymRotate.hs
@@ -16,7 +16,7 @@ import GHC.TypeLits (KnownNat, type (<=))
 import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.Mergeable (Mergeable)
-import Grisette.Core.Data.Class.SOrd (SOrd ((<~)))
+import Grisette.Core.Data.Class.SOrd (SOrd ((.<)))
 import Grisette.Core.Data.Class.SimpleMergeable (UnionLike, mrgIf)
 import Grisette.Core.Data.Class.SymRotate (SymRotate)
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bits
@@ -100,11 +100,11 @@ instance (KnownNat n, 1 <= n) => SafeSymRotate ArithException (SymWordN n) where
 instance (KnownNat n, 1 <= n) => SafeSymRotate ArithException (SymIntN n) where
   safeSymRotateL' f (SymIntN ta) r@(SymIntN tr) =
     mrgIf
-      (r <~ 0)
+      (r .< 0)
       (mrgThrowError $ f Overflow)
       (mrgReturn $ SymIntN $ pevalRotateLeftTerm ta tr)
   safeSymRotateR' f (SymIntN ta) r@(SymIntN tr) =
     mrgIf
-      (r <~ 0)
+      (r .< 0)
       (mrgThrowError $ f Overflow)
       (mrgReturn $ SymIntN $ pevalRotateRightTerm ta tr)

--- a/src/Grisette/Core/Data/Class/Solvable.hs
+++ b/src/Grisette/Core/Data/Class/Solvable.hs
@@ -62,7 +62,7 @@ class (IsString t) => Solvable c t | t -> c where
   -- True
   -- >>> (ssym "a" :: SymBool) == ssym "b"
   -- False
-  -- >>> (ssym "a" :: SymBool) &&~ ssym "a"
+  -- >>> (ssym "a" :: SymBool) .&& ssym "a"
   -- a
   ssym :: T.Text -> t
 

--- a/src/Grisette/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Core/Data/Class/Solver.hs
@@ -67,9 +67,9 @@ class
   where
   -- | Solve a single formula. Find an assignment to it to make it true.
   --
-  -- >>> solve (precise z3) ("a" &&~ ("b" :: SymInteger) ==~ 1)
+  -- >>> solve (precise z3) ("a" .&& ("b" :: SymInteger) .== 1)
   -- Right (Model {a -> True :: Bool, b -> 1 :: Integer})
-  -- >>> solve (precise z3) ("a" &&~ nots "a")
+  -- >>> solve (precise z3) ("a" .&& symNot "a")
   -- Left Unsat
   solve ::
     -- | solver configuration
@@ -81,7 +81,7 @@ class
   -- | Solve a single formula while returning multiple models to make it true.
   -- The maximum number of desired models are given.
   --
-  -- > >>> solveMulti (precise z3) 4 ("a" ||~ "b")
+  -- > >>> solveMulti (precise z3) 4 ("a" .|| "b")
   -- > [Model {a -> True :: Bool, b -> False :: Bool},Model {a -> False :: Bool, b -> True :: Bool},Model {a -> True :: Bool, b -> True :: Bool}]
   solveMulti ::
     -- | solver configuration
@@ -95,7 +95,7 @@ class
   -- | Solve a single formula while returning multiple models to make it true.
   -- All models are returned.
   --
-  -- > >>> solveAll (precise z3) ("a" ||~ "b")
+  -- > >>> solveAll (precise z3) ("a" .|| "b")
   -- > [Model {a -> True :: Bool, b -> False :: Bool},Model {a -> False :: Bool, b -> True :: Bool},Model {a -> True :: Bool, b -> True :: Bool}]
   solveAll ::
     -- | solver configuration
@@ -121,8 +121,8 @@ instance UnionWithExcept (ExceptT e u v) u e v where
 -- >>> :{
 --   res :: ExceptT AssertionError UnionM ()
 --   res = do
---     symAssert $ x >~ 0       -- constrain that x is positive
---     symAssert $ x <~ 2       -- constrain that x is less than 2
+--     symAssert $ x .> 0       -- constrain that x is positive
+--     symAssert $ x .< 2       -- constrain that x is less than 2
 -- :}
 --
 -- >>> :{

--- a/src/Grisette/Core/Data/Class/SubstituteSym.hs
+++ b/src/Grisette/Core/Data/Class/SubstituteSym.hs
@@ -74,8 +74,8 @@ import Grisette.IR.SymPrim.Data.SymPrim
 -- | Substitution of symbolic constants.
 --
 -- >>> a = "a" :: TypedSymbol Bool
--- >>> v = "x" &&~ "y" :: SymBool
--- >>> substituteSym a v (["a" &&~ "b", "a"] :: [SymBool])
+-- >>> v = "x" .&& "y" :: SymBool
+-- >>> substituteSym a v (["a" .&& "b", "a"] :: [SymBool])
 -- [(&& (&& x y) b),(&& x y)]
 --
 -- __Note 1:__ This type class can be derived for algebraic data types.
@@ -85,7 +85,7 @@ import Grisette.IR.SymPrim.Data.SymPrim
 class SubstituteSym a where
   -- Substitute a symbolic constant to some symbolic value
   --
-  -- >>> substituteSym "a" ("c" &&~ "d" :: Sym Bool) ["a" &&~ "b" :: Sym Bool, "a"]
+  -- >>> substituteSym "a" ("c" .&& "d" :: Sym Bool) ["a" .&& "b" :: Sym Bool, "a"]
   -- [(&& (&& c d) b),(&& c d)]
   substituteSym :: (LinkedRep cb sb) => TypedSymbol cb -> sb -> a -> a
 

--- a/src/Grisette/Core/Data/Union.hs
+++ b/src/Grisette/Core/Data/Union.hs
@@ -81,16 +81,16 @@ data Union a
     UnionSingle a
   | -- | A if value
     UnionIf
-      -- | Cached leftmost value
       a
-      -- | Is merged invariant already maintained?
+      -- ^ Cached leftmost value
       !Bool
-      -- | If condition
+      -- ^ Is merged invariant already maintained?
       !SymBool
-      -- | True branch
+      -- ^ If condition
       (Union a)
-      -- | False branch
+      -- ^ True branch
       (Union a)
+      -- ^ False branch
   deriving (Generic, Eq, Lift, Generic1)
 
 instance Eq1 Union where

--- a/src/Grisette/Experimental/GenSymConstrained.hs
+++ b/src/Grisette/Experimental/GenSymConstrained.hs
@@ -53,9 +53,9 @@ import Grisette.Core.Data.Class.GenSym
     chooseUnionFresh,
     runFreshT,
   )
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((||~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.||)))
 import Grisette.Core.Data.Class.Mergeable (Mergeable, Mergeable1)
-import Grisette.Core.Data.Class.SOrd (SOrd ((<~), (>=~)))
+import Grisette.Core.Data.Class.SOrd (SOrd ((.<), (.>=)))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( UnionLike,
     merge,
@@ -136,13 +136,13 @@ instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSym spec a) => GenSymCons
   freshConstrained e (SOrdUpperBound u spec) = do
     s <- fresh spec
     v <- liftToMonadUnion s
-    mrgIf (v >=~ u) (throwError e) (return ())
+    mrgIf (v .>= u) (throwError e) (return ())
     mrgSingle $ mrgSingle v
 
 instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSymSimple spec a) => GenSymSimpleConstrained (SOrdUpperBound a spec) a where
   simpleFreshConstrained e (SOrdUpperBound u spec) = do
     s <- simpleFresh spec
-    mrgIf (s >=~ u) (throwError e) (return ())
+    mrgIf (s .>= u) (throwError e) (return ())
     mrgSingle s
 
 -- | Inclusive bound, generates the values with the specification, then filters
@@ -153,13 +153,13 @@ instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSym spec a) => GenSymCons
   freshConstrained e (SOrdLowerBound l spec) = do
     s <- fresh spec
     v <- liftToMonadUnion s
-    mrgIf (v <~ l) (throwError e) (return ())
+    mrgIf (v .< l) (throwError e) (return ())
     mrgSingle $ mrgSingle v
 
 instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSymSimple spec a) => GenSymSimpleConstrained (SOrdLowerBound a spec) a where
   simpleFreshConstrained e (SOrdLowerBound l spec) = do
     s <- simpleFresh spec
-    mrgIf (s <~ l) (throwError e) (return ())
+    mrgIf (s .< l) (throwError e) (return ())
     mrgSingle s
 
 -- | Left-inclusive, right-exclusive bound, generates the values with the
@@ -170,13 +170,13 @@ instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSym spec a) => GenSymCons
   freshConstrained e (SOrdBound l u spec) = do
     s <- fresh spec
     v <- liftToMonadUnion s
-    mrgIf (v <~ l ||~ v >=~ u) (throwError e) (return ())
+    mrgIf (v .< l .|| v .>= u) (throwError e) (return ())
     mrgSingle $ mrgSingle v
 
 instance {-# OVERLAPPABLE #-} (SOrd a, Mergeable a, GenSymSimple spec a) => GenSymSimpleConstrained (SOrdBound a spec) a where
   simpleFreshConstrained e (SOrdBound l u spec) = do
     s <- simpleFresh spec
-    mrgIf (s <~ l ||~ s >=~ u) (throwError e) (return ())
+    mrgIf (s .< l .|| s .>= u) (throwError e) (return ())
     mrgSingle s
 
 instance GenSymConstrained (SOrdBound Integer ()) Integer where

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -229,7 +229,7 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> :set -XOverloadedStrings
 -- >>> "a" :: SymBool
 -- a
--- >>> "a" &&~ "b" :: SymBool
+-- >>> "a" .&& "b" :: SymBool
 -- (&& a b)
 --
 -- More symbolic operations are available. Please refer to the documentation
@@ -262,7 +262,7 @@ newtype SymInteger = SymInteger {underlyingIntegerTerm :: Term Integer}
 -- 0b101110
 -- >>> sizedBVExt (Proxy @6) (con 0b101 :: SymIntN 3)
 -- 0b111101
--- >>> (8 :: SymIntN 4) <~ (7 :: SymIntN 4)
+-- >>> (8 :: SymIntN 4) .< (7 :: SymIntN 4)
 -- true
 --
 -- More symbolic operations are available. Please refer to the documentation
@@ -332,7 +332,7 @@ binSomeSymIntNR2 op str (SomeSymIntN (l :: SymIntN l)) (SomeSymIntN (r :: SymInt
 -- 0b101110
 -- >>> sizedBVExt (Proxy @6) (con 0b101 :: SymWordN 3)
 -- 0b000101
--- >>> (8 :: SymWordN 4) <~ (7 :: SymWordN 4)
+-- >>> (8 :: SymWordN 4) .< (7 :: SymWordN 4)
 -- false
 --
 -- More symbolic operations are available. Please refer to the documentation

--- a/src/Grisette/Lib/Base.hs
+++ b/src/Grisette/Lib/Base.hs
@@ -15,8 +15,8 @@ module Grisette.Lib.Base
     mrgReturnWithStrategy,
     mrgBindWithStrategy,
     mrgReturn,
-    (>>=~),
-    (>>~),
+    (.>>=),
+    (.>>),
     mrgFoldM,
     mrgMzero,
     mrgMplus,
@@ -41,7 +41,7 @@ module Grisette.Lib.Base
     mrgSequence,
 
     -- ** Symbolic versions for operations in "Data.List"
-    (!!~),
+    (.!!),
     symFilter,
     symTake,
     symDrop,
@@ -56,8 +56,8 @@ import Grisette.Lib.Control.Monad
     mrgMzero,
     mrgReturn,
     mrgReturnWithStrategy,
-    (>>=~),
-    (>>~),
+    (.>>),
+    (.>>=),
   )
 import Grisette.Lib.Data.Foldable
   ( mrgFoldlM,
@@ -73,7 +73,7 @@ import Grisette.Lib.Data.List
   ( symDrop,
     symFilter,
     symTake,
-    (!!~),
+    (.!!),
   )
 import Grisette.Lib.Data.Traversable
   ( mrgFor,

--- a/src/Grisette/Lib/Control/Monad.hs
+++ b/src/Grisette/Lib/Control/Monad.hs
@@ -16,8 +16,8 @@ module Grisette.Lib.Control.Monad
     mrgReturnWithStrategy,
     mrgBindWithStrategy,
     mrgReturn,
-    (>>=~),
-    (>>~),
+    (.>>=),
+    (.>>),
     mrgFoldM,
     mrgMzero,
     mrgMplus,
@@ -53,9 +53,9 @@ mrgReturn = merge . return
 {-# INLINE mrgReturn #-}
 
 -- | '>>=' with 'MergingStrategy' knowledge propagation.
-(>>=~) :: (MonadUnion u, Mergeable b) => u a -> (a -> u b) -> u b
-a >>=~ f = merge $ a >>= f
-{-# INLINE (>>=~) #-}
+(.>>=) :: (MonadUnion u, Mergeable b) => u a -> (a -> u b) -> u b
+a .>>= f = merge $ a >>= f
+{-# INLINE (.>>=) #-}
 
 -- | 'foldM' with 'MergingStrategy' knowledge propagation.
 mrgFoldM :: (MonadUnion m, Mergeable b, Foldable t) => (b -> a -> m b) -> b -> t a -> m b
@@ -65,9 +65,9 @@ mrgFoldM = mrgFoldlM
 -- | '>>' with 'MergingStrategy' knowledge propagation.
 --
 -- This is usually more efficient than calling the original '>>' and merge the results.
-(>>~) :: forall m a b. (MonadUnion m, Mergeable b) => m a -> m b -> m b
-a >>~ f = merge $ mrgFmap (const ()) a >> f
-{-# INLINE (>>~) #-}
+(.>>) :: forall m a b. (MonadUnion m, Mergeable b) => m a -> m b -> m b
+a .>> f = merge $ mrgFmap (const ()) a >> f
+{-# INLINE (.>>) #-}
 
 -- | 'mzero' with 'MergingStrategy' knowledge propagation.
 mrgMzero :: forall m a. (MonadUnion m, Mergeable a, MonadPlus m) => m a

--- a/src/Grisette/Lib/Control/Monad.hs-boot
+++ b/src/Grisette/Lib/Control/Monad.hs-boot
@@ -5,9 +5,9 @@ module Grisette.Lib.Control.Monad
   ( mrgReturnWithStrategy,
     mrgBindWithStrategy,
     mrgReturn,
-    (>>=~),
+    (.>>=),
     mrgFoldM,
-    (>>~),
+    (.>>),
     mrgMzero,
     mrgMplus,
     mrgFmap,
@@ -24,9 +24,9 @@ import Grisette.Core.Data.Class.Mergeable
 mrgReturnWithStrategy :: (MonadUnion u) => MergingStrategy a -> a -> u a
 mrgBindWithStrategy :: (MonadUnion u) => MergingStrategy b -> u a -> (a -> u b) -> u b
 mrgReturn :: (MonadUnion u, Mergeable a) => a -> u a
-(>>=~) :: (MonadUnion u, Mergeable b) => u a -> (a -> u b) -> u b
+(.>>=) :: (MonadUnion u, Mergeable b) => u a -> (a -> u b) -> u b
 mrgFoldM :: (MonadUnion m, Mergeable b, Foldable t) => (b -> a -> m b) -> b -> t a -> m b
-(>>~) :: forall m a b. (MonadUnion m, Mergeable b) => m a -> m b -> m b
+(.>>) :: forall m a b. (MonadUnion m, Mergeable b) => m a -> m b -> m b
 mrgMzero :: forall m a. (MonadUnion m, Mergeable a, MonadPlus m) => m a
 mrgMplus :: forall m a. (MonadUnion m, Mergeable a, MonadPlus m) => m a -> m a -> m a
 mrgFmap :: (MonadUnion f, Mergeable b, Functor f) => (a -> b) -> f a -> f b

--- a/test/Grisette/Core/Control/ExceptionTests.hs
+++ b/test/Grisette/Core/Control/ExceptionTests.hs
@@ -22,7 +22,7 @@ import Grisette.Core.Data.Class.EvaluateSym
 import Grisette.Core.Data.Class.ExtractSymbolics
   ( ExtractSymbolics (extractSymbolics),
   )
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot))
 import Grisette.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
     MergingStrategy (SimpleStrategy),
@@ -31,9 +31,9 @@ import Grisette.Core.Data.Class.ModelOps
   ( ModelOps (emptyModel),
     SymbolSetOps (emptySet),
   )
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.SOrd
-  ( SOrd (symCompare, (<=~), (<~), (>=~), (>~)),
+  ( SOrd (symCompare, (.<), (.<=), (.>), (.>=)),
   )
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
@@ -58,12 +58,12 @@ exceptionTests =
           testCase "ToSym" $ do
             toSym AssertionError @?= AssertionError,
           testCase "SEq" $ do
-            AssertionError ==~ AssertionError @?= con True,
+            AssertionError .== AssertionError @?= con True,
           testCase "SOrd" $ do
-            AssertionError <=~ AssertionError @?= con True
-            AssertionError <~ AssertionError @?= con False
-            AssertionError >=~ AssertionError @?= con True
-            AssertionError >~ AssertionError @?= con False
+            AssertionError .<= AssertionError @?= con True
+            AssertionError .< AssertionError @?= con False
+            AssertionError .>= AssertionError @?= con True
+            AssertionError .> AssertionError @?= con False
             AssertionError
               `symCompare` AssertionError
               @?= (mrgSingle EQ :: UnionM Ordering),
@@ -96,39 +96,39 @@ exceptionTests =
             toSym AssertionViolation @?= AssertionViolation
             toSym AssumptionViolation @?= AssumptionViolation,
           testCase "SEq" $ do
-            AssertionViolation ==~ AssertionViolation @?= con True
-            AssertionViolation ==~ AssumptionViolation @?= con False
-            AssumptionViolation ==~ AssertionViolation @?= con False
-            AssumptionViolation ==~ AssumptionViolation @?= con True,
+            AssertionViolation .== AssertionViolation @?= con True
+            AssertionViolation .== AssumptionViolation @?= con False
+            AssumptionViolation .== AssertionViolation @?= con False
+            AssumptionViolation .== AssumptionViolation @?= con True,
           testCase "SOrd" $ do
-            AssertionViolation <=~ AssertionViolation @?= con True
-            AssertionViolation <~ AssertionViolation @?= con False
-            AssertionViolation >=~ AssertionViolation @?= con True
-            AssertionViolation >~ AssertionViolation @?= con False
+            AssertionViolation .<= AssertionViolation @?= con True
+            AssertionViolation .< AssertionViolation @?= con False
+            AssertionViolation .>= AssertionViolation @?= con True
+            AssertionViolation .> AssertionViolation @?= con False
             AssertionViolation
               `symCompare` AssertionViolation
               @?= (mrgSingle EQ :: UnionM Ordering)
 
-            AssertionViolation <=~ AssumptionViolation @?= con True
-            AssertionViolation <~ AssumptionViolation @?= con True
-            AssertionViolation >=~ AssumptionViolation @?= con False
-            AssertionViolation >~ AssumptionViolation @?= con False
+            AssertionViolation .<= AssumptionViolation @?= con True
+            AssertionViolation .< AssumptionViolation @?= con True
+            AssertionViolation .>= AssumptionViolation @?= con False
+            AssertionViolation .> AssumptionViolation @?= con False
             AssertionViolation
               `symCompare` AssumptionViolation
               @?= (mrgSingle LT :: UnionM Ordering)
 
-            AssumptionViolation <=~ AssertionViolation @?= con False
-            AssumptionViolation <~ AssertionViolation @?= con False
-            AssumptionViolation >=~ AssertionViolation @?= con True
-            AssumptionViolation >~ AssertionViolation @?= con True
+            AssumptionViolation .<= AssertionViolation @?= con False
+            AssumptionViolation .< AssertionViolation @?= con False
+            AssumptionViolation .>= AssertionViolation @?= con True
+            AssumptionViolation .> AssertionViolation @?= con True
             AssumptionViolation
               `symCompare` AssertionViolation
               @?= (mrgSingle GT :: UnionM Ordering)
 
-            AssumptionViolation <=~ AssumptionViolation @?= con True
-            AssumptionViolation <~ AssumptionViolation @?= con False
-            AssumptionViolation >=~ AssumptionViolation @?= con True
-            AssumptionViolation >~ AssumptionViolation @?= con False
+            AssumptionViolation .<= AssumptionViolation @?= con True
+            AssumptionViolation .< AssumptionViolation @?= con False
+            AssumptionViolation .>= AssumptionViolation @?= con True
+            AssumptionViolation .> AssumptionViolation @?= con False
             AssumptionViolation
               `symCompare` AssumptionViolation
               @?= (mrgSingle EQ :: UnionM Ordering),
@@ -146,7 +146,7 @@ exceptionTests =
               (mrgSingle AssumptionViolation)
               (mrgSingle AssertionViolation)
               @?= ( mrgIf
-                      (nots "a")
+                      (symNot "a")
                       (mrgSingle AssertionViolation)
                       (mrgSingle AssumptionViolation) ::
                       UnionM VerificationConditions
@@ -161,7 +161,7 @@ exceptionTests =
         (symAssert "a" :: ExceptT VerificationConditions UnionM ())
           @?= ExceptT
             ( mrgIf
-                (nots "a")
+                (symNot "a")
                 (mrgSingle $ Left AssertionViolation)
                 (mrgSingle $ Right ())
             )

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -144,10 +144,10 @@ unionMTests =
             let v :: UnionM Integer = mrgIf "b" (mrgSingle 1) (mrgSingle 3)
             f
               <*> v
-                @?= unionIf
-                  "a"
-                  (unionIf "b" (single 1) (single 3))
-                  (unionIf "b" (single 2) (single 4))
+              @?= unionIf
+                "a"
+                (unionIf "b" (single 1) (single 3))
+                (unionIf "b" (single 2) (single 4))
         ],
       testGroup
         "Monad"
@@ -624,24 +624,24 @@ unionMTests =
           testCase "plus" $
             (mrgIf "a" (mrgSingle 0) (mrgSingle 1) :: UnionM Integer)
               + mrgIf "b" (mrgSingle 1) (mrgSingle 3)
-                @?= mrgIf
-                  "a"
-                  (mrgIf "b" (mrgSingle 1) (mrgSingle 3))
-                  (mrgIf "b" (mrgSingle 2) (mrgSingle 4)),
+              @?= mrgIf
+                "a"
+                (mrgIf "b" (mrgSingle 1) (mrgSingle 3))
+                (mrgIf "b" (mrgSingle 2) (mrgSingle 4)),
           testCase "minus" $
             (mrgIf "a" (mrgSingle 0) (mrgSingle 1) :: UnionM Integer)
               - mrgIf "b" (mrgSingle $ -3) (mrgSingle $ -1)
-                @?= mrgIf
-                  "a"
-                  (mrgIf (symNot "b") (mrgSingle 1) (mrgSingle 3))
-                  (mrgIf (symNot "b") (mrgSingle 2) (mrgSingle 4)),
+              @?= mrgIf
+                "a"
+                (mrgIf (symNot "b") (mrgSingle 1) (mrgSingle 3))
+                (mrgIf (symNot "b") (mrgSingle 2) (mrgSingle 4)),
           testCase "times" $
             (mrgIf "a" (mrgSingle 1) (mrgSingle 2) :: UnionM Integer)
               * mrgIf "b" (mrgSingle 3) (mrgSingle 4)
-                @?= mrgIf
-                  "a"
-                  (mrgIf "b" (mrgSingle 3) (mrgSingle 4))
-                  (mrgIf "b" (mrgSingle 6) (mrgSingle 8)),
+              @?= mrgIf
+                "a"
+                (mrgIf "b" (mrgSingle 3) (mrgSingle 4))
+                (mrgIf "b" (mrgSingle 6) (mrgSingle 8)),
           testCase "abs" $
             abs (mrgIf "a" (mrgSingle $ -1) (mrgSingle 2) :: UnionM Integer)
               @?= mrgIf "a" (mrgSingle 1) (mrgSingle 2),

--- a/test/Grisette/Core/Control/Monad/UnionTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionTests.hs
@@ -8,8 +8,8 @@
 module Grisette.Core.Control.Monad.UnionTests (unionTests) where
 
 import GHC.Generics (Generic)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
     MergingStrategy (SortedStrategy),
@@ -117,7 +117,7 @@ unionTests =
               "a"
               (UnionSingle ("b" :: SymInteger))
               (UnionSingle "c")
-              @?= UnionSingle (ites "a" "b" "c"),
+              @?= UnionSingle (symIte "a" "b" "c"),
           testGroup
             "ifWithStrategy with ordered mergeables"
             [ testGroup
@@ -166,7 +166,7 @@ unionTests =
                               "a"
                               (UnionSingle (Just ("b" :: SymInteger)))
                               (UnionSingle (Just "c"))
-                              @?= UnionSingle (Just (ites "a" "b" "c"))
+                              @?= UnionSingle (Just (symIte "a" "b" "c"))
                         ],
                       testGroup
                         "idxt == idxf but not terminal"
@@ -188,7 +188,7 @@ unionTests =
                               "a"
                               (UnionSingle $ Just $ Just ("b" :: SymInteger))
                               (UnionSingle $ Just $ Just "c")
-                              @?= UnionSingle (Just (Just (ites "a" "b" "c")))
+                              @?= UnionSingle (Just (Just (symIte "a" "b" "c")))
                         ]
                     ],
                   testGroup
@@ -202,7 +202,7 @@ unionTests =
                           @?= UnionIf
                             1
                             True
-                            (nots "a")
+                            (symNot "a")
                             (UnionSingle 1)
                             (UnionSingle 2),
                       testCase "Maybe Integer" $
@@ -214,7 +214,7 @@ unionTests =
                           @?= UnionIf
                             Nothing
                             True
-                            (nots "a")
+                            (symNot "a")
                             (UnionSingle Nothing)
                             (UnionSingle (Just 2))
                     ]
@@ -278,7 +278,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ("b" ||~ "a")
+                                    ("b" .|| "a")
                                     (UnionSingle $ Just 1)
                                     (UnionSingle (Just 3)),
                               testCase "subidxft < sub-idxt < sub-idxff" $
@@ -290,7 +290,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ((nots "b") &&~ "a")
+                                    ((symNot "b") .&& "a")
                                     (UnionSingle $ Just 1)
                                     ( UnionIf
                                         (Just 2)
@@ -308,7 +308,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ((nots "b") &&~ "a")
+                                    ((symNot "b") .&& "a")
                                     (UnionSingle $ Just 1)
                                     (UnionSingle (Just 3)),
                               testCase "sub-idxff < sub-idxt" $
@@ -320,12 +320,12 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ((nots "b") &&~ "a")
+                                    ((symNot "b") .&& "a")
                                     (UnionSingle $ Just 1)
                                     ( UnionIf
                                         (Just 3)
                                         True
-                                        (nots "b")
+                                        (symNot "b")
                                         (UnionSingle $ Just 3)
                                         (UnionSingle $ Just 4)
                                     )
@@ -345,7 +345,7 @@ unionTests =
                           @?= UnionIf
                             (Left 1)
                             True
-                            (nots "b")
+                            (symNot "b")
                             ( UnionIf
                                 (Left 1)
                                 True
@@ -386,7 +386,7 @@ unionTests =
                       @?= UnionIf
                         (Left 0)
                         True
-                        ("b" ||~ "a")
+                        ("b" .|| "a")
                         ( UnionIf
                             (Left 0)
                             True
@@ -406,7 +406,7 @@ unionTests =
                       @?= UnionIf
                         (Left 1)
                         True
-                        ((nots "b") &&~ "a")
+                        ((symNot "b") .&& "a")
                         (UnionSingle $ Left 1)
                         ( UnionIf
                             (Right 0)
@@ -461,7 +461,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 0)
                                     True
-                                    (nots "b")
+                                    (symNot "b")
                                     (UnionSingle $ Just 0)
                                     ( UnionIf
                                         (Just 1)
@@ -479,7 +479,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ((nots "b") ||~ "a")
+                                    ((symNot "b") .|| "a")
                                     (UnionSingle $ Just 1)
                                     (UnionSingle (Just 3)),
                               testCase "sub-idxtt < sub-idxf < sub-idxtf" $
@@ -491,12 +491,12 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ("b" &&~ "a")
+                                    ("b" .&& "a")
                                     (UnionSingle $ Just 1)
                                     ( UnionIf
                                         (Just 2)
                                         True
-                                        (nots "b")
+                                        (symNot "b")
                                         (UnionSingle $ Just 2)
                                         (UnionSingle $ Just 3)
                                     ),
@@ -509,7 +509,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ("b" &&~ "a")
+                                    ("b" .&& "a")
                                     (UnionSingle $ Just 1)
                                     (UnionSingle (Just 3)),
                               testCase "sub-idxtf < sub-idxf" $
@@ -521,7 +521,7 @@ unionTests =
                                   @?= UnionIf
                                     (Just 1)
                                     True
-                                    ("b" &&~ "a")
+                                    ("b" .&& "a")
                                     (UnionSingle $ Just 1)
                                     ( UnionIf
                                         (Just 3)
@@ -546,7 +546,7 @@ unionTests =
                           @?= UnionIf
                             (Left 1)
                             True
-                            (nots "b")
+                            (symNot "b")
                             (UnionSingle $ Left 1)
                             ( UnionIf
                                 (Right 1)
@@ -567,12 +567,12 @@ unionTests =
                       @?= UnionIf
                         (Left 1)
                         True
-                        ("b" &&~ "a")
+                        ("b" .&& "a")
                         (UnionSingle $ Left 1)
                         ( UnionIf
                             (Right 0)
                             True
-                            (nots "b")
+                            (symNot "b")
                             (UnionSingle $ Right 0)
                             (UnionSingle $ Right 3)
                         ),
@@ -587,11 +587,11 @@ unionTests =
                       @?= UnionIf
                         (Left 0)
                         True
-                        ((nots "b") ||~ "a")
+                        ((symNot "b") .|| "a")
                         ( UnionIf
                             (Left 0)
                             True
-                            (nots "b")
+                            (symNot "b")
                             (UnionSingle $ Left 0)
                             (UnionSingle $ Left 1)
                         )
@@ -607,7 +607,7 @@ unionTests =
                       @?= UnionIf
                         0
                         True
-                        (nots "b")
+                        (symNot "b")
                         (UnionSingle 0)
                         (UnionIf 1 True "a" (UnionSingle 1) (UnionSingle 3))
                 ],
@@ -630,11 +630,11 @@ unionTests =
                       @?= UnionIf
                         (Left 1)
                         True
-                        ("c" ||~ "b")
+                        ("c" .|| "b")
                         ( UnionIf
                             (Left 1)
                             True
-                            ((nots "c") ||~ "a")
+                            ((symNot "c") .|| "a")
                             (UnionSingle $ Left 1)
                             (UnionSingle $ Left 2)
                         )
@@ -656,11 +656,11 @@ unionTests =
                       @?= UnionIf
                         (Left 1)
                         True
-                        ((nots "c") ||~ "b")
+                        ((symNot "c") .|| "b")
                         ( UnionIf
                             (Left 1)
                             True
-                            ("c" ||~ "a")
+                            ("c" .|| "a")
                             (UnionSingle $ Left 1)
                             (UnionSingle $ Left 2)
                         )
@@ -682,16 +682,16 @@ unionTests =
                       @?= UnionIf
                         (TS1 1)
                         True
-                        ("c" &&~ "a")
+                        ("c" .&& "a")
                         (UnionSingle $ TS1 1)
                         ( UnionIf
                             (TS2 1)
                             True
-                            ("c" ||~ "b")
+                            ("c" .|| "b")
                             ( UnionIf
                                 (TS2 1)
                                 True
-                                (nots "c")
+                                (symNot "c")
                                 (UnionSingle $ TS2 1)
                                 (UnionSingle $ TS2 2)
                             )
@@ -714,7 +714,7 @@ unionTests =
                       @?= UnionIf
                         (TS1 1)
                         True
-                        (ites "c" "a" "b")
+                        (symIte "c" "a" "b")
                         ( UnionIf
                             (TS1 1)
                             True
@@ -746,12 +746,12 @@ unionTests =
                       @?= UnionIf
                         (TS1 1)
                         True
-                        ((nots "c") &&~ "b")
+                        ((symNot "c") .&& "b")
                         (UnionSingle $ TS1 1)
                         ( UnionIf
                             (TS2 1)
                             True
-                            ((nots "c") ||~ "a")
+                            ((symNot "c") .|| "a")
                             ( UnionIf
                                 (TS2 1)
                                 True
@@ -781,11 +781,11 @@ unionTests =
                   @?= UnionIf
                     (Left 1)
                     True
-                    (ites "c" (nots "a") (nots "b"))
+                    (symIte "c" (symNot "a") (symNot "b"))
                     ( UnionIf
                         (Left 1)
                         True
-                        (nots "c")
+                        (symNot "c")
                         (UnionSingle $ Left 1)
                         (UnionSingle $ Left 2)
                     )
@@ -820,11 +820,11 @@ unionTests =
               @?= UnionIf
                 (Left 1)
                 True
-                (ites "c" (nots "a") (nots "b"))
+                (symIte "c" (symNot "a") (symNot "b"))
                 ( UnionIf
                     (Left 1)
                     True
-                    (nots "c")
+                    (symNot "c")
                     (UnionSingle $ Left 1)
                     (UnionSingle $ Left 2)
                 )

--- a/test/Grisette/Core/Data/Class/BoolTests.hs
+++ b/test/Grisette/Core/Data/Class/BoolTests.hs
@@ -1,7 +1,7 @@
 module Grisette.Core.Data.Class.BoolTests (boolTests) where
 
 import Grisette.Core.Data.Class.LogicalOp
-  ( LogicalOp (implies, nots, xors, (&&~), (||~)),
+  ( LogicalOp (symImplies, symNot, symXor, (.&&), (.||)),
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
@@ -14,9 +14,9 @@ data CustomAndBool
   deriving (Show, Eq)
 
 instance LogicalOp CustomAndBool where
-  nots (CANot x) = x
-  nots x = CANot x
-  (&&~) = CAAnd
+  symNot (CANot x) = x
+  symNot x = CANot x
+  (.&&) = CAAnd
 
 data CustomOrBool
   = COSBool String
@@ -25,9 +25,9 @@ data CustomOrBool
   deriving (Show, Eq)
 
 instance LogicalOp CustomOrBool where
-  nots (CONot x) = x
-  nots x = CONot x
-  (||~) = COOr
+  symNot (CONot x) = x
+  symNot x = CONot x
+  (.||) = COOr
 
 boolTests :: Test
 boolTests =
@@ -37,38 +37,38 @@ boolTests =
         "LogicalOp"
         [ testGroup
             "Use and"
-            [ testCase "nots" $
-                nots (CASBool "a") @?= CANot (CASBool "a"),
-              testCase "&&~" $
+            [ testCase "symNot" $
+                symNot (CASBool "a") @?= CANot (CASBool "a"),
+              testCase ".&&" $
                 CASBool "a"
-                  &&~ CASBool "b"
+                  .&& CASBool "b"
                   @?= CAAnd (CASBool "a") (CASBool "b"),
-              testCase "||~" $
+              testCase ".||" $
                 CASBool "a"
-                  ||~ CASBool "b"
+                  .|| CASBool "b"
                   @?= CANot (CAAnd (CANot $ CASBool "a") (CANot $ CASBool "b"))
             ],
           testGroup
             "Use or"
-            [ testCase "nots" $
-                nots (COSBool "a") @?= CONot (COSBool "a"),
-              testCase "&&~" $
+            [ testCase "symNot" $
+                symNot (COSBool "a") @?= CONot (COSBool "a"),
+              testCase ".&&" $
                 COSBool "a"
-                  &&~ COSBool "b"
+                  .&& COSBool "b"
                   @?= CONot (COOr (CONot $ COSBool "a") (CONot $ COSBool "b")),
-              testCase "||~" $
+              testCase ".||" $
                 COSBool "a"
-                  ||~ COSBool "b"
+                  .|| COSBool "b"
                   @?= COOr (COSBool "a") (COSBool "b"),
-              testCase "xors" $
+              testCase "symXor" $
                 COSBool "a"
-                  `xors` COSBool "b"
+                  `symXor` COSBool "b"
                   @?= COOr
                     (CONot (COOr (CONot (COSBool "a")) (COSBool "b")))
                     (CONot (COOr (COSBool "a") (CONot (COSBool "b")))),
-              testCase "implies" $
+              testCase "symImplies" $
                 COSBool "a"
-                  `implies` COSBool "b"
+                  `symImplies` COSBool "b"
                   @?= COOr
                     (CONot (COSBool "a"))
                     (COSBool "b")

--- a/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
@@ -20,13 +20,13 @@ import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
 import Grisette (TypedSymbol (IndexedSymbol))
 import Grisette.Core.Data.Class.EvaluateSym (EvaluateSym (evaluateSym))
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.ModelOps
   ( ModelOps (emptyModel),
     ModelRep (buildModel),
   )
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.Solvable (Solvable (con, isym, ssym))
 import Grisette.IR.SymPrim.Data.Prim.Model
   ( ModelValuePair ((::=)),
@@ -61,24 +61,24 @@ evaluateSymTests =
                         eval (ssym "a") @?= ssym "a",
                       testCase "isym" $
                         eval (isym "a" 1) @?= isym "a" 1,
-                      testCase "||~" $
-                        eval (ssym "a" ||~ ssym "b")
+                      testCase ".||" $
+                        eval (ssym "a" .|| ssym "b")
                           @?= ssym "a"
-                            ||~ ssym "b",
-                      testCase "&&~" $
-                        eval (ssym "a" &&~ ssym "b")
+                          .|| ssym "b",
+                      testCase ".&&" $
+                        eval (ssym "a" .&& ssym "b")
                           @?= ssym "a"
-                            &&~ ssym "b",
-                      testCase "==~" $
-                        eval ((ssym "a" :: SymBool) ==~ ssym "b")
+                          .&& ssym "b",
+                      testCase ".==" $
+                        eval ((ssym "a" :: SymBool) .== ssym "b")
                           @?= (ssym "a" :: SymBool)
-                            ==~ ssym "b",
-                      testCase "nots" $
-                        eval (nots (ssym "a"))
-                          @?= nots (ssym "a"),
-                      testCase "ites" $
-                        eval (ites (ssym "a") (ssym "b") (ssym "c"))
-                          @?= ites (ssym "a") (ssym "b") (ssym "c")
+                          .== ssym "b",
+                      testCase "symNot" $
+                        eval (symNot (ssym "a"))
+                          @?= symNot (ssym "a"),
+                      testCase "symIte" $
+                        eval (symIte (ssym "a") (ssym "b") (ssym "c"))
+                          @?= symIte (ssym "a") (ssym "b") (ssym "c")
                     ],
               let model = emptyModel
                   eval :: SymBool -> SymBool
@@ -91,16 +91,16 @@ evaluateSymTests =
                         eval (ssym "a") @?= con False,
                       testCase "isym" $
                         eval (isym "a" 1) @?= con False,
-                      testCase "||~" $
-                        eval (ssym "a" ||~ ssym "b") @?= con False,
-                      testCase "&&~" $
-                        eval (ssym "a" &&~ ssym "b") @?= con False,
-                      testCase "==~" $
-                        eval ((ssym "a" :: SymBool) ==~ ssym "b") @?= con True,
-                      testCase "nots" $
-                        eval (nots (ssym "a")) @?= con True,
-                      testCase "ites" $
-                        eval (ites (ssym "a") (ssym "b") (ssym "c"))
+                      testCase ".||" $
+                        eval (ssym "a" .|| ssym "b") @?= con False,
+                      testCase ".&&" $
+                        eval (ssym "a" .&& ssym "b") @?= con False,
+                      testCase ".==" $
+                        eval ((ssym "a" :: SymBool) .== ssym "b") @?= con True,
+                      testCase "symNot" $
+                        eval (symNot (ssym "a")) @?= con True,
+                      testCase "symIte" $
+                        eval (symIte (ssym "a") (ssym "b") (ssym "c"))
                           @?= con False
                     ],
               let model =
@@ -120,16 +120,16 @@ evaluateSymTests =
                         eval (ssym "a") @?= con True,
                       testCase "isym" $
                         eval (isym "a" 1) @?= con False,
-                      testCase "||~" $
-                        eval (ssym "a" ||~ ssym "b") @?= con True,
-                      testCase "&&~" $
-                        eval (ssym "a" &&~ ssym "b") @?= con False,
-                      testCase "==~" $
-                        eval ((ssym "a" :: SymBool) ==~ ssym "b") @?= con False,
-                      testCase "nots" $
-                        eval (nots (ssym "a")) @?= con False,
-                      testCase "ites" $
-                        eval (ites (ssym "a") (ssym "b") (ssym "c"))
+                      testCase ".||" $
+                        eval (ssym "a" .|| ssym "b") @?= con True,
+                      testCase ".&&" $
+                        eval (ssym "a" .&& ssym "b") @?= con False,
+                      testCase ".==" $
+                        eval ((ssym "a" :: SymBool) .== ssym "b") @?= con False,
+                      testCase "symNot" $
+                        eval (symNot (ssym "a")) @?= con False,
+                      testCase "symIte" $
+                        eval (symIte (ssym "a") (ssym "b") (ssym "c"))
                           @?= con False
                     ]
             ],

--- a/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvaluateSymTests.hs
@@ -64,15 +64,15 @@ evaluateSymTests =
                       testCase ".||" $
                         eval (ssym "a" .|| ssym "b")
                           @?= ssym "a"
-                          .|| ssym "b",
+                            .|| ssym "b",
                       testCase ".&&" $
                         eval (ssym "a" .&& ssym "b")
                           @?= ssym "a"
-                          .&& ssym "b",
+                            .&& ssym "b",
                       testCase ".==" $
                         eval ((ssym "a" :: SymBool) .== ssym "b")
                           @?= (ssym "a" :: SymBool)
-                          .== ssym "b",
+                            .== ssym "b",
                       testCase "symNot" $
                         eval (symNot (ssym "a"))
                           @?= symNot (ssym "a"),

--- a/test/Grisette/Core/Data/Class/ExtractSymbolicsTests.hs
+++ b/test/Grisette/Core/Data/Class/ExtractSymbolicsTests.hs
@@ -26,13 +26,13 @@ import Generics.Deriving (Default (Default))
 import Grisette.Core.Data.Class.ExtractSymbolics
   ( ExtractSymbolics (extractSymbolics),
   )
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.ModelOps
   ( SymbolSetOps (emptySet),
     SymbolSetRep (buildSymbolSet),
   )
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.TestValues
   ( isymBool,
     isymbolBool,
@@ -72,24 +72,24 @@ extractSymbolicsTests =
                 extractSymbolics (isymBool "a" 1)
                   @?= buildSymbolSet (isymbolBool "a" 1),
               testCase "And" $
-                extractSymbolics (ssymBool "a" &&~ isymBool "b" 1)
+                extractSymbolics (ssymBool "a" .&& isymBool "b" 1)
                   @?= buildSymbolSet (ssymbolBool "a", isymbolBool "b" 1),
               testCase "Or" $
-                extractSymbolics (ssymBool "a" ||~ isymBool "b" 1)
+                extractSymbolics (ssymBool "a" .|| isymBool "b" 1)
                   @?= buildSymbolSet (ssymbolBool "a", isymbolBool "b" 1),
               testCase "Equal" $
-                extractSymbolics (ssymBool "a" ==~ isymBool "b" 1)
+                extractSymbolics (ssymBool "a" .== isymBool "b" 1)
                   @?= buildSymbolSet (ssymbolBool "a", isymbolBool "b" 1),
               testCase "ITE" $
                 extractSymbolics
-                  (ites (ssymBool "a") (isymBool "b" 1) (ssymBool "c"))
+                  (symIte (ssymBool "a") (isymBool "b" 1) (ssymBool "c"))
                   @?= buildSymbolSet
                     ( ssymbolBool "a",
                       isymbolBool "b" 1,
                       ssymbolBool "c"
                     ),
               testCase "Not" $
-                extractSymbolics (nots $ isymBool "a" 1)
+                extractSymbolics (symNot $ isymBool "a" 1)
                   @?= buildSymbolSet (isymbolBool "a" 1)
             ],
           testProperty "Bool" $

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -20,7 +20,7 @@ import Grisette.Core.Data.BV
     WordN,
   )
 import Grisette.Core.Data.Class.GPretty (GPretty (gpretty))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((&&~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.&&)))
 import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
@@ -346,12 +346,12 @@ gprettyTests =
         [ testGPretty
             "enough space"
             80
-            ("a" &&~ "b" :: SymBool)
+            ("a" .&& "b" :: SymBool)
             "(&& a b)",
           testGPretty
             "not enough space"
             6
-            ("a" &&~ "b" :: SymBool)
+            ("a" .&& "b" :: SymBool)
             "..."
         ]
     ]

--- a/test/Grisette/Core/Data/Class/GenSymTests.hs
+++ b/test/Grisette/Core/Data/Class/GenSymTests.hs
@@ -26,7 +26,7 @@ import Grisette.Core.Data.Class.GenSym
     runFresh,
     runFreshT,
   )
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( mrgIf,
     mrgSingle,
@@ -1202,16 +1202,16 @@ genSymTests =
                 (mrgIf (isymBool "a" 1) (mrgSingle 2) (mrgSingle 3)),
           testCase "chooseSimpleFresh" $ do
             (runFresh (chooseSimpleFresh ["x", "y", "z"]) "a" :: SymBool)
-              @?= ites
+              @?= symIte
                 (isymBool "a" 0)
                 (ssymBool "x")
-                (ites (isymBool "a" 1) (ssymBool "y") (ssymBool "z")),
+                (symIte (isymBool "a" 1) (ssymBool "y") (ssymBool "z")),
           testCase "chooseSimple" $ do
             (chooseSimple ["x", "y", "z"] "a" :: SymBool)
-              @?= ites
+              @?= symIte
                 (isymBool "a" 0)
                 (ssymBool "x")
-                (ites (isymBool "a" 1) (ssymBool "y") (ssymBool "z")),
+                (symIte (isymBool "a" 1) (ssymBool "y") (ssymBool "z")),
           testCase "chooseUnionFresh" $ do
             ( runFresh
                 ( chooseUnionFresh

--- a/test/Grisette/Core/Data/Class/MergeableTests.hs
+++ b/test/Grisette/Core/Data/Class/MergeableTests.hs
@@ -28,8 +28,8 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
 import Grisette.Core.Control.Monad.UnionM (UnionM)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.Mergeable
   ( DynamicSortedIdx (DynamicSortedIdx),
     Mergeable (rootStrategy),
@@ -87,7 +87,7 @@ mergeableTests =
                     f (con False) (ssym "a") (ssym "b") @?= ssym "b",
                   testCase "general condition" $
                     f (ssym "a") (ssym "b") (ssym "c")
-                      @?= ites (ssym "a") (ssym "b") (ssym "c")
+                      @?= symIte (ssym "a") (ssym "b") (ssym "c")
                 ],
           testProperty "Bool" $
             ioProperty . \(x :: Bool) ->
@@ -203,7 +203,7 @@ mergeableTests =
                             (Left (ssym "a") :: Either SymBool SymBool)
                     idxsL @?= [DynamicSortedIdx False]
                     fL (ssym "a") (Left $ ssym "b") (Left $ ssym "c")
-                      @?= Left (ites (ssym "a") (ssym "b") (ssym "c")),
+                      @?= Left (symIte (ssym "a") (ssym "b") (ssym "c")),
                   testCase "Right v" $ do
                     let (idxsR, SimpleStrategy fR) =
                           resolveStrategy
@@ -211,7 +211,7 @@ mergeableTests =
                             (Right (ssym "a") :: Either SymBool SymBool)
                     idxsR @?= [DynamicSortedIdx True]
                     fR (ssym "a") (Right $ ssym "b") (Right $ ssym "c")
-                      @?= Right (ites (ssym "a") (ssym "b") (ssym "c"))
+                      @?= Right (symIte (ssym "a") (ssym "b") (ssym "c"))
                 ]
             ],
           testGroup
@@ -238,7 +238,7 @@ mergeableTests =
                         (Just (ssym "a") :: Maybe SymBool)
                 idxsJ @?= [DynamicSortedIdx True]
                 fJ (ssym "a") (Just $ ssym "b") (Just $ ssym "c")
-                  @?= Just (ites (ssym "a") (ssym "b") (ssym "c"))
+                  @?= Just (symIte (ssym "a") (ssym "b") (ssym "c"))
             ],
           testGroup
             "List"
@@ -280,8 +280,8 @@ mergeableTests =
                       [ ( ssym "a",
                           [ssym "b", ssym "c"],
                           [ssym "d", ssym "e"],
-                          [ ites (ssym "a") (ssym "b") (ssym "d"),
-                            ites (ssym "a") (ssym "c") (ssym "e")
+                          [ symIte (ssym "a") (ssym "b") (ssym "d"),
+                            symIte (ssym "a") (ssym "c") (ssym "e")
                           ]
                         )
                       ]
@@ -299,8 +299,8 @@ mergeableTests =
                   ([1], [ssym "c", ssym "d"]),
                   ([1], [ssym "f", ssym "g"]),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ]
                   )
                 )
@@ -320,10 +320,10 @@ mergeableTests =
                   ([1], [ssym "c", ssym "d"], ssym "e"),
                   ([1], [ssym "f", ssym "g"], ssym "h"),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h")
+                    symIte (ssym "a") (ssym "e") (ssym "h")
                   )
                 )
               ],
@@ -344,11 +344,11 @@ mergeableTests =
                   ([1], [ssym "c", ssym "d"], ssym "e", [ssym "i"]),
                   ([1], [ssym "f", ssym "g"], ssym "h", [ssym "j"]),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h"),
-                    [ites (ssym "a") (ssym "i") (ssym "j")]
+                    symIte (ssym "a") (ssym "e") (ssym "h"),
+                    [symIte (ssym "a") (ssym "i") (ssym "j")]
                   )
                 )
               ],
@@ -373,11 +373,11 @@ mergeableTests =
                   ([1], [ssym "c", ssym "d"], ssym "e", [ssym "i"], [2, 3]),
                   ([1], [ssym "f", ssym "g"], ssym "h", [ssym "j"], [2, 3]),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h"),
-                    [ites (ssym "a") (ssym "i") (ssym "j")],
+                    symIte (ssym "a") (ssym "e") (ssym "h"),
+                    [symIte (ssym "a") (ssym "i") (ssym "j")],
                     [2, 3]
                   )
                 )
@@ -405,11 +405,11 @@ mergeableTests =
                   ([1], [ssym "c", ssym "d"], ssym "e", [ssym "i"], [2, 3], 2),
                   ([1], [ssym "f", ssym "g"], ssym "h", [ssym "j"], [2, 3], 2),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h"),
-                    [ites (ssym "a") (ssym "i") (ssym "j")],
+                    symIte (ssym "a") (ssym "e") (ssym "h"),
+                    [symIte (ssym "a") (ssym "i") (ssym "j")],
                     [2, 3],
                     2
                   )
@@ -454,14 +454,14 @@ mergeableTests =
                     Just (ssym "l")
                   ),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h"),
-                    [ites (ssym "a") (ssym "i") (ssym "j")],
+                    symIte (ssym "a") (ssym "e") (ssym "h"),
+                    [symIte (ssym "a") (ssym "i") (ssym "j")],
                     [2, 3],
                     2,
-                    Just $ ites (ssym "a") (ssym "k") (ssym "l")
+                    Just $ symIte (ssym "a") (ssym "k") (ssym "l")
                   )
                 )
               ],
@@ -509,14 +509,14 @@ mergeableTests =
                     Left 1
                   ),
                   ( [1],
-                    [ ites (ssym "a") (ssym "c") (ssym "f"),
-                      ites (ssym "a") (ssym "d") (ssym "g")
+                    [ symIte (ssym "a") (ssym "c") (ssym "f"),
+                      symIte (ssym "a") (ssym "d") (ssym "g")
                     ],
-                    ites (ssym "a") (ssym "e") (ssym "h"),
-                    [ites (ssym "a") (ssym "i") (ssym "j")],
+                    symIte (ssym "a") (ssym "e") (ssym "h"),
+                    [symIte (ssym "a") (ssym "i") (ssym "j")],
                     [2, 3],
                     2,
-                    Just $ ites (ssym "a") (ssym "k") (ssym "l"),
+                    Just $ symIte (ssym "a") (ssym "k") (ssym "l"),
                     Left 1
                   )
                 )
@@ -524,7 +524,7 @@ mergeableTests =
           let f1 :: Maybe SymBool -> SymBool =
                 \case Just x -> x; Nothing -> (con True)
               f2 :: Maybe SymBool -> SymBool =
-                \case Just x -> (nots x); Nothing -> (con False)
+                \case Just x -> (symNot x); Nothing -> (con False)
            in testGroup
                 "Function"
                 [ testCase "Simply mergeable result" $ do
@@ -533,8 +533,8 @@ mergeableTests =
                       SimpleStrategy f -> do
                         let r = f (ssym "a") f1 f2
                         r (Just (ssym "x"))
-                          @?= ites (ssym "a") (ssym "x") (nots (ssym "x"))
-                        r Nothing @?= ites (ssym "a") (con True) (con False)
+                          @?= symIte (ssym "a") (ssym "x") (symNot (ssym "x"))
+                        r Nothing @?= symIte (ssym "a") (con True) (con False)
                       _ -> assertFailure "Bad mergeable strategy type",
                   testCase "Other mergeable result" $ do
                     case rootStrategy ::
@@ -594,7 +594,7 @@ mergeableTests =
                   (MaybeT $ Just $ Just $ ssym "b")
                   (MaybeT $ Just $ Just $ ssym "c")
                   @?= MaybeT
-                    (Just (Just (ites (ssym "a") (ssym "b") (ssym "c"))))
+                    (Just (Just (symIte (ssym "a") (ssym "b") (ssym "c"))))
             ],
           testGroup
             "ExceptT"
@@ -658,7 +658,7 @@ mergeableTests =
                       (ExceptT $ Just $ Left $ ssym "b")
                       (ExceptT $ Just $ Left $ ssym "c")
                       @?= ExceptT
-                        (Just (Left (ites (ssym "a") (ssym "b") (ssym "c")))),
+                        (Just (Left (symIte (ssym "a") (ssym "b") (ssym "c")))),
                   testCase "ExceptT (Just (Right v))" $ do
                     let (idxsJR, SimpleStrategy fJR) =
                           resolveStrategy
@@ -672,7 +672,7 @@ mergeableTests =
                       (ExceptT $ Just $ Right $ ssym "b")
                       (ExceptT $ Just $ Right $ ssym "c")
                       @?= ExceptT
-                        (Just (Right (ites (ssym "a") (ssym "b") (ssym "c"))))
+                        (Just (Right (symIte (ssym "a") (ssym "b") (ssym "c"))))
                 ]
             ],
           testGroup
@@ -690,7 +690,7 @@ mergeableTests =
                         mrgSingle (ssym "b", x * 2)
                 let st3 = s (ssym "c") st1 st2
                 StateLazy.runStateT st3 2
-                  @?= mrgSingle (ites (ssym "c") (ssym "a") (ssym "b"), 4)
+                  @?= mrgSingle (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateLazy.runStateT st3 3
                   @?= mrgIf
                     (ssym "c")
@@ -709,7 +709,7 @@ mergeableTests =
                         \(x :: Integer) -> mrgSingle (ssym "b", x * 2)
                 let st3 = s (ssym "c") st1 st2
                 StateStrict.runStateT st3 2
-                  @?= mrgSingle (ites (ssym "c") (ssym "a") (ssym "b"), 4)
+                  @?= mrgSingle (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateStrict.runStateT st3 3
                   @?= mrgIf
                     (ssym "c")
@@ -732,19 +732,19 @@ mergeableTests =
                   mrgIf
                     (ssym "p")
                     (mrgSingle (a, x))
-                    (mrgSingle (nots a, x + 1))
+                    (mrgSingle (symNot a, x + 1))
               )
               @?= mrgIf
                 (ssym "c")
                 ( mrgIf
                     (ssym "p")
                     (mrgSingle (ssym "a", 2))
-                    (mrgSingle (nots $ ssym "a", 3))
+                    (mrgSingle (symNot $ ssym "a", 3))
                 )
                 ( mrgIf
                     (ssym "p")
                     (mrgSingle (ssym "b", 3))
-                    (mrgSingle (nots $ ssym "b", 4))
+                    (mrgSingle (symNot $ ssym "b", 4))
                 ),
           testGroup
             "RWST"
@@ -768,9 +768,9 @@ mergeableTests =
                         (Integer, SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br &&~ bs),
-                              (ir - is, br ||~ bs),
-                              (ir * is, bs &&~ br)
+                            ( (ir + is, br .&& bs),
+                              (ir - is, br .|| bs),
+                              (ir * is, bs .&& br)
                             )
                 let rws2 ::
                       RWSTLazy.RWST
@@ -781,9 +781,9 @@ mergeableTests =
                         (Integer, SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br ||~ bs),
-                              (ir - is, br &&~ bs),
-                              (ir * is, bs ||~ br)
+                            ( (ir + is, br .|| bs),
+                              (ir - is, br .&& bs),
+                              (ir * is, bs .|| br)
                             )
                 let rws3 = s (ssym "c") rws1 rws2
 
@@ -796,15 +796,15 @@ mergeableTests =
                         mrgIf
                           (ssym "c")
                           ( mrgSingle
-                              ( (1, ssym "a" &&~ ssym "b"),
-                                (-1, ssym "a" ||~ ssym "b"),
-                                (0, ssym "b" &&~ ssym "a")
+                              ( (1, ssym "a" .&& ssym "b"),
+                                (-1, ssym "a" .|| ssym "b"),
+                                (0, ssym "b" .&& ssym "a")
                               )
                           )
                           ( mrgSingle
-                              ( (1, ssym "a" ||~ ssym "b"),
-                                (-1, ssym "a" &&~ ssym "b"),
-                                (0, ssym "b" ||~ ssym "a")
+                              ( (1, ssym "a" .|| ssym "b"),
+                                (-1, ssym "a" .&& ssym "b"),
+                                (0, ssym "b" .|| ssym "a")
                               )
                           )
                 RWSTLazy.runRWST rws3 (0, ssym "a") (1, ssym "b") @?= res1,
@@ -828,9 +828,9 @@ mergeableTests =
                         (Integer, SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br &&~ bs),
-                              (ir - is, br ||~ bs),
-                              (ir * is, bs &&~ br)
+                            ( (ir + is, br .&& bs),
+                              (ir - is, br .|| bs),
+                              (ir * is, bs .&& br)
                             )
                 let rws2 ::
                       RWSTStrict.RWST
@@ -841,9 +841,9 @@ mergeableTests =
                         (Integer, SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br ||~ bs),
-                              (ir - is, br &&~ bs),
-                              (ir * is, bs ||~ br)
+                            ( (ir + is, br .|| bs),
+                              (ir - is, br .&& bs),
+                              (ir * is, bs .|| br)
                             )
                 let rws3 = s (ssym "c") rws1 rws2
 
@@ -856,15 +856,15 @@ mergeableTests =
                         mrgIf
                           (ssym "c")
                           ( mrgSingle
-                              ( (1, "a" &&~ "b"),
-                                (-1, "a" ||~ "b"),
-                                (0, "b" &&~ "a")
+                              ( (1, "a" .&& "b"),
+                                (-1, "a" .|| "b"),
+                                (0, "b" .&& "a")
                               )
                           )
                           ( mrgSingle
-                              ( (1, "a" ||~ "b"),
-                                (-1, "a" &&~ "b"),
-                                (0, "b" ||~ "a")
+                              ( (1, "a" .|| "b"),
+                                (-1, "a" .&& "b"),
+                                (0, "b" .|| "a")
                               )
                           )
                 RWSTStrict.runRWST rws3 (0, ssym "a") (1, ssym "b") @?= res1
@@ -890,7 +890,7 @@ mergeableTests =
                     (mrgSingle (ssym "a", 1))
                     (mrgSingle (ssym "b", 2))
                 WriterLazy.runWriterT w5
-                  @?= mrgSingle (ites (ssym "d") (ssym "a") (ssym "c"), 1),
+                  @?= mrgSingle (symIte (ssym "d") (ssym "a") (ssym "c"), 1),
               testCase "Strict WriterT" $ do
                 let SimpleStrategy s =
                       rootStrategy ::
@@ -910,7 +910,7 @@ mergeableTests =
                     (mrgSingle (ssym "a", 1))
                     (mrgSingle (ssym "b", 2))
                 WriterStrict.runWriterT w5
-                  @?= mrgSingle (ites (ssym "d") (ssym "a") (ssym "c"), 1)
+                  @?= mrgSingle (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
             ],
           testCase "ReaderT" $ do
             let SimpleStrategy s =
@@ -938,7 +938,7 @@ mergeableTests =
                   [ ( ssym "a",
                       Identity $ ssym "b",
                       Identity $ ssym "c",
-                      Identity $ ites (ssym "a") (ssym "b") (ssym "c")
+                      Identity $ symIte (ssym "a") (ssym "b") (ssym "c")
                     )
                   ]
             ],
@@ -989,7 +989,7 @@ mergeableTests =
                           IdentityT $ Just $ ssym "c",
                           IdentityT $
                             Just $
-                              ites (ssym "a") (ssym "b") (ssym "c")
+                              symIte (ssym "a") (ssym "b") (ssym "c")
                         )
                       ]
                 ]
@@ -1041,7 +1041,7 @@ mergeableTests =
                       [ ( ssym "a",
                           InL $ Just $ ssym "b",
                           InL $ Just $ ssym "c",
-                          InL $ Just $ ites (ssym "a") (ssym "b") (ssym "c")
+                          InL $ Just $ symIte (ssym "a") (ssym "b") (ssym "c")
                         )
                       ],
                   testCase "InR Nothing" $
@@ -1056,7 +1056,7 @@ mergeableTests =
                       [ ( ssym "a",
                           InR $ Just $ ssym "b",
                           InR $ Just $ ssym "c",
-                          InR $ Just $ ites (ssym "a") (ssym "b") (ssym "c")
+                          InR $ Just $ symIte (ssym "a") (ssym "b") (ssym "c")
                         )
                       ]
                 ]

--- a/test/Grisette/Core/Data/Class/SEqTests.hs
+++ b/test/Grisette/Core/Data/Class/SEqTests.hs
@@ -101,12 +101,12 @@ seqTests =
                     [ssymBool "a"]
                       .== [ssymBool "b"]
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase "Same length 2" $
                     [ssymBool "a", ssymBool "b"]
                       .== [ssymBool "c", ssymBool "d"]
                       @=? (ssymBool "a" .== ssymBool "c")
-                      .&& (ssymBool "b" .== ssymBool "d"),
+                        .&& (ssymBool "b" .== ssymBool "d"),
                   testCase "length 1 vs length 0" $
                     [ssymBool "a"] .== [] @=? conBool False,
                   testCase "length 1 vs length 2" $
@@ -131,7 +131,7 @@ seqTests =
                     Just (ssymBool "a")
                       .== Just (ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b"
+                        .== ssymBool "b"
                 ]
             ],
           testGroup
@@ -144,7 +144,7 @@ seqTests =
                     (Left (ssymBool "a") :: Either SymBool SymBool)
                       .== Left (ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase "Right vs Left" $
                     (Right (ssymBool "a") :: Either SymBool SymBool)
                       .== Left (ssymBool "b")
@@ -157,7 +157,7 @@ seqTests =
                     (Right (ssymBool "a") :: Either SymBool SymBool)
                       .== Right (ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b"
+                        .== ssymBool "b"
                 ]
             ],
           testGroup
@@ -208,7 +208,7 @@ seqTests =
                               MaybeT Maybe SymBool
                           )
                       @=? ssymBool "a"
-                      .== ssymBool "b"
+                        .== ssymBool "b"
                 ]
             ],
           testGroup
@@ -246,7 +246,7 @@ seqTests =
                               ExceptT SymBool Maybe SymBool
                           )
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase
                     "ExceptT (Just (Right v)) vs ExceptT (Just (Left v))"
                     $ ExceptT (Just (Right (ssymBool "a")))
@@ -268,7 +268,7 @@ seqTests =
                               ExceptT SymBool Maybe SymBool
                           )
                       @=? ssymBool "a"
-                      .== ssymBool "b"
+                        .== ssymBool "b"
                 ]
             ],
           testProperty "()" (ioProperty . concreteSEqOkProp @()),
@@ -280,9 +280,9 @@ seqTests =
                 (ssymBool "a", ssymBool "c")
                   .== (ssymBool "b", ssymBool "d")
                   @=? ssymBool "a"
-                  .== ssymBool "b"
-                  .&& ssymBool "c"
-                  .== ssymBool "d"
+                    .== ssymBool "b"
+                    .&& ssymBool "c"
+                      .== ssymBool "d"
             ],
           testGroup
             "(,,)"
@@ -292,9 +292,9 @@ seqTests =
                 (ssymBool "a", ssymBool "c", ssymBool "e")
                   .== (ssymBool "b", ssymBool "d", ssymBool "f")
                   @=? (ssymBool "a" .== ssymBool "b")
-                  .&& ( (ssymBool "c" .== ssymBool "d")
-                          .&& (ssymBool "e" .== ssymBool "f")
-                      )
+                    .&& ( (ssymBool "c" .== ssymBool "d")
+                            .&& (ssymBool "e" .== ssymBool "f")
+                        )
             ],
           testGroup
             "(,,,)"
@@ -308,9 +308,9 @@ seqTests =
                   @=? ( (ssymBool "a" .== ssymBool "b")
                           .&& (ssymBool "c" .== ssymBool "d")
                       )
-                  .&& ( (ssymBool "e" .== ssymBool "f")
-                          .&& (ssymBool "g" .== ssymBool "h")
-                      )
+                    .&& ( (ssymBool "e" .== ssymBool "f")
+                            .&& (ssymBool "g" .== ssymBool "h")
+                        )
             ],
           testGroup
             "(,,,,)"
@@ -335,11 +335,11 @@ seqTests =
                   @=? ( (ssymBool "a" .== ssymBool "b")
                           .&& (ssymBool "c" .== ssymBool "d")
                       )
-                  .&& ( (ssymBool "e" .== ssymBool "f")
-                          .&& ( (ssymBool "g" .== ssymBool "h")
-                                  .&& (ssymBool "i" .== ssymBool "j")
-                              )
-                      )
+                    .&& ( (ssymBool "e" .== ssymBool "f")
+                            .&& ( (ssymBool "g" .== ssymBool "h")
+                                    .&& (ssymBool "i" .== ssymBool "j")
+                                )
+                        )
             ],
           testGroup
             "(,,,,,)"
@@ -375,11 +375,11 @@ seqTests =
                                   .&& (ssymBool "e" .== ssymBool "f")
                               )
                       )
-                  .&& ( (ssymBool "g" .== ssymBool "h")
-                          .&& ( (ssymBool "i" .== ssymBool "j")
-                                  .&& (ssymBool "k" .== ssymBool "l")
-                              )
-                      )
+                    .&& ( (ssymBool "g" .== ssymBool "h")
+                            .&& ( (ssymBool "i" .== ssymBool "j")
+                                    .&& (ssymBool "k" .== ssymBool "l")
+                                )
+                        )
             ],
           testGroup
             "(,,,,,,)"
@@ -419,13 +419,13 @@ seqTests =
                                     .&& (ssymBool "e" .== ssymBool "f")
                                 )
                         )
-                    .&& ( ( (ssymBool "g" .== ssymBool "h")
-                              .&& (ssymBool "i" .== ssymBool "j")
+                      .&& ( ( (ssymBool "g" .== ssymBool "h")
+                                .&& (ssymBool "i" .== ssymBool "j")
+                            )
+                              .&& ( (ssymBool "k" .== ssymBool "l")
+                                      .&& (ssymBool "m" .== ssymBool "n")
+                                  )
                           )
-                            .&& ( (ssymBool "k" .== ssymBool "l")
-                                    .&& (ssymBool "m" .== ssymBool "n")
-                                )
-                        )
             ],
           testGroup
             "(,,,,,,,)"
@@ -469,13 +469,13 @@ seqTests =
                                   .&& (ssymBool "g" .== ssymBool "h")
                               )
                       )
-                  .&& ( ( (ssymBool "i" .== ssymBool "j")
-                            .&& (ssymBool "k" .== ssymBool "l")
+                    .&& ( ( (ssymBool "i" .== ssymBool "j")
+                              .&& (ssymBool "k" .== ssymBool "l")
+                          )
+                            .&& ( (ssymBool "m" .== ssymBool "n")
+                                    .&& (ssymBool "o" .== ssymBool "p")
+                                )
                         )
-                          .&& ( (ssymBool "m" .== ssymBool "n")
-                                  .&& (ssymBool "o" .== ssymBool "p")
-                              )
-                      )
             ],
           testCase "ByteString" $ do
             let bytestrings :: [B.ByteString] = ["", "a", "ab"]
@@ -500,7 +500,7 @@ seqTests =
                     (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       .== InL (Just $ ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase "InL (Just v) vs InR (Just v)" $
                     (InL $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       .== InR (Just $ ssymBool "b")
@@ -509,7 +509,7 @@ seqTests =
                     (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       .== InR (Just $ ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase "InR (Just v) vs InL (Just v)" $
                     (InR $ Just $ ssymBool "a" :: Sum Maybe Maybe SymBool)
                       .== InL (Just $ ssymBool "b")
@@ -539,7 +539,7 @@ seqTests =
                         )
                           .== WriterLazy.WriterT (Left $ ssymBool "b")
                           @=? ssymBool "a"
-                          .== ssymBool "b",
+                            .== ssymBool "b",
                       testCase "WriterT (Left v) vs WriterT (Right v)" $
                         ( WriterLazy.WriterT (Left $ ssymBool "a") ::
                             WriterLazy.WriterT SymBool (Either SymBool) SymBool
@@ -562,7 +562,7 @@ seqTests =
                           .== WriterLazy.WriterT
                             (Right (ssymBool "c", ssymBool "d"))
                           @=? (ssymBool "a" .== ssymBool "c")
-                          .&& (ssymBool "b" .== ssymBool "d")
+                            .&& (ssymBool "b" .== ssymBool "d")
                     ]
                 ],
               testGroup
@@ -589,7 +589,7 @@ seqTests =
                         )
                           .== WriterStrict.WriterT (Left $ ssymBool "b")
                           @=? ssymBool "a"
-                          .== ssymBool "b",
+                            .== ssymBool "b",
                       testCase "WriterT (Left v) vs WriterT (Right v)" $
                         ( WriterStrict.WriterT (Left $ ssymBool "a") ::
                             WriterStrict.WriterT
@@ -621,9 +621,9 @@ seqTests =
                           .== WriterStrict.WriterT
                             (Right (ssymBool "c", ssymBool "d"))
                           @=? ssymBool "a"
-                          .== ssymBool "c"
-                          .&& ssymBool "b"
-                          .== ssymBool "d"
+                            .== ssymBool "c"
+                            .&& ssymBool "b"
+                              .== ssymBool "d"
                     ]
                 ]
             ],
@@ -638,7 +638,7 @@ seqTests =
                 (Identity $ ssymBool "a" :: Identity SymBool)
                   .== Identity (ssymBool "b")
                   @=? ssymBool "a"
-                  .== ssymBool "b"
+                    .== ssymBool "b"
             ],
           testGroup
             "IdentityT"
@@ -655,7 +655,7 @@ seqTests =
                     )
                       .== IdentityT (Left $ ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b",
+                        .== ssymBool "b",
                   testCase "IdentityT (Left v) vs IdentityT (Right v)" $
                     ( IdentityT $ Left $ ssymBool "a" ::
                         IdentityT (Either SymBool) SymBool
@@ -674,7 +674,7 @@ seqTests =
                     )
                       .== IdentityT (Right $ ssymBool "b")
                       @=? ssymBool "a"
-                      .== ssymBool "b"
+                        .== ssymBool "b"
                 ]
             ]
         ],
@@ -694,7 +694,7 @@ seqTests =
                 A2 (ssymBool "a")
                   .== A2 (ssymBool "b")
                   @=? ssymBool "a"
-                  .== ssymBool "b",
+                    .== ssymBool "b",
               testCase "A2 vs A3" $
                 A2 (ssymBool "a")
                   .== A3 (ssymBool "b") (ssymBool "c")
@@ -709,7 +709,7 @@ seqTests =
                 A3 (ssymBool "a") (ssymBool "b")
                   .== A3 (ssymBool "c") (ssymBool "d")
                   @=? (ssymBool "a" .== ssymBool "c")
-                  .&& (ssymBool "b" .== ssymBool "d")
+                    .&& (ssymBool "b" .== ssymBool "d")
             ]
         ]
     ]

--- a/test/Grisette/Core/Data/Class/SOrdTests.hs
+++ b/test/Grisette/Core/Data/Class/SOrdTests.hs
@@ -102,19 +102,19 @@ sordTests =
                 ssymBool "a"
                   .<= ssymBool "b"
                   @?= (symNot (ssymBool "a"))
-                  .|| (ssymBool "b")
+                    .|| (ssymBool "b")
                 ssymBool "a"
                   .< ssymBool "b"
                   @?= (symNot (ssymBool "a"))
-                  .&& (ssymBool "b")
+                    .&& (ssymBool "b")
                 ssymBool "a"
                   .>= ssymBool "b"
                   @?= (ssymBool "a")
-                  .|| (symNot (ssymBool "b"))
+                    .|| (symNot (ssymBool "b"))
                 ssymBool "a"
                   .> ssymBool "b"
                   @?= (ssymBool "a")
-                  .&& (symNot (ssymBool "b"))
+                    .&& (symNot (ssymBool "b"))
                 symCompare (ssymBool "a") (ssymBool "b")
                   @?= ( mrgIf
                           ((symNot (ssymBool "a")) .&& (ssymBool "b"))

--- a/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
+++ b/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
@@ -26,9 +26,9 @@ import qualified Control.Monad.Writer.Strict as WriterStrict
 import qualified Data.Monoid as Monoid
 import GHC.Generics (Generic)
 import Generics.Deriving (Default (Default))
-import Grisette.Core.Control.Monad.UnionM (UnionM, (#~))
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
+import Grisette.Core.Control.Monad.UnionM (UnionM, (.#))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
@@ -50,7 +50,7 @@ newtype AndMonoidSymBool = AndMonoidSymBool SymBool
   deriving (Mergeable) via (Default AndMonoidSymBool)
 
 instance Semigroup AndMonoidSymBool where
-  (AndMonoidSymBool a) <> (AndMonoidSymBool b) = AndMonoidSymBool (a &&~ b)
+  (AndMonoidSymBool a) <> (AndMonoidSymBool b) = AndMonoidSymBool (a .&& b)
 
 instance Monoid AndMonoidSymBool where
   mempty = AndMonoidSymBool $ conBool True
@@ -63,7 +63,7 @@ simpleMergeableTests =
         "SimpleMergeable for common types"
         [ testCase "SymBool" $ do
             mrgIte (ssymBool "a") (ssymBool "b") (ssymBool "c")
-              @?= ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+              @?= symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
           testCase "()" $ do
             mrgIte (ssymBool "a") () () @?= (),
           testCase "(SymBool, SymBool)" $ do
@@ -71,27 +71,27 @@ simpleMergeableTests =
               (ssymBool "a")
               (ssymBool "b", ssymBool "d")
               (ssymBool "c", ssymBool "e")
-              @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    ites (ssymBool "a") (ssymBool "d") (ssymBool "e")
+              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e")
                   ),
           testCase "(SymBool, SymBool, SymBool)" $ do
             mrgIte
               (ssymBool "a")
               (ssymBool "b", ssymBool "d", ssymBool "f")
               (ssymBool "c", ssymBool "e", ssymBool "g")
-              @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    ites (ssymBool "a") (ssymBool "f") (ssymBool "g")
+              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
               (ssymBool "a")
               (ssymBool "b", ssymBool "d", ssymBool "f", ssymBool "h")
               (ssymBool "c", ssymBool "e", ssymBool "g", ssymBool "i")
-              @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    ites (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    ites (ssymBool "a") (ssymBool "h") (ssymBool "i")
+              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
+                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
@@ -108,11 +108,11 @@ simpleMergeableTests =
                 ssymBool "i",
                 ssymBool "k"
               )
-              @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    ites (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    ites (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                    ites (ssymBool "a") (ssymBool "j") (ssymBool "k")
+              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
+                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
+                    symIte (ssymBool "a") (ssymBool "j") (ssymBool "k")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
@@ -131,12 +131,12 @@ simpleMergeableTests =
                 ssymBool "k",
                 ssymBool "m"
               )
-              @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    ites (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    ites (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                    ites (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                    ites (ssymBool "a") (ssymBool "l") (ssymBool "m")
+              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
+                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
+                    symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
+                    symIte (ssymBool "a") (ssymBool "l") (ssymBool "m")
                   ),
           testCase
             "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
@@ -159,13 +159,13 @@ simpleMergeableTests =
                   ssymBool "m",
                   ssymBool "o"
                 )
-                @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                      ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                      ites (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                      ites (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                      ites (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                      ites (ssymBool "a") (ssymBool "l") (ssymBool "m"),
-                      ites (ssymBool "a") (ssymBool "n") (ssymBool "o")
+                @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                      symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                      symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
+                      symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
+                      symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
+                      symIte (ssymBool "a") (ssymBool "l") (ssymBool "m"),
+                      symIte (ssymBool "a") (ssymBool "n") (ssymBool "o")
                     ),
           testCase
             "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
@@ -190,22 +190,22 @@ simpleMergeableTests =
                   ssymBool "o",
                   ssymBool "q"
                 )
-                @?= ( ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                      ites (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                      ites (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                      ites (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                      ites (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                      ites (ssymBool "a") (ssymBool "l") (ssymBool "m"),
-                      ites (ssymBool "a") (ssymBool "n") (ssymBool "o"),
-                      ites (ssymBool "a") (ssymBool "p") (ssymBool "q")
+                @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+                      symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
+                      symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
+                      symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
+                      symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
+                      symIte (ssymBool "a") (ssymBool "l") (ssymBool "m"),
+                      symIte (ssymBool "a") (ssymBool "n") (ssymBool "o"),
+                      symIte (ssymBool "a") (ssymBool "p") (ssymBool "q")
                     ),
           testCase "SymBool -> SymBool" $ do
-            let f = mrgIte (ssymBool "a") nots ((ssymBool "b") &&~)
+            let f = mrgIte (ssymBool "a") symNot ((ssymBool "b") .&&)
             f (ssymBool "c")
-              @?= ites
+              @?= symIte
                 (ssymBool "a")
-                (nots $ ssymBool "c")
-                ((ssymBool "b") &&~ (ssymBool "c")),
+                (symNot $ ssymBool "c")
+                ((ssymBool "b") .&& (ssymBool "c")),
           testCase "MaybeT (UnionM) SymBool" $ do
             let l :: MaybeT (UnionM) SymBool =
                   MaybeT
@@ -286,7 +286,7 @@ simpleMergeableTests =
                 let st3u1 = mrgIf (ssymBool "c") st1 st2
                 StateLazy.runStateT st3 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateLazy.runStateT st3 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -294,7 +294,7 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 6))
                 StateLazy.runStateT st31 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateLazy.runStateT st31 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -302,7 +302,7 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 6))
                 StateLazy.runStateT st3u1 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateLazy.runStateT st3u1 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -320,7 +320,7 @@ simpleMergeableTests =
                 let st3u1 = mrgIf (ssymBool "c") st1 st2
                 StateStrict.runStateT st3 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateStrict.runStateT st3 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -328,7 +328,7 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 6))
                 StateStrict.runStateT st31 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateStrict.runStateT st31 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -336,7 +336,7 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 6))
                 StateStrict.runStateT st3u1 2
                   @?= mrgSingle
-                    (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
                 StateStrict.runStateT st3u1 3
                   @?= mrgIf
                     (ssymBool "c")
@@ -356,18 +356,18 @@ simpleMergeableTests =
                     ( mrgIf
                         (ssymBool "p")
                         (mrgSingle (ssymBool "a", 2))
-                        (mrgSingle (nots $ ssymBool "a", 3))
+                        (mrgSingle (symNot $ ssymBool "a", 3))
                     )
                     ( mrgIf
                         (ssymBool "p")
                         (mrgSingle (ssymBool "b", 3))
-                        (mrgSingle (nots $ ssymBool "b", 4))
+                        (mrgSingle (symNot $ ssymBool "b", 4))
                     )
             let f (a, x) =
                   mrgIf
                     (ssymBool "p")
                     (mrgSingle (a, x))
-                    (mrgSingle (nots a, x + 1))
+                    (mrgSingle (symNot a, x + 1))
             runContT c3 f @?= r
             runContT c3u1 f @?= r,
           testGroup
@@ -382,10 +382,10 @@ simpleMergeableTests =
                         (Integer, SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br &&~ bs),
-                              (ir - is, br ||~ bs),
+                            ( (ir + is, br .&& bs),
+                              (ir - is, br .|| bs),
                               ( Monoid.Sum $ ir * is,
-                                AndMonoidSymBool $ bs &&~ br
+                                AndMonoidSymBool $ bs .&& br
                               )
                             )
                 let rws2 ::
@@ -397,10 +397,10 @@ simpleMergeableTests =
                         (Integer, SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br ||~ bs),
-                              (ir - is, br &&~ bs),
+                            ( (ir + is, br .|| bs),
+                              (ir - is, br .&& bs),
                               ( Monoid.Sum $ ir * is,
-                                AndMonoidSymBool $ bs ||~ br
+                                AndMonoidSymBool $ bs .|| br
                               )
                             )
                 let rws3 = mrgIte (ssymBool "c") rws1 rws2
@@ -415,20 +415,20 @@ simpleMergeableTests =
                         mrgIf
                           (ssymBool "c")
                           ( mrgSingle
-                              ( (1, ssymBool "a" &&~ ssymBool "b"),
-                                (-1, ssymBool "a" ||~ ssymBool "b"),
+                              ( (1, ssymBool "a" .&& ssymBool "b"),
+                                (-1, ssymBool "a" .|| ssymBool "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" &&~ ssymBool "a"
+                                    ssymBool "b" .&& ssymBool "a"
                                 )
                               )
                           )
                           ( mrgSingle
-                              ( (1, ssymBool "a" ||~ ssymBool "b"),
-                                (-1, ssymBool "a" &&~ ssymBool "b"),
+                              ( (1, ssymBool "a" .|| ssymBool "b"),
+                                (-1, ssymBool "a" .&& ssymBool "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" ||~ ssymBool "a"
+                                    ssymBool "b" .|| ssymBool "a"
                                 )
                               )
                           )
@@ -446,10 +446,10 @@ simpleMergeableTests =
                         (Integer, SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br &&~ bs),
-                              (ir - is, br ||~ bs),
+                            ( (ir + is, br .&& bs),
+                              (ir - is, br .|| bs),
                               ( Monoid.Sum $ ir * is,
-                                AndMonoidSymBool $ bs &&~ br
+                                AndMonoidSymBool $ bs .&& br
                               )
                             )
                 let rws2 ::
@@ -461,10 +461,10 @@ simpleMergeableTests =
                         (Integer, SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
-                            ( (ir + is, br ||~ bs),
-                              (ir - is, br &&~ bs),
+                            ( (ir + is, br .|| bs),
+                              (ir - is, br .&& bs),
                               ( Monoid.Sum $ ir * is,
-                                AndMonoidSymBool $ bs ||~ br
+                                AndMonoidSymBool $ bs .|| br
                               )
                             )
                 let rws3 = mrgIte (ssymBool "c") rws1 rws2
@@ -479,20 +479,20 @@ simpleMergeableTests =
                         mrgIf
                           (ssymBool "c")
                           ( mrgSingle
-                              ( (1, ssymBool "a" &&~ ssymBool "b"),
-                                (-1, ssymBool "a" ||~ ssymBool "b"),
+                              ( (1, ssymBool "a" .&& ssymBool "b"),
+                                (-1, ssymBool "a" .|| ssymBool "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" &&~ ssymBool "a"
+                                    ssymBool "b" .&& ssymBool "a"
                                 )
                               )
                           )
                           ( mrgSingle
-                              ( (1, ssymBool "a" ||~ ssymBool "b"),
-                                (-1, ssymBool "a" &&~ ssymBool "b"),
+                              ( (1, ssymBool "a" .|| ssymBool "b"),
+                                (-1, ssymBool "a" .&& ssymBool "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" ||~ ssymBool "a"
+                                    ssymBool "b" .|| ssymBool "a"
                                 )
                               )
                           )
@@ -545,13 +545,13 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 2))
                 WriterLazy.runWriterT st5
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
                 WriterLazy.runWriterT st51
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
                 WriterLazy.runWriterT st5u1
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1),
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1),
               testCase "Strict" $ do
                 let st1 ::
                       WriterStrict.WriterT
@@ -594,13 +594,13 @@ simpleMergeableTests =
                     (mrgSingle (ssymBool "b", 2))
                 WriterStrict.runWriterT st5
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
                 WriterStrict.runWriterT st51
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
                 WriterStrict.runWriterT st5u1
                   @?= mrgSingle
-                    (ites (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
             ],
           testCase "ReaderT Integer (UnionM) Integer" $ do
             let r1 :: ReaderT Integer (UnionM) Integer =
@@ -619,25 +619,25 @@ simpleMergeableTests =
                 (mrgSingle 6)
 
             let r4 :: ReaderT SymBool (UnionM) SymBool =
-                  ReaderT $ \x -> mrgSingle $ x &&~ ssymBool "x"
+                  ReaderT $ \x -> mrgSingle $ x .&& ssymBool "x"
             let r5 :: ReaderT SymBool (UnionM) SymBool =
-                  ReaderT $ \x -> mrgSingle $ x ||~ ssymBool "y"
+                  ReaderT $ \x -> mrgSingle $ x .|| ssymBool "y"
             let r61 = mrgIte1 (ssymBool "c") r4 r5
             runReaderT r61 (ssymBool "a")
               @?= mrgSingle
-                ( ites
+                ( symIte
                     (ssymBool "c")
-                    (ssymBool "a" &&~ ssymBool "x")
-                    (ssymBool "a" ||~ ssymBool "y")
+                    (ssymBool "a" .&& ssymBool "x")
+                    (ssymBool "a" .|| ssymBool "y")
                 ),
           testCase "Identity SymBool" $ do
             let i1 :: Identity SymBool = Identity $ ssymBool "a"
             let i2 :: Identity SymBool = Identity $ ssymBool "b"
             let i3 = mrgIte (ssymBool "c") i1 i2
             let i31 = mrgIte1 (ssymBool "c") i1 i2
-            runIdentity i3 @?= ites (ssymBool "c") (ssymBool "a") (ssymBool "b")
+            runIdentity i3 @?= symIte (ssymBool "c") (ssymBool "a") (ssymBool "b")
             runIdentity i31
-              @?= ites (ssymBool "c") (ssymBool "a") (ssymBool "b"),
+              @?= symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"),
           testCase "IdentityT (UnionM) SymBool" $ do
             let i1 :: IdentityT (UnionM) SymBool =
                   IdentityT $ mrgSingle $ ssymBool "a"
@@ -647,32 +647,32 @@ simpleMergeableTests =
             let i31 = mrgIte1 (ssymBool "c") i1 i2
             let i3u1 = mrgIf (ssymBool "c") i1 i2
             runIdentityT i3
-              @?= mrgSingle (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
             runIdentityT i31
-              @?= mrgSingle (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
             runIdentityT i3u1
-              @?= mrgSingle (ites (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
         ],
       testGroup
         "Combinators"
         [ testCase "simpleMerge" $ do
             simpleMerge
               (unionIf "a" (return "b") (return "c") :: UnionM SymBool)
-              @?= ites (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+              @?= symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
           testCase "onUnion" $ do
-            let symAll = foldl (&&~) (conBool True)
+            let symAll = foldl (.&&) (conBool True)
             let symAllU = onUnion symAll
             symAllU
               ( unionIf "cond" (return ["a"]) (return ["b", "c"]) ::
                   UnionM [SymBool]
               )
-              @?= ites "cond" "a" ("b" &&~ "c"),
-          testCase "(#~)" $ do
-            let symAll = foldl (&&~) (conBool True)
+              @?= symIte "cond" "a" ("b" .&& "c"),
+          testCase "(.#)" $ do
+            let symAll = foldl (.&&) (conBool True)
             symAll
-              #~ ( unionIf "cond" (return ["a"]) (return ["b", "c"]) ::
+              .# ( unionIf "cond" (return ["a"]) (return ["b", "c"]) ::
                      UnionM [SymBool]
                  )
-              @?= ites "cond" "a" ("b" &&~ "c")
+              @?= symIte "cond" "a" ("b" .&& "c")
         ]
     ]

--- a/test/Grisette/Core/Data/Class/SubstituteSymTests.hs
+++ b/test/Grisette/Core/Data/Class/SubstituteSymTests.hs
@@ -19,7 +19,7 @@ import Data.Functor.Sum (Sum (InL, InR))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((||~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.||)))
 import Grisette.Core.Data.Class.SubstituteSym (SubstituteSym (substituteSym))
 import Grisette.Core.Data.Class.TestValues (ssymBool, ssymbolBool)
 import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
@@ -48,7 +48,7 @@ substituteSymTests =
             let subst = substituteSym asym b
             subst a @?= b
             subst c @?= c
-            subst (a ||~ c) @?= b ||~ c,
+            subst (a .|| c) @?= b .|| c,
           testProperty "Bool" $ ioProperty . concreteSubstituteSymOkProp @Bool,
           testProperty "Integer" $
             ioProperty . concreteSubstituteSymOkProp @Integer,

--- a/test/Grisette/Core/Data/Class/ToConTests.hs
+++ b/test/Grisette/Core/Data/Class/ToConTests.hs
@@ -18,9 +18,9 @@ import Data.Functor.Sum (Sum (InL, InR))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.TestValues
   ( conBool,
     isymBool,
@@ -57,11 +57,11 @@ toConTests =
                     let sbools :: [SymBool] =
                           [ ssymBool "a",
                             isymBool "a" 1,
-                            ssymBool "a" &&~ ssymBool "b",
-                            ssymBool "a" ||~ ssymBool "b",
-                            nots $ ssymBool "a",
-                            ssymBool "a" ==~ ssymBool "b",
-                            ites (ssymBool "a") (ssymBool "b") (ssymBool "c")
+                            ssymBool "a" .&& ssymBool "b",
+                            ssymBool "a" .|| ssymBool "b",
+                            symNot $ ssymBool "a",
+                            ssymBool "a" .== ssymBool "b",
+                            symIte (ssymBool "a") (ssymBool "b") (ssymBool "c")
                           ]
                     traverse_ (\v -> toCon v @?= (Nothing :: Maybe Bool)) sbools
                 ],
@@ -70,11 +70,11 @@ toConTests =
                       [ symTrue,
                         ssymBool "a",
                         isymBool "a" 1,
-                        ssymBool "a" &&~ ssymBool "b",
-                        ssymBool "a" ||~ ssymBool "b",
-                        nots $ ssymBool "a",
-                        ssymBool "a" ==~ ssymBool "b",
-                        ites (ssymBool "a") (ssymBool "b") (ssymBool "c")
+                        ssymBool "a" .&& ssymBool "b",
+                        ssymBool "a" .|| ssymBool "b",
+                        symNot $ ssymBool "a",
+                        ssymBool "a" .== ssymBool "b",
+                        symIte (ssymBool "a") (ssymBool "b") (ssymBool "c")
                       ]
                 traverse_ (\v -> toCon v @?= Just v) sbools
             ],

--- a/test/Grisette/Core/Data/Class/ToSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ToSymTests.hs
@@ -21,9 +21,9 @@ import Data.Functor.Sum (Sum (InL, InR))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots, (&&~), (||~)))
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.Solvable (Solvable (con, isym, ssym))
 import Grisette.Core.Data.Class.ToSym (ToSym (toSym))
 import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
@@ -53,11 +53,11 @@ toSymTests =
                       [ con True,
                         ssym "a",
                         isym "a" 1,
-                        ssym "a" &&~ ssym "b",
-                        ssym "a" ||~ ssym "b",
-                        nots (ssym "a"),
-                        (ssym "a" :: SymBool) ==~ ssym "b",
-                        ites (ssym "a") (ssym "b") (ssym "c")
+                        ssym "a" .&& ssym "b",
+                        ssym "a" .|| ssym "b",
+                        symNot (ssym "a"),
+                        (ssym "a" :: SymBool) .== ssym "b",
+                        symIte (ssym "a") (ssym "b") (ssym "c")
                       ]
                 traverse_ (\v -> toSym v @?= v) sbools
             ],

--- a/test/Grisette/Core/Data/Class/UnionLikeTests.hs
+++ b/test/Grisette/Core/Data/Class/UnionLikeTests.hs
@@ -12,8 +12,8 @@ import qualified Control.Monad.Trans.State.Strict as StateStrict
 import qualified Control.Monad.Trans.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Trans.Writer.Strict as WriterStrict
 import Grisette.Core.Control.Monad.UnionM (UnionM)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( UnionLike (single, unionIf),
     merge,
@@ -39,7 +39,7 @@ unionLikeTests =
               (single $ ssym "c") ::
               UnionM SymBool
           )
-          @?= ites (ssym "a") (ssym "b") (ssym "c"),
+          @?= symIte (ssym "a") (ssym "b") (ssym "c"),
       testGroup
         "UnionLike"
         [ testGroup
@@ -55,7 +55,7 @@ unionLikeTests =
                       )
                   )
                   @?= MaybeT
-                    (mrgSingle $ Just $ ites (ssym "a") (ssym "b") (ssym "c")),
+                    (mrgSingle $ Just $ symIte (ssym "a") (ssym "b") (ssym "c")),
               testCase "mrgSingle" $ do
                 (mrgSingle 1 :: MaybeT UnionM Integer)
                   @?= MaybeT (mrgSingle $ Just 1),
@@ -65,7 +65,7 @@ unionLikeTests =
                   @?= MaybeT
                     ( mrgSingle $
                         Just $
-                          ites (ssym "a") (ssym "b") (ssym "c") ::
+                          symIte (ssym "a") (ssym "b") (ssym "c") ::
                         UnionM (Maybe SymBool)
                     )
             ],
@@ -82,7 +82,7 @@ unionLikeTests =
                       )
                   )
                   @?= ExceptT
-                    (mrgSingle $ Left $ ites (ssym "a") (ssym "b") (ssym "c")),
+                    (mrgSingle $ Left $ symIte (ssym "a") (ssym "b") (ssym "c")),
               testCase "mrgSingle" $ do
                 (mrgSingle 1 :: ExceptT SymBool UnionM Integer)
                   @?= ExceptT (mrgSingle $ Right 1),
@@ -92,7 +92,7 @@ unionLikeTests =
                   @?= ExceptT
                     ( mrgSingle $
                         Right $
-                          ites (ssym "a") (ssym "b") (ssym "c") ::
+                          symIte (ssym "a") (ssym "b") (ssym "c") ::
                         UnionM (Either SymBool SymBool)
                     )
             ],
@@ -105,12 +105,12 @@ unionLikeTests =
                           merge $ StateLazy.StateT $ \(x :: SymBool) ->
                             unionIf
                               (ssym "a")
-                              (single (x, nots x))
-                              (single (nots x, x))
+                              (single (x, symNot x))
+                              (single (symNot x, x))
                     StateLazy.runStateT s (ssym "b")
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (nots $ ssym "b"),
-                          ites (ssym "a") (nots $ ssym "b") (ssym "b")
+                        ( symIte (ssym "a") (ssym "b") (symNot $ ssym "b"),
+                          symIte (ssym "a") (symNot $ ssym "b") (ssym "b")
                         ),
                   testCase "mrgSingle" $ do
                     let s :: StateLazy.StateT SymBool UnionM SymBool =
@@ -122,15 +122,15 @@ unionLikeTests =
                           mrgIf
                             (ssym "a")
                             ( StateLazy.StateT $ \(x :: SymBool) ->
-                                single (x, nots x)
+                                single (x, symNot x)
                             )
                             ( StateLazy.StateT $ \(x :: SymBool) ->
-                                single (nots x, x)
+                                single (symNot x, x)
                             )
                     StateLazy.runStateT s (ssym "b")
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (nots $ ssym "b"),
-                          ites (ssym "a") (nots $ ssym "b") (ssym "b")
+                        ( symIte (ssym "a") (ssym "b") (symNot $ ssym "b"),
+                          symIte (ssym "a") (symNot $ ssym "b") (ssym "b")
                         )
                 ],
               testGroup
@@ -140,12 +140,12 @@ unionLikeTests =
                           merge $ StateStrict.StateT $ \(x :: SymBool) ->
                             unionIf
                               (ssym "a")
-                              (single (x, nots x))
-                              (single (nots x, x))
+                              (single (x, symNot x))
+                              (single (symNot x, x))
                     StateStrict.runStateT s (ssym "b")
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (nots $ ssym "b"),
-                          ites (ssym "a") (nots $ ssym "b") (ssym "b")
+                        ( symIte (ssym "a") (ssym "b") (symNot $ ssym "b"),
+                          symIte (ssym "a") (symNot $ ssym "b") (ssym "b")
                         ),
                   testCase "mrgSingle" $ do
                     let s :: StateStrict.StateT SymBool UnionM SymBool =
@@ -157,15 +157,15 @@ unionLikeTests =
                           mrgIf
                             (ssym "a")
                             ( StateStrict.StateT $ \(x :: SymBool) ->
-                                single (x, nots x)
+                                single (x, symNot x)
                             )
                             ( StateStrict.StateT $ \(x :: SymBool) ->
-                                single (nots x, x)
+                                single (symNot x, x)
                             )
                     StateStrict.runStateT s (ssym "b")
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (nots $ ssym "b"),
-                          ites (ssym "a") (nots $ ssym "b") (ssym "b")
+                        ( symIte (ssym "a") (ssym "b") (symNot $ ssym "b"),
+                          symIte (ssym "a") (symNot $ ssym "b") (ssym "b")
                         )
                 ]
             ],
@@ -183,8 +183,8 @@ unionLikeTests =
                                 (single (ssym "d", [ssym "e"]))
                     WriterLazy.runWriterT s
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (ssym "d"),
-                          [ites (ssym "a") (ssym "c") (ssym "e")]
+                        ( symIte (ssym "a") (ssym "b") (ssym "d"),
+                          [symIte (ssym "a") (ssym "c") (ssym "e")]
                         ),
                   testCase "mrgSingle" $ do
                     let s :: WriterLazy.WriterT [SymBool] UnionM SymBool =
@@ -198,8 +198,8 @@ unionLikeTests =
                             (WriterLazy.WriterT $ single (ssym "d", [ssym "e"]))
                     WriterLazy.runWriterT s
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (ssym "d"),
-                          [ites (ssym "a") (ssym "c") (ssym "e")]
+                        ( symIte (ssym "a") (ssym "b") (ssym "d"),
+                          [symIte (ssym "a") (ssym "c") (ssym "e")]
                         )
                 ],
               testGroup
@@ -214,8 +214,8 @@ unionLikeTests =
                                 (single (ssym "d", [ssym "e"]))
                     WriterStrict.runWriterT s
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (ssym "d"),
-                          [ites (ssym "a") (ssym "c") (ssym "e")]
+                        ( symIte (ssym "a") (ssym "b") (ssym "d"),
+                          [symIte (ssym "a") (ssym "c") (ssym "e")]
                         ),
                   testCase "mrgSingle" $ do
                     let s :: WriterStrict.WriterT [SymBool] UnionM SymBool =
@@ -233,8 +233,8 @@ unionLikeTests =
                             )
                     WriterStrict.runWriterT s
                       @?= mrgSingle
-                        ( ites (ssym "a") (ssym "b") (ssym "d"),
-                          [ites (ssym "a") (ssym "c") (ssym "e")]
+                        ( symIte (ssym "a") (ssym "b") (ssym "d"),
+                          [symIte (ssym "a") (ssym "c") (ssym "e")]
                         )
                 ]
             ],
@@ -244,10 +244,10 @@ unionLikeTests =
                 do
                   let s :: ReaderT SymBool UnionM SymBool =
                         merge $ ReaderT $ \(x :: SymBool) ->
-                          unionIf (ssym "a") (single x) (single $ nots x)
+                          unionIf (ssym "a") (single x) (single $ symNot x)
                   runReaderT s (ssym "b")
                     @?= mrgSingle
-                      (ites (ssym "a") (ssym "b") (nots $ ssym "b")),
+                      (symIte (ssym "a") (ssym "b") (symNot $ ssym "b")),
               testCase
                 "mrgSingle"
                 $ do
@@ -260,10 +260,10 @@ unionLikeTests =
                         mrgIf
                           (ssym "a")
                           (ReaderT $ \(x :: SymBool) -> single x)
-                          (ReaderT $ \(x :: SymBool) -> single $ nots x)
+                          (ReaderT $ \(x :: SymBool) -> single $ symNot x)
                   runReaderT s (ssym "b")
                     @?= mrgSingle
-                      (ites (ssym "a") (ssym "b") (nots $ ssym "b"))
+                      (symIte (ssym "a") (ssym "b") (symNot $ ssym "b"))
             ],
           testGroup
             "IdentityT"
@@ -277,7 +277,7 @@ unionLikeTests =
                               (single $ ssym "b")
                               (single $ ssym "c")
                   runIdentityT s
-                    @?= mrgSingle (ites (ssym "a") (ssym "b") (ssym "c")),
+                    @?= mrgSingle (symIte (ssym "a") (ssym "b") (ssym "c")),
               testCase
                 "mrgSingle"
                 $ do
@@ -292,7 +292,7 @@ unionLikeTests =
                           (IdentityT $ single (ssym "b"))
                           (IdentityT $ single (ssym "c"))
                   runIdentityT s
-                    @?= mrgSingle (ites (ssym "a") (ssym "b") (ssym "c"))
+                    @?= mrgSingle (symIte (ssym "a") (ssym "b") (ssym "c"))
             ]
         ]
     ]

--- a/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -60,9 +60,9 @@ import Grisette.Core.Data.Class.GenSym
     genSymSimple,
     nameWithInfo,
   )
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.LogicalOp
-  ( LogicalOp (implies, nots, xors, (&&~), (||~)),
+  ( LogicalOp (symImplies, symNot, symXor, (.&&), (.||)),
   )
 import Grisette.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
@@ -72,9 +72,9 @@ import Grisette.Core.Data.Class.ModelOps
   ( ModelOps (emptyModel, insertValue),
     ModelRep (buildModel),
   )
-import Grisette.Core.Data.Class.SEq (SEq ((/=~), (==~)))
+import Grisette.Core.Data.Class.SEq (SEq ((./=), (.==)))
 import Grisette.Core.Data.Class.SOrd
-  ( SOrd (symCompare, (<=~), (<~), (>=~), (>~)),
+  ( SOrd (symCompare, (.<), (.<=), (.>), (.>=)),
   )
 import Grisette.Core.Data.Class.SafeDivision
   ( SafeDivision
@@ -306,10 +306,10 @@ safeDivisionBoundedOnlyTests f f' cf pf =
     testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError DivideByZero)
                 ( mrgIf
-                    ((ssym "b" :: s) ==~ con (-1) &&~ (ssym "a" :: s) ==~ con (minBound :: c) :: SymBool)
+                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
                     (throwError Overflow)
                     (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b"))
                 ) ::
@@ -317,10 +317,10 @@ safeDivisionBoundedOnlyTests f f' cf pf =
             )
       f' (const ()) (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError ())
                 ( mrgIf
-                    ((ssym "b" :: s) ==~ con (-1) &&~ (ssym "a" :: s) ==~ con (minBound :: c) :: SymBool)
+                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
                     (throwError ())
                     (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b"))
                 ) ::
@@ -339,14 +339,14 @@ safeDivisionUnboundedOnlyTests f f' pf =
   [ testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError DivideByZero)
                 (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b")) ::
                 ExceptT ArithException UnionM s
             )
       f' (const ()) (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError ())
                 (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b")) ::
                 ExceptT () UnionM s
@@ -433,10 +433,10 @@ safeDivModBoundedOnlyTests f f' cf pf1 pf2 =
     testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError DivideByZero)
                 ( mrgIf
-                    ((ssym "b" :: s) ==~ con (-1) &&~ (ssym "a" :: s) ==~ con (minBound :: c) :: SymBool)
+                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
                     (throwError Overflow)
                     ( mrgSingle
                         ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
@@ -448,10 +448,10 @@ safeDivModBoundedOnlyTests f f' cf pf1 pf2 =
             )
       f' (const ()) (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError ())
                 ( mrgIf
-                    ((ssym "b" :: s) ==~ con (-1) &&~ (ssym "a" :: s) ==~ con (minBound :: c) :: SymBool)
+                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
                     (throwError ())
                     ( mrgSingle
                         ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
@@ -482,7 +482,7 @@ safeDivModUnboundedOnlyTests f f' pf1 pf2 =
   [ testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError DivideByZero)
                 ( mrgSingle
                     ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
@@ -493,7 +493,7 @@ safeDivModUnboundedOnlyTests f f' pf1 pf2 =
             )
       f' (const ()) (ssym "a" :: s) (ssym "b")
         @=? ( mrgIf
-                ((ssym "b" :: s) ==~ con (0 :: c) :: SymBool)
+                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
                 (throwError ())
                 ( mrgSingle
                     ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
@@ -607,17 +607,17 @@ symPrimTests =
             ],
           testGroup
             "ITEOp"
-            [ testCase "ites" $
-                ites (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c")
+            [ testCase "symIte" $
+                symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c")
                   @=? SymInteger (pevalITETerm (ssymTerm "a") (ssymTerm "b") (ssymTerm "c"))
             ],
           testCase "Mergeable" $ do
             let SimpleStrategy s = rootStrategy :: MergingStrategy SymInteger
             s (ssym "a") (ssym "b") (ssym "c")
-              @=? ites (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
+              @=? symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
           testCase "SimpleMergeable" $
             mrgIte (ssym "a" :: SymBool) (ssym "b") (ssym "c")
-              @=? ites (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
+              @=? symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
           testCase "IsString" $ ("a" :: SymBool) @=? SymBool (ssymTerm "a"),
           testGroup
             "ToSym"
@@ -633,11 +633,11 @@ symPrimTests =
             let m1 = emptyModel :: Model
             let m2 = insertValue (SimpleSymbol "a") (1 :: Integer) m1
             let m3 = insertValue (SimpleSymbol "b") True m2
-            evaluateSym False m3 (ites ("c" :: SymBool) "a" ("a" + "a" :: SymInteger))
-              @=? ites ("c" :: SymBool) 1 2
-            evaluateSym True m3 (ites ("c" :: SymBool) "a" ("a" + "a" :: SymInteger)) @=? 2,
+            evaluateSym False m3 (symIte ("c" :: SymBool) "a" ("a" + "a" :: SymInteger))
+              @=? symIte ("c" :: SymBool) 1 2
+            evaluateSym True m3 (symIte ("c" :: SymBool) "a" ("a" + "a" :: SymInteger)) @=? 2,
           testCase "ExtractSymbolics" $
-            extractSymbolics (ites ("c" :: SymBool) ("a" :: SymInteger) ("b" :: SymInteger))
+            extractSymbolics (symIte ("c" :: SymBool) ("a" :: SymInteger) ("b" :: SymInteger))
               @=? SymbolSet
                 ( S.fromList
                     [ someTypedSymbol (SimpleSymbol "c" :: TypedSymbol Bool),
@@ -653,18 +653,18 @@ symPrimTests =
             (genSym () (nameWithInfo "a" True) :: UnionM SymBool) @=? mrgSingle (iinfosym "a" 0 True)
             (genSymSimple () (nameWithInfo "a" True) :: SymBool) @=? iinfosym "a" 0 True,
           testCase "SEq" $ do
-            (ssym "a" :: SymBool) ==~ ssym "b" @=? SymBool (pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
-            (ssym "a" :: SymBool) /=~ ssym "b" @=? SymBool (pevalNotTerm $ pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
+            (ssym "a" :: SymBool) .== ssym "b" @=? SymBool (pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
+            (ssym "a" :: SymBool) ./= ssym "b" @=? SymBool (pevalNotTerm $ pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
         ],
       testGroup
         "SymBool"
         [ testGroup
             "LogicalOp"
-            [ testCase "||~" $ ssym "a" ||~ ssym "b" @=? SymBool (pevalOrTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "&&~" $ ssym "a" &&~ ssym "b" @=? SymBool (pevalAndTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "nots" $ nots (ssym "a") @=? SymBool (pevalNotTerm (ssymTerm "a")),
-              testCase "xors" $ xors (ssym "a") (ssym "b") @=? SymBool (pevalXorTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "implies" $ implies (ssym "a") (ssym "b") @=? SymBool (pevalImplyTerm (ssymTerm "a") (ssymTerm "b"))
+            [ testCase ".||" $ ssym "a" .|| ssym "b" @=? SymBool (pevalOrTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase ".&&" $ ssym "a" .&& ssym "b" @=? SymBool (pevalAndTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "symNot" $ symNot (ssym "a") @=? SymBool (pevalNotTerm (ssymTerm "a")),
+              testCase "symXor" $ symXor (ssym "a") (ssym "b") @=? SymBool (pevalXorTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "symImplies" $ symImplies (ssym "a") (ssym "b") @=? SymBool (pevalImplyTerm (ssymTerm "a") (ssymTerm "b"))
             ]
         ],
       testGroup
@@ -727,10 +727,10 @@ symPrimTests =
           testGroup
             "SOrd"
             [ testProperty "SOrd on concrete" $ \(i :: Integer, j :: Integer) -> ioProperty $ do
-                (con i :: SymInteger) <=~ con j @=? (con (i <= j) :: SymBool)
-                (con i :: SymInteger) <~ con j @=? (con (i < j) :: SymBool)
-                (con i :: SymInteger) >=~ con j @=? (con (i >= j) :: SymBool)
-                (con i :: SymInteger) >~ con j @=? (con (i > j) :: SymBool)
+                (con i :: SymInteger) .<= con j @=? (con (i <= j) :: SymBool)
+                (con i :: SymInteger) .< con j @=? (con (i < j) :: SymBool)
+                (con i :: SymInteger) .>= con j @=? (con (i >= j) :: SymBool)
+                (con i :: SymInteger) .> con j @=? (con (i > j) :: SymBool)
                 (con i :: SymInteger)
                   `symCompare` con j
                   @=? (i `symCompare` j :: UnionM Ordering),
@@ -739,12 +739,12 @@ symPrimTests =
                 let b :: SymInteger = ssym "b"
                 let at :: Term Integer = ssymTerm "a"
                 let bt :: Term Integer = ssymTerm "b"
-                a <=~ b @=? SymBool (pevalLeNumTerm at bt)
-                a <~ b @=? SymBool (pevalLtNumTerm at bt)
-                a >=~ b @=? SymBool (pevalGeNumTerm at bt)
-                a >~ b @=? SymBool (pevalGtNumTerm at bt)
+                a .<= b @=? SymBool (pevalLeNumTerm at bt)
+                a .< b @=? SymBool (pevalLtNumTerm at bt)
+                a .>= b @=? SymBool (pevalGeNumTerm at bt)
+                a .> b @=? SymBool (pevalGtNumTerm at bt)
                 (a `symCompare` ssym "b" :: UnionM Ordering)
-                  @=? mrgIf (a <~ b) (mrgSingle LT) (mrgIf (a ==~ b) (mrgSingle EQ) (mrgSingle GT))
+                  @=? mrgIf (a .< b) (mrgSingle LT) (mrgIf (a .== b) (mrgSingle EQ) (mrgSingle GT))
             ]
         ],
       let au :: SymWordN 4 = ssym "a"
@@ -812,10 +812,10 @@ symPrimTests =
                               jint = fromIntegral j
                            in safeAdd (toSym i :: SymIntN 8) (toSym j)
                                 @=? mrgIf
-                                  (iint + jint <~ fromIntegral (i + j))
+                                  (iint + jint .< fromIntegral (i + j))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (iint + jint >~ fromIntegral (i + j))
+                                      (iint + jint .> fromIntegral (i + j))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ i + j :: ExceptT ArithException UnionM (SymIntN 8))
                                   ),
@@ -825,10 +825,10 @@ symPrimTests =
                               jint = fromIntegral j
                            in safeMinus (toSym i :: SymIntN 8) (toSym j)
                                 @=? mrgIf
-                                  (iint - jint <~ fromIntegral (i - j))
+                                  (iint - jint .< fromIntegral (i - j))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (iint - jint >~ fromIntegral (i - j))
+                                      (iint - jint .> fromIntegral (i - j))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ i - j :: ExceptT ArithException UnionM (SymIntN 8))
                                   ),
@@ -837,10 +837,10 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                            in safeNeg (toSym i :: SymIntN 8)
                                 @=? mrgIf
-                                  (-iint <~ fromIntegral (-i))
+                                  (-iint .< fromIntegral (-i))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (-iint >~ fromIntegral (-i))
+                                      (-iint .> fromIntegral (-i))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ -i :: ExceptT ArithException UnionM (SymIntN 8))
                                   )
@@ -853,10 +853,10 @@ symPrimTests =
                               jint = fromIntegral j
                            in safeAdd (toSym i :: SymWordN 8) (toSym j)
                                 @=? mrgIf
-                                  (iint + jint <~ fromIntegral (i + j))
+                                  (iint + jint .< fromIntegral (i + j))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (iint + jint >~ fromIntegral (i + j))
+                                      (iint + jint .> fromIntegral (i + j))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ i + j :: ExceptT ArithException UnionM (SymWordN 8))
                                   ),
@@ -866,10 +866,10 @@ symPrimTests =
                               jint = fromIntegral j
                            in safeMinus (toSym i :: SymWordN 8) (toSym j)
                                 @=? mrgIf
-                                  (iint - jint <~ fromIntegral (i - j))
+                                  (iint - jint .< fromIntegral (i - j))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (iint - jint >~ fromIntegral (i - j))
+                                      (iint - jint .> fromIntegral (i - j))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ i - j :: ExceptT ArithException UnionM (SymWordN 8))
                                   ),
@@ -878,10 +878,10 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                            in safeNeg (toSym i :: SymWordN 8)
                                 @=? mrgIf
-                                  (-iint <~ fromIntegral (-i))
+                                  (-iint .< fromIntegral (-i))
                                   (throwError Underflow)
                                   ( mrgIf
-                                      (-iint >~ fromIntegral (-i))
+                                      (-iint .> fromIntegral (-i))
                                       (throwError Overflow)
                                       (mrgSingle $ toSym $ -i :: ExceptT ArithException UnionM (SymWordN 8))
                                   )
@@ -896,34 +896,34 @@ symPrimTests =
                     let js :: IntN 4 = fromInteger j
                     let normalizeu k = k - k `div` 16 * 16
                     let normalizes k = if normalizeu k >= 8 then normalizeu k - 16 else normalizeu k
-                    (con iu :: SymWordN 4) <=~ con ju @=? (con (normalizeu i <= normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) <~ con ju @=? (con (normalizeu i < normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) >=~ con ju @=? (con (normalizeu i >= normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) >~ con ju @=? (con (normalizeu i > normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .<= con ju @=? (con (normalizeu i <= normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .< con ju @=? (con (normalizeu i < normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .>= con ju @=? (con (normalizeu i >= normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .> con ju @=? (con (normalizeu i > normalizeu j) :: SymBool)
                     (con iu :: SymWordN 4)
                       `symCompare` con ju
                       @=? (normalizeu i `symCompare` normalizeu j :: UnionM Ordering)
-                    (con is :: SymIntN 4) <=~ con js @=? (con (normalizes i <= normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) <~ con js @=? (con (normalizes i < normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) >=~ con js @=? (con (normalizes i >= normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) >~ con js @=? (con (normalizes i > normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .<= con js @=? (con (normalizes i <= normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .< con js @=? (con (normalizes i < normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .>= con js @=? (con (normalizes i >= normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .> con js @=? (con (normalizes i > normalizes j) :: SymBool)
                     (con is :: SymIntN 4)
                       `symCompare` con js
                       @=? (normalizes i `symCompare` normalizes j :: UnionM Ordering),
                   testCase "SOrd on symbolic" $ do
-                    au <=~ bu @=? SymBool (pevalLeNumTerm aut but)
-                    au <~ bu @=? SymBool (pevalLtNumTerm aut but)
-                    au >=~ bu @=? SymBool (pevalGeNumTerm aut but)
-                    au >~ bu @=? SymBool (pevalGtNumTerm aut but)
+                    au .<= bu @=? SymBool (pevalLeNumTerm aut but)
+                    au .< bu @=? SymBool (pevalLtNumTerm aut but)
+                    au .>= bu @=? SymBool (pevalGeNumTerm aut but)
+                    au .> bu @=? SymBool (pevalGtNumTerm aut but)
                     (au `symCompare` bu :: UnionM Ordering)
-                      @=? mrgIf (au <~ bu) (mrgSingle LT) (mrgIf (au ==~ bu) (mrgSingle EQ) (mrgSingle GT))
+                      @=? mrgIf (au .< bu) (mrgSingle LT) (mrgIf (au .== bu) (mrgSingle EQ) (mrgSingle GT))
 
-                    as <=~ bs @=? SymBool (pevalLeNumTerm ast bst)
-                    as <~ bs @=? SymBool (pevalLtNumTerm ast bst)
-                    as >=~ bs @=? SymBool (pevalGeNumTerm ast bst)
-                    as >~ bs @=? SymBool (pevalGtNumTerm ast bst)
+                    as .<= bs @=? SymBool (pevalLeNumTerm ast bst)
+                    as .< bs @=? SymBool (pevalLtNumTerm ast bst)
+                    as .>= bs @=? SymBool (pevalGeNumTerm ast bst)
+                    as .> bs @=? SymBool (pevalGtNumTerm ast bst)
                     (as `symCompare` bs :: UnionM Ordering)
-                      @=? mrgIf (as <~ bs) (mrgSingle LT) (mrgIf (as ==~ bs) (mrgSingle EQ) (mrgSingle GT))
+                      @=? mrgIf (as .< bs) (mrgSingle LT) (mrgIf (as .== bs) (mrgSingle EQ) (mrgSingle GT))
                 ],
               testGroup
                 "Bits"
@@ -1076,7 +1076,7 @@ symPrimTests =
             symSize (con 1 + ssym "a" :: SymInteger) @=? 3
             symSize (ssym "a" + ssym "a" :: SymInteger) @=? 2
             symSize (-(ssym "a") :: SymInteger) @=? 2
-            symSize (ites (ssym "a" :: SymBool) (ssym "b") (ssym "c") :: SymInteger) @=? 4,
+            symSize (symIte (ssym "a" :: SymBool) (ssym "b") (ssym "c") :: SymInteger) @=? 4,
           testCase "symsSize" $ symsSize [ssym "a" :: SymInteger, ssym "a" + ssym "a"] @=? 2
         ],
       let asymbol :: TypedSymbol Integer = "a"

--- a/test/Grisette/Lib/Control/Monad/ExceptTests.hs
+++ b/test/Grisette/Lib/Control/Monad/ExceptTests.hs
@@ -4,7 +4,7 @@ module Grisette.Lib.Control.Monad.ExceptTests (monadExceptFunctionTests) where
 
 import Control.Monad.Trans.Except (ExceptT (ExceptT), runExceptT)
 import Grisette.Core.Control.Monad.UnionM (UnionM)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( UnionLike (unionIf),
     mrgSingle,
@@ -30,5 +30,5 @@ monadExceptFunctionTests =
             ExceptT SymBool UnionM SymBool
         )
           `mrgCatchError` return
-          @?= mrgSingle (ites "a" "b" "c")
+          @?= mrgSingle (symIte "a" "b" "c")
     ]

--- a/test/Grisette/Lib/Control/Monad/Trans/ClassTests.hs
+++ b/test/Grisette/Lib/Control/Monad/Trans/ClassTests.hs
@@ -7,7 +7,7 @@ where
 
 import Control.Monad.Except (ExceptT)
 import Grisette.Core.Control.Monad.UnionM (UnionM)
-import Grisette.Core.Data.Class.ITEOp (ITEOp (ites))
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( UnionLike (single, unionIf),
     mrgSingle,
@@ -29,5 +29,5 @@ monadTransClassTests =
             ) ::
             ExceptT SymBool UnionM SymBool
           )
-          @?= mrgSingle (ites "a" "b" "c")
+          @?= mrgSingle (symIte "a" "b" "c")
     ]

--- a/test/Grisette/Lib/Control/Monad/Trans/State/Common.hs
+++ b/test/Grisette/Lib/Control/Monad/Trans/State/Common.hs
@@ -15,7 +15,7 @@ module Grisette.Lib.Control.Monad.Trans.State.Common
 where
 
 import Grisette.Core.Control.Monad.UnionM (UnionM, unionSize)
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((&&~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.&&)))
 import Grisette.Core.Data.Class.SimpleMergeable
   ( SimpleMergeable (mrgIte),
     UnionLike (unionIf),
@@ -54,11 +54,11 @@ type GetsFunc stateT s a = (s -> a) -> stateT s UnionM a
 
 stateA ::
   StateFunc stateT SymBool SymBool -> stateT SymBool UnionM SymBool
-stateA state = state (\s -> (s &&~ ssymBool "av", s &&~ ssymBool "as"))
+stateA state = state (\s -> (s .&& ssymBool "av", s .&& ssymBool "as"))
 
 stateB ::
   StateFunc stateT SymBool SymBool -> stateT SymBool UnionM SymBool
-stateB state = state (\s -> (s &&~ ssymBool "bv", s &&~ ssymBool "bs"))
+stateB state = state (\s -> (s .&& ssymBool "bv", s .&& ssymBool "bs"))
 
 stateAB ::
   (UnionLike (stateT SymBool UnionM)) =>
@@ -77,19 +77,19 @@ mrgStateTest ::
   Assertion
 mrgStateTest mrgState runStateT = do
   let a =
-        mrgState (\s -> (s &&~ ssymBool "av", s &&~ ssymBool "as"))
+        mrgState (\s -> (s .&& ssymBool "av", s .&& ssymBool "as"))
   let b =
-        mrgState (\s -> (s &&~ ssymBool "bv", s &&~ ssymBool "bs"))
+        mrgState (\s -> (s .&& ssymBool "bv", s .&& ssymBool "bs"))
   let actual = runStateT (unionIf (ssymBool "c") a b) (ssymBool "d")
   let expected =
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "av",
-                ssymBool "d" &&~ ssymBool "as"
+              ( ssymBool "d" .&& ssymBool "av",
+                ssymBool "d" .&& ssymBool "as"
               )
-              ( ssymBool "d" &&~ ssymBool "bv",
-                ssymBool "d" &&~ ssymBool "bs"
+              ( ssymBool "d" .&& ssymBool "bv",
+                ssymBool "d" .&& ssymBool "bs"
               )
           )
   unionSize actual @?= 1
@@ -106,11 +106,11 @@ mrgRunStateTTest state mrgRunStateT = do
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "av",
-                ssymBool "d" &&~ ssymBool "as"
+              ( ssymBool "d" .&& ssymBool "av",
+                ssymBool "d" .&& ssymBool "as"
               )
-              ( ssymBool "d" &&~ ssymBool "bv",
-                ssymBool "d" &&~ ssymBool "bs"
+              ( ssymBool "d" .&& ssymBool "bv",
+                ssymBool "d" .&& ssymBool "bs"
               )
           )
   unionSize actual @?= 1
@@ -127,8 +127,8 @@ mrgEvalStateTTest state mrgEvalStateT = do
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              (ssymBool "d" &&~ ssymBool "av")
-              (ssymBool "d" &&~ ssymBool "bv")
+              (ssymBool "d" .&& ssymBool "av")
+              (ssymBool "d" .&& ssymBool "bv")
           )
   unionSize actual @?= 1
   actual @?=~ expected
@@ -144,8 +144,8 @@ mrgExecStateTTest state mrgExecStateT = do
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              (ssymBool "d" &&~ ssymBool "as")
-              (ssymBool "d" &&~ ssymBool "bs")
+              (ssymBool "d" .&& ssymBool "as")
+              (ssymBool "d" .&& ssymBool "bs")
           )
   unionSize actual @?= 1
   actual @?=~ expected
@@ -164,11 +164,11 @@ mrgMapStateTTest state runStateT mrgMapStateT = do
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "av",
-                ssymBool "d" &&~ ssymBool "as"
+              ( ssymBool "d" .&& ssymBool "av",
+                ssymBool "d" .&& ssymBool "as"
               )
-              ( ssymBool "d" &&~ ssymBool "bv",
-                ssymBool "d" &&~ ssymBool "bs"
+              ( ssymBool "d" .&& ssymBool "bv",
+                ssymBool "d" .&& ssymBool "bs"
               )
           )
   unionSize actual @?= 1
@@ -181,18 +181,18 @@ mrgWithStateTTest ::
   WithStateFunc stateT SymBool SymBool ->
   Assertion
 mrgWithStateTTest state runStateT mrgWithStateT = do
-  let a = mrgWithStateT (&&~ ssymBool "x") (stateA state)
-  let b = mrgWithStateT (&&~ ssymBool "y") (stateB state)
+  let a = mrgWithStateT (.&& ssymBool "x") (stateA state)
+  let b = mrgWithStateT (.&& ssymBool "y") (stateB state)
   let actual = runStateT (unionIf (ssymBool "c") a b) (ssymBool "d")
   let expected =
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "av" &&~ ssymBool "x",
-                ssymBool "d" &&~ ssymBool "as" &&~ ssymBool "x"
+              ( ssymBool "d" .&& ssymBool "av" .&& ssymBool "x",
+                ssymBool "d" .&& ssymBool "as" .&& ssymBool "x"
               )
-              ( ssymBool "d" &&~ ssymBool "bv" &&~ ssymBool "y",
-                ssymBool "d" &&~ ssymBool "bs" &&~ ssymBool "y"
+              ( ssymBool "d" .&& ssymBool "bv" .&& ssymBool "y",
+                ssymBool "d" .&& ssymBool "bs" .&& ssymBool "y"
               )
           )
   unionSize actual @?= 1
@@ -212,11 +212,11 @@ mrgGetTest state runStateT mrgGet = do
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "as",
-                ssymBool "d" &&~ ssymBool "as"
+              ( ssymBool "d" .&& ssymBool "as",
+                ssymBool "d" .&& ssymBool "as"
               )
-              ( ssymBool "d" &&~ ssymBool "bs",
-                ssymBool "d" &&~ ssymBool "bs"
+              ( ssymBool "d" .&& ssymBool "bs",
+                ssymBool "d" .&& ssymBool "bs"
               )
           )
   unionSize actual @?= 1
@@ -246,18 +246,18 @@ mrgModifyTest ::
   ModifyFunc stateT SymBool SymBool ->
   Assertion
 mrgModifyTest state runStateT mrgModify = do
-  let a = do stateA state; mrgModify (&&~ ssymBool "x")
-  let b = do stateB state; mrgModify (&&~ ssymBool "y")
+  let a = do stateA state; mrgModify (.&& ssymBool "x")
+  let b = do stateB state; mrgModify (.&& ssymBool "y")
   let actual = runStateT (unionIf (ssymBool "c") a b) (ssymBool "d")
   let expected =
         mrgSingle
           ( mrgIte
               (ssymBool "c")
               ( (),
-                ssymBool "d" &&~ ssymBool "as" &&~ ssymBool "x"
+                ssymBool "d" .&& ssymBool "as" .&& ssymBool "x"
               )
               ( (),
-                ssymBool "d" &&~ ssymBool "bs" &&~ ssymBool "y"
+                ssymBool "d" .&& ssymBool "bs" .&& ssymBool "y"
               )
           )
   unionSize actual @?= 1
@@ -270,18 +270,18 @@ mrgGetsTest ::
   GetsFunc stateT SymBool SymBool ->
   Assertion
 mrgGetsTest state runStateT mrgGets = do
-  let a = do stateA state; mrgGets (&&~ ssymBool "x")
-  let b = do stateB state; mrgGets (&&~ ssymBool "y")
+  let a = do stateA state; mrgGets (.&& ssymBool "x")
+  let b = do stateB state; mrgGets (.&& ssymBool "y")
   let actual = runStateT (unionIf (ssymBool "c") a b) (ssymBool "d")
   let expected =
         mrgSingle
           ( mrgIte
               (ssymBool "c")
-              ( ssymBool "d" &&~ ssymBool "as" &&~ ssymBool "x",
-                ssymBool "d" &&~ ssymBool "as"
+              ( ssymBool "d" .&& ssymBool "as" .&& ssymBool "x",
+                ssymBool "d" .&& ssymBool "as"
               )
-              ( ssymBool "d" &&~ ssymBool "bs" &&~ ssymBool "y",
-                ssymBool "d" &&~ ssymBool "bs"
+              ( ssymBool "d" .&& ssymBool "bs" .&& ssymBool "y",
+                ssymBool "d" .&& ssymBool "bs"
               )
           )
   unionSize actual @?= 1

--- a/test/Grisette/Lib/Control/MonadTests.hs
+++ b/test/Grisette/Lib/Control/MonadTests.hs
@@ -16,8 +16,8 @@ import Grisette.Lib.Control.Monad
     mrgMplus,
     mrgMzero,
     mrgReturn,
-    (>>=~),
-    (>>~),
+    (.>>),
+    (.>>=),
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
@@ -53,12 +53,12 @@ monadFunctionTests =
       testCase "mrgFmap" $ do
         mrgFmap (\x -> x * x) (mrgIf "a" (mrgReturn $ -1) (mrgReturn 1) :: UnionM Integer)
           @?= mrgReturn 1,
-      testCase ">>~" $ do
+      testCase ".>>" $ do
         (unionIf "a" (single $ -1) (single 1) :: UnionM Integer)
-          >>~ unionIf "a" (single $ -1) (single 1)
+          .>> unionIf "a" (single $ -1) (single 1)
           @?= (mrgIf "a" (mrgReturn $ -1) (mrgReturn 1) :: UnionM Integer),
-      testCase ">>=~" $ do
+      testCase ".>>=" $ do
         unionIf "a" (single $ -1) (single 1)
-          >>=~ (\x -> return $ x * x)
+          .>>= (\x -> return $ x * x)
           @?= (mrgSingle 1 :: UnionM Integer)
     ]

--- a/test/Grisette/TestUtil/SymbolicAssertion.hs
+++ b/test/Grisette/TestUtil/SymbolicAssertion.hs
@@ -4,14 +4,14 @@ import GHC.Stack (HasCallStack)
 import Grisette.Backend.SBV (z3)
 import Grisette.Backend.SBV.Data.SMT.Solving (SolvingFailure (Unsat), precise)
 import Grisette.Core.Data.Class.EvaluateSym (EvaluateSym (evaluateSym))
-import Grisette.Core.Data.Class.LogicalOp (LogicalOp (nots))
-import Grisette.Core.Data.Class.SEq (SEq ((==~)))
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot))
+import Grisette.Core.Data.Class.SEq (SEq ((.==)))
 import Grisette.Core.Data.Class.Solver (Solver (solve))
 import Test.HUnit (Assertion)
 
 (@?=~) :: (HasCallStack, SEq a, Show a, EvaluateSym a) => a -> a -> Assertion
 actual @?=~ expected = do
-  cex <- solve (precise z3) (nots $ actual ==~ expected)
+  cex <- solve (precise z3) (symNot $ actual .== expected)
   case cex of
     Left Unsat -> return ()
     Left err -> error $ "Solver isn't working: " ++ show err


### PR DESCRIPTION
This pull request renames several symbolic operators:

- `&&~` is renamed to `.&&`.
- `||~` is renamed to `.||`.
- `xors` is renamed to `symXor`.
- `nots` is renamed to `symNot`.
- `implies` is renamed to `symImplies`.
- `==~` is renamed to `.==`.
- `/=~` is renamed to `./=`.
- `<~` is renamed to `.<`.
- `<=~` is renamed to `.<=`.
- `>~` is renamed to `.>`.
- `>=~` is renamed to `.>=`.
- `#~` is renamed to `.#`.

These changes make the naming scheme more consistent, avoid name clashes with lens operators, and could benefit the resolution of #116.