### PR TITLE
Fixes safe division for merging and incorrect behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the creation of unparameterized bit vectors from run-time bit-widths. ([#168])(https://github.com/lsrcz/grisette/pull/168)
 - Added all the functions available for the exception transformer in `transformers` and `mtl` packages. ([#171](https://github.com/lsrcz/grisette/pull/171))
 
+### Fixed
+- Fixed the merging for safe division. ([#173](https://github.com/lsrcz/grisette/pull/173))
+- Fixed the behavior for safe `mod` and `rem` for signed, bounded concrete types. ([#173](https://github.com/lsrcz/grisette/pull/173))
+
 ### Changed
 
 - [Breaking] Removed the `UnionLike` and `UnionPrjOp` interface, added the

--- a/test/Grisette/Core/Data/Class/SafeDivisionTests.hs
+++ b/test/Grisette/Core/Data/Class/SafeDivisionTests.hs
@@ -8,67 +8,140 @@ module Grisette.Core.Data.Class.SafeDivisionTests (safeDivisionTests) where
 
 import Control.DeepSeq (NFData, force)
 import Control.Exception (ArithException, catch)
+import Control.Monad.Except (ExceptT, runExceptT)
+import Data.Bifunctor (Bifunctor (bimap))
 import Data.Data (Typeable, typeRep)
-import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Proxy (Proxy (Proxy))
-import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.IO (evaluate)
+import GHC.Int (Int16, Int32, Int64, Int8)
+import GHC.Word (Word16, Word32, Word64, Word8)
 import Grisette
-  ( IntN,
+  ( BV (bv),
+    IntN,
+    Mergeable,
     SafeDivision (safeDiv, safeDivMod, safeMod, safeQuot, safeQuotRem, safeRem),
+    SomeIntN (SomeIntN),
+    SomeWordN (SomeWordN),
+    UnionM,
     WordN,
+    mrgPure,
   )
+import Grisette.Core.Control.Monad.UnionM (isMerged)
+import Grisette.Core.Data.BV (BitwidthMismatch (BitwidthMismatch))
+import Grisette.Lib.Control.Monad.Except (mrgThrowError)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit ((@?=))
+import Test.HUnit (assertBool, (@?=))
 import Test.QuickCheck (Arbitrary, ioProperty)
 
 matches ::
-  (NFData a, Eq a, Show a) =>
-  (t -> t -> Either ArithException a) ->
-  (t -> t -> a) ->
+  (NFData r, Eq r', Show r', Mergeable r', Mergeable e, Eq e, Show e) =>
+  (t -> t') ->
+  (r -> r') ->
+  (ArithException -> e) ->
+  (t' -> t' -> ExceptT e UnionM r') ->
+  (t -> t -> r) ->
   t ->
   t ->
   IO ()
-matches f fref x y = do
+matches wrapInput wrapOutput wrapError f fref x y = do
   rref <-
-    (Right <$> evaluate (force (fref x y)))
-      `catch` \(e :: ArithException) -> return $ Left e
-  f x y @?= rref
+    (mrgPure . wrapOutput <$> evaluate (force (fref x y)))
+      `catch` \(e :: ArithException) -> return $ mrgThrowError $ wrapError e
+  let r = f (wrapInput x) (wrapInput y)
+  assertBool "Is merged" $ isMerged $ runExceptT r
+  r @?= rref
 
-generalOpTest ::
-  (NFData r, Arbitrary t, Show t, Eq r, Show r, Eq r, Num t) =>
+generalOpTestBase ::
+  ( NFData r,
+    Arbitrary t,
+    Show t,
+    Eq r',
+    Show r',
+    Eq r,
+    Num t,
+    Mergeable r',
+    Mergeable e,
+    Show e,
+    Eq e
+  ) =>
+  (t -> t') ->
+  (r -> r') ->
+  (ArithException -> e) ->
   String ->
-  (t -> t -> Either ArithException r) ->
+  (t' -> t' -> ExceptT e UnionM r') ->
   (t -> t -> r) ->
   Test
-generalOpTest name f fref =
+generalOpTestBase wrapInput wrapOutput wrapError name f fref =
   testGroup
     name
-    [ testProperty "random" $ \x y -> ioProperty $ matches f fref x y,
-      testCase "divided by zero" $ matches f fref 1 0
+    [ testProperty "random" $ \x y ->
+        ioProperty $ matches wrapInput wrapOutput wrapError f fref x y,
+      testCase "divided by zero" $
+        matches wrapInput wrapOutput wrapError f fref 1 0
     ]
 
-opBoundedSignedTest ::
-  (NFData a, Arbitrary t, Show t, Eq a, Show a, Eq a, Num t, Bounded t) =>
+generalOpTest ::
+  (NFData r, Arbitrary t, Show t, Eq r, Show r, Eq r, Num t, Mergeable r) =>
   String ->
-  (t -> t -> Either ArithException a) ->
-  (t -> t -> a) ->
+  (t -> t -> ExceptT ArithException UnionM r) ->
+  (t -> t -> r) ->
   Test
-opBoundedSignedTest name f fref =
+generalOpTest = generalOpTestBase id id id
+
+opBoundedTestBase ::
+  ( NFData r,
+    Arbitrary t,
+    Show t,
+    Show r',
+    Eq r',
+    Num t,
+    Bounded t,
+    Mergeable r',
+    Mergeable e,
+    Show e,
+    Eq e
+  ) =>
+  (t -> t') ->
+  (r -> r') ->
+  (ArithException -> e) ->
+  String ->
+  (t' -> t' -> ExceptT e UnionM r') ->
+  (t -> t -> r) ->
+  Test
+opBoundedTestBase wrapInput wrapOutput wrapError name f fref =
   testGroup
     name
-    [ testProperty "random" $ \x y -> ioProperty $ matches f fref x y,
-      testCase "divided by zero" $ matches f fref 1 0,
-      testCase "minBound/-1" $ matches f fref minBound (-1)
+    [ testProperty "random" $ \x y ->
+        ioProperty $ matches wrapInput wrapOutput wrapError f fref x y,
+      testCase "divided by zero" $
+        matches wrapInput wrapOutput wrapError f fref 1 0,
+      testCase "minBound/-1" $
+        matches wrapInput wrapOutput wrapError f fref minBound (-1)
     ]
+
+opBoundedTest ::
+  ( NFData r,
+    Arbitrary t,
+    Show t,
+    Show r,
+    Eq r,
+    Num t,
+    Bounded t,
+    Mergeable r
+  ) =>
+  String ->
+  (t -> t -> ExceptT ArithException UnionM r) ->
+  (t -> t -> r) ->
+  Test
+opBoundedTest = opBoundedTestBase id id id
 
 type OpTestFunc t =
   forall r.
-  (Eq r, Show r, Eq r, NFData r) =>
+  (Eq r, Show r, Eq r, NFData r, Mergeable r) =>
   String ->
-  (t -> t -> Either ArithException r) ->
+  (t -> t -> ExceptT ArithException UnionM r) ->
   (t -> t -> r) ->
   Test
 
@@ -76,40 +149,127 @@ testType ::
   forall t.
   ( NFData t,
     Show t,
-    SafeDivision ArithException t (Either ArithException),
+    SafeDivision ArithException t (ExceptT ArithException UnionM),
+    Mergeable t,
     Integral t,
     Typeable t
   ) =>
   OpTestFunc t ->
-  OpTestFunc t ->
   Proxy t ->
   Test
-testType divQuotTest modRemTest p =
+testType testFunc p =
   testGroup
     (show $ typeRep p)
-    [ divQuotTest "div" safeDiv (div @t),
-      modRemTest "mod" safeMod (mod @t),
-      divQuotTest "divMod" safeDivMod (divMod @t),
-      divQuotTest "quot" safeQuot (quot @t),
-      modRemTest "rem" safeRem (rem @t),
-      modRemTest "quotRem" safeQuotRem (quotRem @t)
+    [ testFunc "div" safeDiv (div @t),
+      testFunc "mod" safeMod (mod @t),
+      testFunc "divMod" safeDivMod (divMod @t),
+      testFunc "quot" safeQuot (quot @t),
+      testFunc "rem" safeRem (rem @t),
+      testFunc "quotRem" safeQuotRem (quotRem @t)
     ]
+
+-- type SomeOpTestFunc t t' =
+--   forall r r'.
+--   (Eq r, Show r, Eq r, NFData r, Mergeable r) =>
+--   String ->
+--   (t' -> t' -> ExceptT ArithException UnionM r') ->
+--   (t -> t -> r) ->
+--   Test
+--
+-- testSomeType ::
+--   forall t t'.
+--   ( NFData t,
+--     Show t,
+--     SafeDivision ArithException t' (ExceptT ArithException UnionM),
+--     Mergeable t,
+--     Integral t,
+--     Typeable t'
+--   ) =>
+--   SomeDivTestFunc t t' ->
+--   SomeDivTestFunc t t' ->
+--   Proxy t ->
+--   Proxy t' ->
+--   Test
+-- testSomeType divQuotTest modRemTest _ p =
+--   testGroup
+--     (show $ typeRep p)
+--     [ divQuotTest "div" safeDiv (div @t),
+--       modRemTest "mod" safeMod (mod @t),
+--       divQuotTest "divMod" safeDivMod (divMod @t),
+--       divQuotTest "quot" safeQuot (quot @t),
+--       modRemTest "rem" safeRem (rem @t),
+--       modRemTest "quotRem" safeQuotRem (quotRem @t)
+--     ]
 
 safeDivisionTests :: Test
 safeDivisionTests =
   testGroup
     "SafeDivision"
-    [ testType generalOpTest generalOpTest (Proxy :: Proxy Integer),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy Int8),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy Int16),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy Int32),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy Int64),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy Int),
-      testType opBoundedSignedTest generalOpTest (Proxy :: Proxy (IntN 8)),
-      testType generalOpTest generalOpTest (Proxy :: Proxy Word),
-      testType generalOpTest generalOpTest (Proxy :: Proxy Word8),
-      testType generalOpTest generalOpTest (Proxy :: Proxy Word16),
-      testType generalOpTest generalOpTest (Proxy :: Proxy Word32),
-      testType generalOpTest generalOpTest (Proxy :: Proxy Word64),
-      testType generalOpTest generalOpTest (Proxy :: Proxy (WordN 8))
+    [ testType generalOpTest (Proxy :: Proxy Integer),
+      testType opBoundedTest (Proxy :: Proxy Int8),
+      testType opBoundedTest (Proxy :: Proxy Int16),
+      testType opBoundedTest (Proxy :: Proxy Int32),
+      testType opBoundedTest (Proxy :: Proxy Int64),
+      testType opBoundedTest (Proxy :: Proxy Int),
+      testType opBoundedTest (Proxy :: Proxy (IntN 8)),
+      testType opBoundedTest (Proxy :: Proxy Word),
+      testType opBoundedTest (Proxy :: Proxy Word8),
+      testType opBoundedTest (Proxy :: Proxy Word16),
+      testType opBoundedTest (Proxy :: Proxy Word32),
+      testType opBoundedTest (Proxy :: Proxy Word64),
+      testType opBoundedTest (Proxy :: Proxy (WordN 8)),
+      testGroup "SomeWordN" $ do
+        let singleOutputTest =
+              opBoundedTestBase
+                SomeWordN
+                SomeWordN
+                (\e -> Right e :: Either BitwidthMismatch ArithException)
+        let doubleOutputTest =
+              opBoundedTestBase
+                SomeWordN
+                (bimap SomeWordN SomeWordN)
+                (\e -> Right e :: Either BitwidthMismatch ArithException)
+        [ singleOutputTest "div" safeDiv (div @(WordN 8)),
+          singleOutputTest "mod" safeMod (mod @(WordN 8)),
+          doubleOutputTest "divMod" safeDivMod (divMod @(WordN 8)),
+          singleOutputTest "quot" safeQuot (quot @(WordN 8)),
+          singleOutputTest "rem" safeRem (rem @(WordN 8)),
+          doubleOutputTest "quotRem" safeQuotRem (quotRem @(WordN 8)),
+          testCase "Bitwidth mismatch" $ do
+            let actual =
+                  safeDiv (bv 10 2) (bv 11 3) ::
+                    ExceptT
+                      (Either BitwidthMismatch ArithException)
+                      UnionM
+                      SomeWordN
+            let expected = mrgThrowError $ Left BitwidthMismatch
+            actual @?= expected
+          ],
+      testGroup "SomeIntN" $ do
+        let singleOutputTest =
+              opBoundedTestBase
+                SomeIntN
+                SomeIntN
+                (\e -> Right e :: Either BitwidthMismatch ArithException)
+        let doubleOutputTest =
+              opBoundedTestBase
+                SomeIntN
+                (bimap SomeIntN SomeIntN)
+                (\e -> Right e :: Either BitwidthMismatch ArithException)
+        [ singleOutputTest "div" safeDiv (div @(IntN 8)),
+          singleOutputTest "mod" safeMod (mod @(IntN 8)),
+          doubleOutputTest "divMod" safeDivMod (divMod @(IntN 8)),
+          singleOutputTest "quot" safeQuot (quot @(IntN 8)),
+          singleOutputTest "rem" safeRem (rem @(IntN 8)),
+          doubleOutputTest "quotRem" safeQuotRem (quotRem @(IntN 8)),
+          testCase "Bitwidth mismatch" $ do
+            let actual =
+                  safeDiv (bv 10 2) (bv 11 3) ::
+                    ExceptT
+                      (Either BitwidthMismatch ArithException)
+                      UnionM
+                      SomeIntN
+            let expected = mrgThrowError $ Left BitwidthMismatch
+            actual @?= expected
+          ]
     ]


### PR DESCRIPTION
The results are correctly merged now.

Also, fixed the exception for `mod`/`rem` for signed bounded types. They should not throw errors when doing `minBound mod -1`.