### PR TITLE
Update to latest lts and nightly snapshots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest]
         plan:
           - {
               build: stack,
@@ -61,47 +61,15 @@ jobs:
               ismain: true,
               experimental: false,
               ghc: "963",
-              cachekey: "stack-22.4",
+              cachekey: "stack-22.6",
             }
           - {
               build: stack,
               arg: "--stack-yaml stack-nightly.yaml",
               ismain: false,
               experimental: false,
-              ghc: "963",
+              ghc: "981",
               cachekey: "stack-nightly",
-            }
-          - {
-              build: cabal,
-              arg: "--constraint=sbv<10",
-              ismain: false,
-              experimental: false,
-              ghc: "8107",
-              cachekey: "cabal-8107",
-            }
-          - {
-              build: cabal,
-              arg: "--constraint=sbv<10",
-              ismain: false,
-              experimental: false,
-              ghc: "902",
-              cachekey: "cabal-902",
-            }
-          - {
-              build: cabal,
-              arg: "",
-              ismain: false,
-              experimental: false,
-              ghc: "928",
-              cachekey: "cabal-928",
-            }
-          - {
-              build: cabal,
-              arg: "",
-              ismain: false,
-              experimental: false,
-              ghc: "948",
-              cachekey: "cabal-948",
             }
           - {
               build: cabal,
@@ -111,6 +79,17 @@ jobs:
               ghc: "963",
               cachekey: "cabal-963",
             }
+        include:
+          - os: macOS-latest
+            plan:
+              {
+                build: stack,
+                arg: "",
+                ismain: true,
+                experimental: false,
+                ghc: "963",
+                cachekey: "stack-22.6",
+              }
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.plan.experimental }}
@@ -138,9 +117,19 @@ jobs:
           case ${{ matrix.os }} in
             macOS-latest)
               sed -i '' "s/pkgs.haskell.packages.\"ghc902\"/pkgs.haskell.packages.\"ghc${{ matrix.plan.ghc }}\"/" flake.nix
+              case ${{ matrix.plan.build }} in
+                stack)
+                  sed -i '' "s/hPkgs.cabal-install//" flake.nix
+                  ;;
+              esac
               ;;
             ubuntu-latest)
               sed -i "s/pkgs.haskell.packages.\"ghc902\"/pkgs.haskell.packages.\"ghc${{ matrix.plan.ghc }}\"/" flake.nix
+              case ${{ matrix.plan.build }} in
+                stack)
+                  sed -i "s/hPkgs.cabal-install//" flake.nix
+                  ;;
+              esac
               ;;
           esac
 

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704194953,
-        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
         "type": "github"
       },
       "original": {

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -30,6 +30,7 @@ tested-with:
   , GHC == 9.2.8
   , GHC == 9.4.8
   , GHC == 9.6.3
+  , GHC == 9.8.1
 extra-source-files:
     CHANGELOG.md
     README.md

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ tested-with:
   - GHC == 9.2.8
   - GHC == 9.4.8
   - GHC == 9.6.3
+  - GHC == 9.8.1
 
 dependencies:
   - base >= 4.14 && < 5

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2023-12-26
+resolver: nightly-2024-02-12
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,8 +39,6 @@ packages:
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
-extra-deps:
-  - sbv-10.3
 # Override default flag values for local packages and extra-deps
 # flags: {}
 

--- a/stack-nightly.yaml.lock
+++ b/stack-nightly.yaml.lock
@@ -3,17 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: sbv-10.3@sha256:d869a49fd8e6303a81f7f704bb8669deff20d000e4644f93ddc64749d4bc0f9a,23712
-    pantry-tree:
-      sha256: 94cac2af8f8ac8f1a6cf8bbd37c679cdeff94d6034c074c670c20adf2e8c86dc
-      size: 72362
-  original:
-    hackage: sbv-10.3
+packages: []
 snapshots:
 - completed:
-    sha256: b69a06c70e1092e2aa60ce69a4877c6181fbe53dfb7ea041cb98d97617d6007f
-    size: 716491
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2023/12/26.yaml
-  original: nightly-2023-12-26
+    sha256: 62f2f54aac083e25613ce5aefd04b390f1e8853631b2059e31d7a039e5f50e03
+    size: 602427
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2024/2/12.yaml
+  original: nightly-2024-02-12

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-22.4
+resolver: lts-22.6
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 8b211c5a6aad3787e023dfddaf7de7868968e4f240ecedf14ad1c5b2199046ca
-    size: 714097
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/4.yaml
-  original: lts-22.4
+    sha256: 1b4c2669e26fa828451830ed4725e4d406acc25a1fa24fcc039465dd13d7a575
+    size: 714100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/22/6.yaml
+  original: lts-22.6


### PR DESCRIPTION
Update to latest snapshots as `sbv` is now available in latest nightly snapshot (https://github.com/LeventErkok/sbv/issues/680).