### PR TITLE
Add creation of SomeBV from runtime bit-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added the creation of unparameterized bit vectors from run-time bit-widths. ([#168])(https://github.com/lsrcz/grisette/pull/168)
+
 ## [0.4.1.0] -- 2024-01-10
 
 ### Added
@@ -131,6 +137,7 @@ No user-facing changes.
 
 - Initial release for Grisette.
 
+[Unreleased]: https://github.com/lsrcz/grisette/compare/v0.4.1.0...HEAD
 [0.4.1.0]: https://github.com/lsrcz/grisette/compare/v0.4.1.0...v0.4.0.0
 [0.4.0.0]: https://github.com/lsrcz/grisette/compare/v0.4.0.0...v0.3.1.0
 [0.3.1.1]: https://github.com/lsrcz/grisette/compare/v0.3.1.0...v0.3.1.1

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -27,7 +27,7 @@ module Grisette.Core.Data.Class.BitVector
 where
 
 import Data.Proxy (Proxy (Proxy))
-import GHC.TypeNats (KnownNat, type (+), type (-), type (<=), Natural)
+import GHC.TypeNats (KnownNat, Natural, type (+), type (-), type (<=))
 import Grisette.Utils.Parameterized
   ( KnownProof (KnownProof),
     LeqProof (LeqProof),
@@ -121,7 +121,6 @@ class BV bv where
   -- >>> bv 12 21 :: SomeSymIntN 12
   -- 0x015
   bv :: Natural -> Integer -> bv
-
 
 -- | Slicing out a smaller bit vector from a larger one, extract a slice from
 -- bit @i@ down to @j@.

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -119,7 +119,7 @@ class BV bv where
   -- | Create a bit vector from an integer. The bit-width is the first argument,
   -- which should not be zero.
   --
-  -- >>> bv 12 21 :: SomeSymIntN 12
+  -- >>> bv 12 21 :: SomeSymIntN
   -- 0x015
   bv :: Natural -> Integer -> bv
 

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -27,7 +27,7 @@ module Grisette.Core.Data.Class.BitVector
 where
 
 import Data.Proxy (Proxy (Proxy))
-import GHC.TypeNats (KnownNat, Natural, type (+), type (-), type (<=))
+import GHC.TypeNats (KnownNat, type (+), type (-), type (<=))
 import Grisette.Utils.Parameterized
   ( KnownProof (KnownProof),
     LeqProof (LeqProof),
@@ -37,6 +37,7 @@ import Grisette.Utils.Parameterized
     subNat,
     unsafeLeqProof,
   )
+import Numeric.Natural (Natural)
 
 -- $setup
 -- >>> import Grisette.Core

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -27,7 +27,7 @@ module Grisette.Core.Data.Class.BitVector
 where
 
 import Data.Proxy (Proxy (Proxy))
-import GHC.TypeNats (KnownNat, type (+), type (-), type (<=))
+import GHC.TypeNats (KnownNat, type (+), type (-), type (<=), Natural)
 import Grisette.Utils.Parameterized
   ( KnownProof (KnownProof),
     LeqProof (LeqProof),
@@ -114,6 +114,14 @@ class BV bv where
     -- | Bit vector to select from
     bv ->
     bv
+
+  -- | Create a bit vector from an integer. The bit-width is the first argument,
+  -- which should not be zero.
+  --
+  -- >>> bv 12 21 :: SomeSymIntN 12
+  -- 0x015
+  bv :: Natural -> Integer -> bv
+
 
 -- | Slicing out a smaller bit vector from a larger one, extract a slice from
 -- bit @i@ down to @j@.

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -127,7 +127,7 @@ import Grisette.Core.Data.BV
     WordN,
   )
 import Grisette.Core.Data.Class.BitVector
-  ( BV (bvConcat, bvExt, bvSelect, bvSext, bvZext),
+  ( BV (bv, bvConcat, bvExt, bvSelect, bvSext, bvZext),
     SizedBV (sizedBVConcat, sizedBVExt, sizedBVSelect, sizedBVSext, sizedBVZext),
   )
 import Grisette.Core.Data.Class.Function (Apply (FunType, apply), Function (Arg, Ret, (#)))
@@ -210,11 +210,14 @@ import Grisette.IR.SymPrim.Data.TabularFun (type (=->))
 import Grisette.Utils.Parameterized
   ( KnownProof (KnownProof),
     LeqProof (LeqProof),
+    NatRepr,
+    Some (Some),
     knownAdd,
     leqAddPos,
     leqTrans,
     unsafeKnownProof,
     unsafeLeqProof,
+    withKnownNat, mkNatRepr,
   )
 import Language.Haskell.TH.Syntax (Lift)
 
@@ -960,6 +963,13 @@ bvSelect ix w (somety (a :: origty n)) \
           (KnownProof, KnownProof, LeqProof, LeqProof) -> \
             somety $ sizedBVSelect (Proxy @ix) (Proxy @w) a
 
+#define BVBV(somety, origty) \
+  bv n i = case mkNatRepr n of \
+    Some (natRepr :: NatRepr x) -> \
+      case unsafeLeqProof @1 @x of \
+        LeqProof -> withKnownNat natRepr $ \
+          somety (fromIntegral i :: origty x)
+
 #if 1
 instance BV SomeSymIntN where
   BVCONCAT(SomeSymIntN, SymIntN)
@@ -972,6 +982,8 @@ instance BV SomeSymIntN where
   {-# INLINE bvExt #-}
   BVSELECT(SomeSymIntN, SymIntN)
   {-# INLINE bvSelect #-}
+  BVBV(SomeSymIntN, SymIntN)
+  {-# INLINE bv #-}
 
 instance BV SomeSymWordN where
   BVCONCAT(SomeSymWordN, SymWordN)
@@ -984,6 +996,8 @@ instance BV SomeSymWordN where
   {-# INLINE bvExt #-}
   BVSELECT(SomeSymWordN, SymWordN)
   {-# INLINE bvSelect #-}
+  BVBV(SomeSymWordN, SymWordN)
+  {-# INLINE bv #-}
 #endif
 
 -- BVSignConversion

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -215,9 +215,10 @@ import Grisette.Utils.Parameterized
     knownAdd,
     leqAddPos,
     leqTrans,
+    mkNatRepr,
     unsafeKnownProof,
     unsafeLeqProof,
-    withKnownNat, mkNatRepr,
+    withKnownNat,
   )
 import Language.Haskell.TH.Syntax (Lift)
 

--- a/src/Grisette/Utils.hs
+++ b/src/Grisette/Utils.hs
@@ -18,7 +18,6 @@ module Grisette.Utils
     -- ** Runtime representation of type-level natural numbers
     NatRepr,
     natValue,
-    unsafeMkNatRepr,
     natRepr,
     decNat,
     predNat,
@@ -76,7 +75,6 @@ import Grisette.Utils.Parameterized
     unsafeAxiom,
     unsafeKnownProof,
     unsafeLeqProof,
-    unsafeMkNatRepr,
     withKnownProof,
     withLeqProof,
   )

--- a/src/Grisette/Utils/Parameterized.hs
+++ b/src/Grisette/Utils/Parameterized.hs
@@ -94,7 +94,6 @@ where
 
 import Data.Kind (Type)
 import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
-import GHC.Natural (Natural)
 import GHC.TypeNats
   ( Div,
     KnownNat,
@@ -106,6 +105,7 @@ import GHC.TypeNats
     type (-),
     type (<=),
   )
+import Numeric.Natural (Natural)
 import Unsafe.Coerce (unsafeCoerce)
 
 data Some (f :: k -> Type) = forall x. Some (f x)

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -44,9 +44,15 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Typeable (Typeable, typeRep)
 import Data.Word (Word8)
 import GHC.Stack (HasCallStack)
-import Grisette.Core.Data.BV (IntN (IntN), WordN (unWordN))
+import Grisette.Core.Data.BV
+  ( IntN (IntN),
+    SomeIntN (SomeIntN),
+    SomeWordN (SomeWordN),
+    WordN (unWordN),
+  )
 import Grisette.Core.Data.Class.BitVector
-  ( SizedBV
+  ( BV (bv),
+    SizedBV
       ( sizedBVConcat,
         sizedBVExt,
         sizedBVSelect,
@@ -57,7 +63,7 @@ import Grisette.Core.Data.Class.BitVector
 import Test.Framework (Test, TestName, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit (Assertion, assertFailure, (@=?))
+import Test.HUnit (Assertion, assertFailure, (@=?), (@?=))
 import Test.QuickCheck (Arbitrary, Property, ioProperty)
 
 unaryConform :: forall a b c d. (Show c, Eq c, HasCallStack) => (a -> b) -> (d -> c) -> (a -> c) -> (b -> d) -> a -> Property
@@ -326,10 +332,10 @@ integralConformTest pref ptyp =
       testProperty "toInteger" $ unaryConform @ref @typ fromIntegral id toInteger toInteger
     ]
 
-bvTests :: Test
-bvTests =
+sizedBVTests :: Test
+sizedBVTests =
   testGroup
-    "BV"
+    "sizedBV"
     [ testGroup
         "WordN 8 conform to Word8 for Bits instances"
         [ testProperty "(.&.)" $ \x y -> ioProperty $ wordBinConform (.&.) (.&.) x y,
@@ -481,3 +487,34 @@ bvTests =
             ioProperty $ shiftL x maxBound @=? 0
         ]
     ]
+
+someWordNTests :: Test
+someWordNTests =
+  testGroup
+    "SomeWordN"
+    [ testGroup
+        "BV"
+        [ testGroup
+            "bv"
+            [ testCase "bv 12 21" $
+                (bv 12 21 :: SomeWordN) @?= SomeWordN (0x015 :: WordN 12)
+            ]
+        ]
+    ]
+
+someIntNTests :: Test
+someIntNTests =
+  testGroup
+    "SomeIntN"
+    [ testGroup
+        "BV"
+        [ testGroup
+            "bv"
+            [ testCase "bv 12 21" $
+                (bv 12 21 :: SomeIntN) @?= SomeIntN (0x015 :: IntN 12)
+            ]
+        ]
+    ]
+
+bvTests :: Test
+bvTests = testGroup "BV" [sizedBVTests, someWordNTests, someIntNTests]

--- a/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -40,7 +40,8 @@ import Data.Word (Word8)
 import Grisette.Core.Control.Monad.UnionM (UnionM)
 import Grisette.Core.Data.BV (IntN (IntN), WordN (WordN))
 import Grisette.Core.Data.Class.BitVector
-  ( SizedBV
+  ( BV (bv),
+    SizedBV
       ( sizedBVConcat,
         sizedBVExt,
         sizedBVSelect,
@@ -182,6 +183,8 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
   )
 import Grisette.IR.SymPrim.Data.SymPrim
   ( ModelSymPair ((:=)),
+    SomeSymIntN (SomeSymIntN),
+    SomeSymWordN (SomeSymWordN),
     SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
@@ -196,7 +199,7 @@ import Grisette.IR.SymPrim.Data.TabularFun (type (=->))
 import Test.Framework (Test, TestName, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit (Assertion, assertFailure, (@=?))
+import Test.HUnit (Assertion, assertFailure, (@=?), (@?=))
 import Test.QuickCheck (Arbitrary, ioProperty)
 
 newtype AEWrapper = AEWrapper ArithException deriving (Eq)
@@ -1026,6 +1029,15 @@ symPrimTests =
                     toCon (con 255 :: SymWordN 8) @=? Just (255 :: Word8)
                 ]
             ],
+      testGroup
+        "SomeSym"
+        [ testGroup
+            "BV"
+            [ testCase "bv" $ do
+                (bv 12 21 :: SomeSymWordN) @?= SomeSymWordN (21 :: SymWordN 12)
+                (bv 12 21 :: SomeSymIntN) @?= SomeSymIntN (21 :: SymIntN 12)
+            ]
+        ],
       testGroup
         "TabularFun"
         [ testCase "#" $


### PR DESCRIPTION
This pull request adds the creation of `SomeIntN`, `SomeWordN`, `SomeSymIntN` and `SomeSymWordN` from runtime bit-width, resolves #166.

```haskell
> bv 12 21 :: SymWordN
0x015
```