### PR TITLE
Loosen the upper-bound for sbv to <11

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -155,7 +155,7 @@ library
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.11 && <10.4
+    , sbv >=8.11 && <11
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.22
     , text >=1.2.4.1 && <2.2
@@ -194,7 +194,7 @@ test-suite doctest
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.11 && <10.4
+    , sbv >=8.11 && <11
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.22
     , text >=1.2.4.1 && <2.2
@@ -277,7 +277,7 @@ test-suite spec
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.11 && <10.4
+    , sbv >=8.11 && <11
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.22
     , test-framework >=0.8.2 && <0.9

--- a/package.yaml
+++ b/package.yaml
@@ -43,7 +43,7 @@ dependencies:
   - loch-th >= 0.2.2 && < 0.3
   - th-compat >= 0.1.2 && < 0.2
   - array >= 0.5.4 && < 0.6
-  - sbv >= 8.11 && < 10.4
+  - sbv >= 8.11 && < 11
   - parallel >= 3.2.2.0 && < 3.3
   - text >= 1.2.4.1 && < 2.2
   - QuickCheck >= 2.14 && < 2.15


### PR DESCRIPTION
The sbv-10.4 package has been released. This pull request loosen the upper bound to <11.