### PR TITLE
Standardize the constraints for Mergeable1 and SimpleMergeable1 classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Renamed multiple symbolic operators. ([#158](https://github.com/lsrcz/grisette/pull/158))
 - [Breaking] Changed the solver interface. ([#159](https://github.com/lsrcz/grisette/pull/159))
 - [Breaking] Changed the CEGIS solver interface. ([#159](https://github.com/lsrcz/grisette/pull/159))
+- [Breaking] Changed the constraints for `Mergeable1` and `SimpleMergeable1` classes as described in https://github.com/haskell/core-libraries-committee/issues/10. ([#160](https://github.com/lsrcz/grisette/pull/160))
 
 ## [0.3.1.1] -- 2023-09-29
 

--- a/src/Grisette/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Core/Data/Class/SimpleMergeable.hs
@@ -149,7 +149,10 @@ instance (Generic a, Mergeable' (Rep a), SimpleMergeable' (Rep a)) => SimpleMerg
   {-# INLINE mrgIte #-}
 
 -- | Lifting of the 'SimpleMergeable' class to unary type constructors.
-class SimpleMergeable1 u where
+class
+  (forall a. (SimpleMergeable a) => SimpleMergeable (u a), Mergeable1 u) =>
+  SimpleMergeable1 u
+  where
   -- | Lift 'mrgIte' through the type constructor.
   --
   -- >>> liftMrgIte mrgIte "a" (Identity "b") (Identity "c") :: Identity SymInteger
@@ -165,7 +168,10 @@ mrgIte1 = liftMrgIte mrgIte
 {-# INLINE mrgIte1 #-}
 
 -- | Lifting of the 'SimpleMergeable' class to binary type constructors.
-class (Mergeable2 u) => SimpleMergeable2 u where
+class
+  (forall a. (SimpleMergeable a) => SimpleMergeable1 (u a), Mergeable2 u) =>
+  SimpleMergeable2 u
+  where
   -- | Lift 'mrgIte' through the type constructor.
   --
   -- >>> liftMrgIte2 mrgIte mrgIte "a" ("b", "c") ("d", "e") :: (SymInteger, SymBool)


### PR DESCRIPTION
This pull request standardizes the constraints for `*1` classes as described in https://github.com/haskell/core-libraries-committee/issues/10. Resolves #124.