### PR TITLE
Add cegisForAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1.0] -- 2024-01-10
+
+### Added
+
+- Added `cegisForAll` interfaces. ([#165])(https://github.com/lsrcz/grisette/pull/165)
+
 ## [0.4.0.0] -- 2024-01-08
 
 ### Added
@@ -125,6 +131,7 @@ No user-facing changes.
 
 - Initial release for Grisette.
 
+[0.4.1.0]: https://github.com/lsrcz/grisette/compare/v0.4.1.0...v0.4.0.0
 [0.4.0.0]: https://github.com/lsrcz/grisette/compare/v0.4.0.0...v0.3.1.0
 [0.3.1.1]: https://github.com/lsrcz/grisette/compare/v0.3.1.0...v0.3.1.1
 [0.3.1.0]: https://github.com/lsrcz/grisette/compare/v0.3.0.0...v0.3.1.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ packages. You can add it to your project's `.cabal` file:
 ```cabal
 library
   ...
-  build-depends: grisette >= 0.4 < 0.5
+  build-depends: grisette >= 0.4.1 < 0.5
 ```
 
 #### Quick start template with `stack new`

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           grisette
-version:        0.4.0.0
+version:        0.4.1.0
 synopsis:       Symbolic evaluation as a library
 description:    Grisette is a reusable symbolic evaluation library for Haskell. By
                 translating programs into constraints, Grisette can help the development of

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: grisette
-version: 0.4.0.0
+version: 0.4.1.0
 synopsis: Symbolic evaluation as a library
 description: |
   Grisette is a reusable symbolic evaluation library for Haskell. By

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -964,9 +964,9 @@ module Grisette.Core
 
     -- ** CEGIS interfaces with pre/post conditions
     CEGISCondition (..),
-    cegisMultiInputs,
     cegisPostCond,
     cegisPrePost,
+    cegisMultiInputs,
     cegis,
     cegisExcept,
     cegisExceptStdVC,
@@ -974,6 +974,10 @@ module Grisette.Core
     cegisExceptMultiInputs,
     cegisExceptStdVCMultiInputs,
     cegisExceptVCMultiInputs,
+    cegisForAll,
+    cegisForAllExcept,
+    cegisForAllExceptStdVC,
+    cegisForAllExceptVC,
 
     -- ** Symbolic constant extraction
 
@@ -1087,6 +1091,10 @@ import Grisette.Core.Data.Class.CEGISSolver
     cegisExceptStdVCMultiInputs,
     cegisExceptVC,
     cegisExceptVCMultiInputs,
+    cegisForAll,
+    cegisForAllExcept,
+    cegisForAllExceptStdVC,
+    cegisForAllExceptVC,
     cegisMultiInputs,
     cegisPostCond,
     cegisPrePost,


### PR DESCRIPTION
This pull request adds the `cegisForAll` interface, which is similar to the `cegis` interface prior to grisette-0.4.0.0.

The interface seems to be useful and cannot be easily simulated with the current `cegis` interface, so we reimplemented it with the `genericCEGIS` function.