### PR TITLE
Unify the SomeBV implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added all the functions available for the exception transformer in `transformers` and `mtl` packages. ([#171](https://github.com/lsrcz/grisette/pull/171))
 
 ### Fixed
+
 - Fixed the merging for safe division. ([#173](https://github.com/lsrcz/grisette/pull/173))
 - Fixed the behavior for safe `mod` and `rem` for signed, bounded concrete types. ([#173](https://github.com/lsrcz/grisette/pull/173))
 
@@ -23,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used with non-union programs. ([#170](https://github.com/lsrcz/grisette/pull/170))
 - [Breaking] Refined the safe operations interface using `TryMerge`. ([#172](https://github.com/lsrcz/grisette/pull/172))
 - [Breaking] Renamed `safeMinus` to `safeSub` to be more consistent. ([#172](https://github.com/lsrcz/grisette/pull/172))
+- [Breaking] Unifies the implementation for all symbolic non-indexed
+  bit-vectors. The legacy types are now type and pattern synonyms. ([#174])(https://github.com/lsrcz/grisette/pull/174)
 
 ## [0.4.1.0] -- 2024-01-10
 

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -90,6 +90,7 @@ library
       Grisette.Core.Data.Class.TryMerge
       Grisette.Core.Data.FileLocation
       Grisette.Core.Data.MemoUtils
+      Grisette.Core.Data.SomeBV
       Grisette.Core.Data.Union
       Grisette.Core.TH
       Grisette.Core.THCompat
@@ -244,6 +245,7 @@ test-suite spec
       Grisette.Core.Data.Class.ToConTests
       Grisette.Core.Data.Class.ToSymTests
       Grisette.Core.Data.Class.TryMergeTests
+      Grisette.Core.Data.SomeBVTests
       Grisette.IR.SymPrim.Data.Prim.BitsTests
       Grisette.IR.SymPrim.Data.Prim.BoolTests
       Grisette.IR.SymPrim.Data.Prim.BVTests

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -213,6 +214,12 @@ class SizedBV bv where
     -- | Bit vector to select from
     bv n ->
     bv w
+
+  -- Analogous to 'fromIntegral'.
+  sizedBVFromIntegral :: (Integral a, KnownNat n, 1 <= n) => a -> bv n
+  default sizedBVFromIntegral ::
+    (Num (bv n), Integral a, KnownNat n, 1 <= n) => a -> bv n
+  sizedBVFromIntegral = fromIntegral
 
 -- | Slicing out a smaller bit vector from a larger one, extract a slice from
 -- bit @i@ down to @j@.

--- a/src/Grisette/Core/Data/Class/EvaluateSym.hs
+++ b/src/Grisette/Core/Data/Class/EvaluateSym.hs
@@ -51,14 +51,12 @@ import Generics.Deriving
   )
 import Generics.Deriving.Instances ()
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term (LinkedRep, SupportedPrim)
 import Grisette.IR.SymPrim.Data.Prim.Model (Model, evaluateTerm)
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
@@ -125,8 +123,6 @@ CONCRETE_EVALUATESYM(Word8)
 CONCRETE_EVALUATESYM(Word16)
 CONCRETE_EVALUATESYM(Word32)
 CONCRETE_EVALUATESYM(Word64)
-CONCRETE_EVALUATESYM(SomeIntN)
-CONCRETE_EVALUATESYM(SomeWordN)
 CONCRETE_EVALUATESYM(B.ByteString)
 CONCRETE_EVALUATESYM(T.Text)
 CONCRETE_EVALUATESYM_BV(IntN)
@@ -243,10 +239,6 @@ instance (KnownNat n, 1 <= n) => EvaluateSym (symtype n) where \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => EvaluateSym (sa op sb) where \
   evaluateSym fillDefault model (cons t) = cons $ evaluateTerm fillDefault model t
 
-#define EVALUATE_SYM_BV_SOME(somety, origty) \
-instance EvaluateSym somety where \
-  evaluateSym fillDefault model (somety (origty t)) = somety $ origty $ evaluateTerm fillDefault model t
-
 #if 1
 EVALUATE_SYM_SIMPLE(SymBool)
 EVALUATE_SYM_SIMPLE(SymInteger)
@@ -254,8 +246,6 @@ EVALUATE_SYM_BV(SymIntN)
 EVALUATE_SYM_BV(SymWordN)
 EVALUATE_SYM_FUN(=~>, SymTabularFun)
 EVALUATE_SYM_FUN(-~>, SymGeneralFun)
-EVALUATE_SYM_BV_SOME(SomeSymIntN, SymIntN)
-EVALUATE_SYM_BV_SOME(SomeSymWordN, SymWordN)
 #endif
 
 -- Exception

--- a/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
+++ b/src/Grisette/Core/Data/Class/ExtractSymbolics.hs
@@ -48,7 +48,7 @@ import Generics.Deriving
     type (:+:) (L1, R1),
   )
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( LinkedRep,
     SupportedPrim,
@@ -58,9 +58,7 @@ import Grisette.IR.SymPrim.Data.Prim.Model
   ( SymbolSet (SymbolSet),
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
@@ -113,8 +111,6 @@ CONCRETE_EXTRACT_SYMBOLICS(Word8)
 CONCRETE_EXTRACT_SYMBOLICS(Word16)
 CONCRETE_EXTRACT_SYMBOLICS(Word32)
 CONCRETE_EXTRACT_SYMBOLICS(Word64)
-CONCRETE_EXTRACT_SYMBOLICS(SomeWordN)
-CONCRETE_EXTRACT_SYMBOLICS(SomeIntN)
 CONCRETE_EXTRACT_SYMBOLICS(B.ByteString)
 CONCRETE_EXTRACT_SYMBOLICS(T.Text)
 CONCRETE_EXTRACT_SYMBOLICS_BV(WordN)
@@ -274,10 +270,6 @@ instance (KnownNat n, 1 <= n) => ExtractSymbolics (symtype n) where \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ExtractSymbolics (sa op sb) where \
   extractSymbolics (cons t) = SymbolSet $ extractSymbolicsTerm t
 
-#define EXTRACT_SYMBOLICS_BV_SOME(somety, origty) \
-instance ExtractSymbolics somety where \
-  extractSymbolics (somety (origty t)) = SymbolSet $ extractSymbolicsTerm t
-
 #if 1
 EXTRACT_SYMBOLICS_SIMPLE(SymBool)
 EXTRACT_SYMBOLICS_SIMPLE(SymInteger)
@@ -285,8 +277,6 @@ EXTRACT_SYMBOLICS_BV(SymIntN)
 EXTRACT_SYMBOLICS_BV(SymWordN)
 EXTRACT_SYMBOLICS_FUN(=~>, SymTabularFun)
 EXTRACT_SYMBOLICS_FUN(-~>, SymGeneralFun)
-EXTRACT_SYMBOLICS_BV_SOME(SomeSymIntN, SymIntN)
-EXTRACT_SYMBOLICS_BV_SOME(SomeSymWordN, SymWordN)
 #endif
 
 -- Exception

--- a/src/Grisette/Core/Data/Class/GPretty.hs
+++ b/src/Grisette/Core/Data/Class/GPretty.hs
@@ -51,16 +51,14 @@ import GHC.Generics
   )
 import GHC.TypeLits (KnownNat, type (<=))
 import Generics.Deriving (Default (Default, unDefault))
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( LinkedRep,
     SupportedPrim,
     prettyPrintTerm,
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
@@ -135,8 +133,6 @@ GPRETTY_SIMPLE(Word8)
 GPRETTY_SIMPLE(Word16)
 GPRETTY_SIMPLE(Word32)
 GPRETTY_SIMPLE(Word64)
-GPRETTY_SIMPLE(SomeIntN)
-GPRETTY_SIMPLE(SomeWordN)
 #endif
 
 instance GPretty B.ByteString where
@@ -340,10 +336,6 @@ instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb)\
   => GPretty (sa op sb) where \
   gpretty (cons t) = prettyPrintTerm t
 
-#define GPRETTY_SYM_SOME_BV(symtype) \
-instance GPretty symtype where \
-  gpretty (symtype t) = gpretty t
-
 #if 1
 GPRETTY_SYM_SIMPLE(SymBool)
 GPRETTY_SYM_SIMPLE(SymInteger)
@@ -351,8 +343,6 @@ GPRETTY_SYM_BV(SymIntN)
 GPRETTY_SYM_BV(SymWordN)
 GPRETTY_SYM_FUN(=~>, SymTabularFun)
 GPRETTY_SYM_FUN(-~>, SymGeneralFun)
-GPRETTY_SYM_SOME_BV(SomeSymIntN)
-GPRETTY_SYM_SOME_BV(SomeSymWordN)
 #endif
 
 instance (Generic a, GPretty' (Rep a)) => GPretty (Default a) where

--- a/src/Grisette/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Core/Data/Class/ITEOp.hs
@@ -24,14 +24,10 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   )
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool (pevalITETerm)
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN,
-    SomeSymWordN,
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
-    binSomeSymIntNR1,
-    binSomeSymWordNR1,
     type (-~>) (SymGeneralFun),
     type (=~>) (SymTabularFun),
   )
@@ -66,11 +62,6 @@ instance (KnownNat n, 1 <= n) => ITEOp (type n) where \
   symIte (SymBool c) (type t) (type f) = type $ pevalITETerm c t f; \
   {-# INLINE symIte #-}
 
-#define ITEOP_BV_SOME(symtype, bf) \
-instance ITEOp symtype where \
-  symIte c = bf (symIte c) "symIte"; \
-  {-# INLINE symIte #-}
-
 #define ITEOP_FUN(op, cons) \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ITEOp (sa op sb) where \
   symIte (SymBool c) (cons t) (cons f) = cons $ pevalITETerm c t f; \
@@ -81,8 +72,6 @@ ITEOP_SIMPLE(SymBool)
 ITEOP_SIMPLE(SymInteger)
 ITEOP_BV(SymIntN)
 ITEOP_BV(SymWordN)
-ITEOP_BV_SOME(SomeSymIntN, binSomeSymIntNR1)
-ITEOP_BV_SOME(SomeSymWordN, binSomeSymWordNR1)
 ITEOP_FUN(=~>, SymTabularFun)
 ITEOP_FUN(-~>, SymGeneralFun)
 #endif

--- a/src/Grisette/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Core/Data/Class/Mergeable.hs
@@ -89,14 +89,12 @@ import Data.Kind (Type)
 import qualified Data.Monoid as Monoid
 import qualified Data.Text as T
 import Data.Typeable
-  ( Proxy (Proxy),
-    Typeable,
+  ( Typeable,
     eqT,
     type (:~:) (Refl),
   )
 import Data.Word (Word16, Word32, Word64, Word8)
-import GHC.Natural (Natural)
-import GHC.TypeNats (KnownNat, natVal, type (<=))
+import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
   ( Default (Default),
     Default1 (Default1),
@@ -114,10 +112,8 @@ import Generics.Deriving
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
 import Grisette.Core.Data.BV
   ( BitwidthMismatch,
-    IntN (IntN),
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
-    WordN (WordN),
+    IntN,
+    WordN,
   )
 import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
@@ -125,16 +121,13 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
     SupportedPrim,
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool,
+  ( SymBool,
     SymIntN,
     SymInteger,
     SymWordN,
     type (-~>),
     type (=~>),
   )
-import Grisette.Utils.Parameterized (unsafeAxiom)
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Helper type for combining arbitrary number of indices into one.
@@ -416,26 +409,6 @@ CONCRETE_ORD_MERGEABLE(T.Text)
 CONCRETE_ORD_MERGEABLE_BV(WordN)
 CONCRETE_ORD_MERGEABLE_BV(IntN)
 #endif
-
-instance Mergeable SomeIntN where
-  rootStrategy =
-    SortedStrategy @Natural
-      (\(SomeIntN (_ :: IntN n)) -> natVal (Proxy @n))
-      ( \_ ->
-          SortedStrategy @Integer
-            (\(SomeIntN (IntN i)) -> i)
-            (const $ SimpleStrategy $ \_ l _ -> l)
-      )
-
-instance Mergeable SomeWordN where
-  rootStrategy =
-    SortedStrategy @Natural
-      (\(SomeWordN (_ :: WordN n)) -> natVal (Proxy @n))
-      ( \_ ->
-          SortedStrategy @Integer
-            (\(SomeWordN (WordN i)) -> i)
-            (const $ SimpleStrategy $ \_ l _ -> l)
-      )
 
 -- ()
 deriving via (Default ()) instance Mergeable ()
@@ -943,30 +916,6 @@ MERGEABLE_BV(SymWordN)
 MERGEABLE_FUN(=~>)
 MERGEABLE_FUN(-~>)
 #endif
-
-instance Mergeable SomeSymIntN where
-  rootStrategy =
-    SortedStrategy @Natural
-      (\(SomeSymIntN (_ :: SymIntN n)) -> natVal (Proxy @n))
-      ( \_ ->
-          SimpleStrategy
-            ( \c (SomeSymIntN (l :: SymIntN l)) (SomeSymIntN (r :: SymIntN r)) ->
-                case unsafeAxiom @l @r of
-                  Refl -> SomeSymIntN $ symIte c l r
-            )
-      )
-
-instance Mergeable SomeSymWordN where
-  rootStrategy =
-    SortedStrategy @Natural
-      (\(SomeSymWordN (_ :: SymWordN n)) -> natVal (Proxy @n))
-      ( \_ ->
-          SimpleStrategy
-            ( \c (SomeSymWordN (l :: SymWordN l)) (SomeSymWordN (r :: SymWordN r)) ->
-                case unsafeAxiom @l @r of
-                  Refl -> SomeSymWordN $ symIte c l r
-            )
-      )
 
 -- Exceptions
 instance Mergeable ArithException where

--- a/src/Grisette/Core/Data/Class/SEq.hs
+++ b/src/Grisette/Core/Data/Class/SEq.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -39,9 +38,7 @@ import qualified Data.ByteString as B
 import Data.Functor.Sum (Sum)
 import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.Text as T
-import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
 import Data.Word (Word16, Word32, Word64, Word8)
-import GHC.TypeLits (sameNat)
 import GHC.TypeNats (KnownNat, type (<=))
 import Generics.Deriving
   ( Default (Default),
@@ -54,14 +51,12 @@ import Generics.Deriving
     type (:+:) (L1, R1),
   )
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&)))
 import Grisette.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.IR.SymPrim.Data.Prim.PartialEval.Bool (pevalEqvTerm)
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
@@ -138,8 +133,6 @@ CONCRETE_SEQ(B.ByteString)
 CONCRETE_SEQ(T.Text)
 CONCRETE_SEQ_BV(WordN)
 CONCRETE_SEQ_BV(IntN)
-CONCRETE_SEQ(SomeWordN)
-CONCRETE_SEQ(SomeIntN)
 #endif
 
 -- List
@@ -241,26 +234,11 @@ instance SEq symtype where \
 instance (KnownNat n, 1 <= n) => SEq (symtype n) where \
   (symtype l) .== (symtype r) = SymBool $ pevalEqvTerm l r
 
-#define SEQ_BV_SOME(somety, origty) \
-instance SEq somety where \
-  somety (l :: origty l) .== somety (r :: origty r) = \
-    (case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> l .== r; \
-      Nothing -> con False); \
-  {-# INLINE (.==) #-}; \
-  somety (l :: origty l) ./= somety (r :: origty r) = \
-    (case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> l ./= r; \
-      Nothing -> con True); \
-  {-# INLINE (./=) #-}
-
 #if 1
 SEQ_SIMPLE(SymBool)
 SEQ_SIMPLE(SymInteger)
 SEQ_BV(SymIntN)
 SEQ_BV(SymWordN)
-SEQ_BV_SOME(SomeSymIntN, SymIntN)
-SEQ_BV_SOME(SomeSymWordN, SymWordN)
 #endif
 
 -- Exceptions

--- a/src/Grisette/Core/Data/Class/SOrd.hs
+++ b/src/Grisette/Core/Data/Class/SOrd.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}

--- a/src/Grisette/Core/Data/Class/SOrd.hs
+++ b/src/Grisette/Core/Data/Class/SOrd.hs
@@ -53,7 +53,7 @@ import Generics.Deriving
   )
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
 import Grisette.Core.Control.Monad.UnionM (UnionM, liftToMonadUnion)
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&), (.||)))
 import Grisette.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Core.Data.Class.PlainUnion
@@ -75,14 +75,10 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.Num
     pevalLtNumTerm,
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN,
-    SomeSymWordN,
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
-    binSomeSymIntN,
-    binSomeSymWordN,
   )
 
 -- $setup
@@ -184,8 +180,6 @@ CONCRETE_SORD(Word8)
 CONCRETE_SORD(Word16)
 CONCRETE_SORD(Word32)
 CONCRETE_SORD(Word64)
-CONCRETE_SORD(SomeWordN)
-CONCRETE_SORD(SomeIntN)
 CONCRETE_SORD(B.ByteString)
 CONCRETE_SORD(T.Text)
 CONCRETE_SORD_BV(WordN)
@@ -336,19 +330,6 @@ instance (KnownNat n, 1 <= n) => SOrd (symtype n) where \
     (mrgPure LT) \
     (mrgIf (a .== b) (mrgPure EQ) (mrgPure GT))
 
-#define SORD_BV_SOME(somety, bf) \
-instance SOrd somety where \
-  (.<=) = bf (.<=) ".<="; \
-  {-# INLINE (.<=) #-}; \
-  (.<) = bf (.<) ".<"; \
-  {-# INLINE (.<) #-}; \
-  (.>=) = bf (.>=) ".>="; \
-  {-# INLINE (.>=) #-}; \
-  (.>) = bf (.>) ".>"; \
-  {-# INLINE (.>) #-}; \
-  symCompare = bf symCompare "symCompare"; \
-  {-# INLINE symCompare #-}
-
 instance SOrd SymBool where
   l .<= r = symNot l .|| r
   l .< r = symNot l .&& r
@@ -364,8 +345,6 @@ instance SOrd SymBool where
 SORD_SIMPLE(SymInteger)
 SORD_BV(SymIntN)
 SORD_BV(SymWordN)
-SORD_BV_SOME(SomeSymIntN, binSomeSymIntN)
-SORD_BV_SOME(SomeSymWordN, binSomeSymWordN)
 #endif
 
 -- Exception

--- a/src/Grisette/Core/Data/Class/SafeDivision.hs
+++ b/src/Grisette/Core/Data/Class/SafeDivision.hs
@@ -29,15 +29,11 @@ where
 import Control.Exception (ArithException (DivideByZero, Overflow, Underflow))
 import Control.Monad.Except (MonadError (throwError))
 import Data.Int (Int16, Int32, Int64, Int8)
-import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
 import Data.Word (Word16, Word32, Word64, Word8)
-import GHC.TypeNats (KnownNat, sameNat, type (<=))
+import GHC.TypeNats (KnownNat, type (<=))
 import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.BV
-  ( BitwidthMismatch (BitwidthMismatch),
-    IntN,
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
+  ( IntN,
     WordN,
   )
 import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.&&)))
@@ -226,46 +222,6 @@ instance
   safeQuot = concreteSafeDivisionHelper quot
   safeRem = concreteSafeDivisionHelper rem
   safeQuotRem = concreteSafeDivisionHelper quotRem
-#endif
-
-#define SAFE_DIVISION_CONCRETE_FUNC_SOME(stype, type, name, op) \
-  name (stype (l :: type l)) (stype (r :: type r)) = \
-    (case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> \
-        (case name l r of \
-          Left err -> mrgThrowError $ Right err; \
-          Right value -> mrgReturn $ stype value); \
-      Nothing -> mrgThrowError $ Left BitwidthMismatch); \
-  
-#define SAFE_DIVISION_CONCRETE_FUNC_SOME_DIVMOD(stype, type, name, op) \
-  name (stype (l :: type l)) (stype (r :: type r)) = \
-    (case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> \
-        (case name l r of \
-          Left err -> mrgThrowError $ Right err; \
-          Right (value1, value2) -> mrgReturn (stype value1, stype value2)); \
-      Nothing -> mrgThrowError $ Left BitwidthMismatch); \
-
-#if 1
-instance
-  (MonadError (Either BitwidthMismatch ArithException) m, TryMerge m) =>
-  SafeDivision (Either BitwidthMismatch ArithException) SomeIntN m where
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeIntN, IntN, safeDiv, div)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeIntN, IntN, safeMod, mod)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME_DIVMOD(SomeIntN, IntN, safeDivMod, divMod)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeIntN, IntN, safeQuot, quot)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeIntN, IntN, safeRem, rem)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME_DIVMOD(SomeIntN, IntN, safeQuotRem, quotRem)
-
-instance
-  (MonadError (Either BitwidthMismatch ArithException) m, TryMerge m) =>
-  SafeDivision (Either BitwidthMismatch ArithException) SomeWordN m where
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeWordN, WordN, safeDiv, div)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeWordN, WordN, safeMod, mod)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME_DIVMOD(SomeWordN, WordN, safeDivMod, divMod)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeWordN, WordN, safeQuot, quot)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME(SomeWordN, WordN, safeRem, rem)
-  SAFE_DIVISION_CONCRETE_FUNC_SOME_DIVMOD(SomeWordN, WordN, safeQuotRem, quotRem)
 #endif
 
 #define SAFE_DIVISION_SYMBOLIC_FUNC(name, type, op) \

--- a/src/Grisette/Core/Data/Class/SafeDivision.hs
+++ b/src/Grisette/Core/Data/Class/SafeDivision.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 

--- a/src/Grisette/Core/Data/Class/SafeLinearArith.hs
+++ b/src/Grisette/Core/Data/Class/SafeLinearArith.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Trustworthy #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -28,15 +27,11 @@ where
 import Control.Exception (ArithException (DivideByZero, Overflow, Underflow))
 import Control.Monad.Except (MonadError (throwError))
 import Data.Int (Int16, Int32, Int64, Int8)
-import Data.Typeable (Proxy (Proxy), type (:~:) (Refl))
 import Data.Word (Word16, Word32, Word64, Word8)
-import GHC.TypeNats (KnownNat, sameNat, type (<=))
+import GHC.TypeNats (KnownNat, type (<=))
 import Grisette.Core.Control.Monad.Union (MonadUnion)
 import Grisette.Core.Data.BV
-  ( BitwidthMismatch (BitwidthMismatch),
-    IntN,
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
+  ( IntN,
     WordN,
   )
 import Grisette.Core.Data.Class.LogicalOp
@@ -52,7 +47,6 @@ import Grisette.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Core.Data.Class.TryMerge
   ( TryMerge,
     mrgPure,
-    tryMerge,
   )
 import Grisette.IR.SymPrim.Data.SymPrim
   ( SymIntN,
@@ -60,7 +54,7 @@ import Grisette.IR.SymPrim.Data.SymPrim
     SymWordN,
   )
 import Grisette.Lib.Control.Monad (mrgReturn)
-import Grisette.Lib.Control.Monad.Except (mrgModifyError, mrgThrowError)
+import Grisette.Lib.Control.Monad.Except (mrgThrowError)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -160,21 +154,6 @@ instance \
   where \
   SAFE_LINARITH_UNSIGNED_CONCRETE_BODY
 
-#define SAFE_LINARITH_SOME_CONCRETE(type, ctype) \
-instance \
-  (MonadError (Either BitwidthMismatch ArithException) m, TryMerge m) => \
-  SafeLinearArith (Either BitwidthMismatch ArithException) type m \
-  where \
-  safeAdd (type (l :: ctype l)) (type (r :: ctype r)) = tryMerge (\
-    case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> mrgModifyError Right $ type <$> safeAdd l r; \
-      _ -> mrgThrowError $ Left BitwidthMismatch); \
-  safeSub (type (l :: ctype l)) (type (r :: ctype r)) = tryMerge (\
-    case sameNat (Proxy @l) (Proxy @r) of \
-      Just Refl -> mrgModifyError Right $ type <$> safeSub l r; \
-      _ -> mrgThrowError $ Left BitwidthMismatch); \
-  safeNeg (type l) = mrgModifyError Right $ type <$> safeNeg l
-
 #if 1
 SAFE_LINARITH_SIGNED_CONCRETE(Int8)
 SAFE_LINARITH_SIGNED_CONCRETE(Int16)
@@ -182,14 +161,12 @@ SAFE_LINARITH_SIGNED_CONCRETE(Int32)
 SAFE_LINARITH_SIGNED_CONCRETE(Int64)
 SAFE_LINARITH_SIGNED_CONCRETE(Int)
 SAFE_LINARITH_SIGNED_BV_CONCRETE(IntN)
-SAFE_LINARITH_SOME_CONCRETE(SomeIntN, IntN)
 SAFE_LINARITH_UNSIGNED_CONCRETE(Word8)
 SAFE_LINARITH_UNSIGNED_CONCRETE(Word16)
 SAFE_LINARITH_UNSIGNED_CONCRETE(Word32)
 SAFE_LINARITH_UNSIGNED_CONCRETE(Word64)
 SAFE_LINARITH_UNSIGNED_CONCRETE(Word)
 SAFE_LINARITH_UNSIGNED_BV_CONCRETE(WordN)
-SAFE_LINARITH_SOME_CONCRETE(SomeWordN, WordN)
 #endif
 
 instance

--- a/src/Grisette/Core/Data/Class/SubstituteSym.hs
+++ b/src/Grisette/Core/Data/Class/SubstituteSym.hs
@@ -49,7 +49,7 @@ import Generics.Deriving
     type (:+:) (L1, R1),
   )
 import Generics.Deriving.Instances ()
-import Grisette.Core.Data.BV (IntN, SomeIntN, SomeWordN, WordN)
+import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( LinkedRep (underlyingTerm),
     SupportedPrim,
@@ -57,9 +57,7 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.TermSubstitution (substTerm)
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool (SymBool),
+  ( SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),
     SymWordN (SymWordN),
@@ -111,8 +109,6 @@ CONCRETE_SUBSTITUTESYM(Word8)
 CONCRETE_SUBSTITUTESYM(Word16)
 CONCRETE_SUBSTITUTESYM(Word32)
 CONCRETE_SUBSTITUTESYM(Word64)
-CONCRETE_SUBSTITUTESYM(SomeWordN)
-CONCRETE_SUBSTITUTESYM(SomeIntN)
 CONCRETE_SUBSTITUTESYM(B.ByteString)
 CONCRETE_SUBSTITUTESYM(T.Text)
 CONCRETE_SUBSTITUTESYM_BV(WordN)
@@ -273,10 +269,6 @@ instance (KnownNat n, 1 <= n) => SubstituteSym (symtype n) where \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => SubstituteSym (sa op sb) where \
   substituteSym sym v (cons t) = cons $ substTerm sym (underlyingTerm v) t
 
-#define SUBSTITUTE_SYM_BV_SOME(somety, origty) \
-instance SubstituteSym somety where \
-  substituteSym sym v (somety (origty t)) = somety $ origty $ substTerm sym (underlyingTerm v) t
-
 #if 1
 SUBSTITUTE_SYM_SIMPLE(SymBool)
 SUBSTITUTE_SYM_SIMPLE(SymInteger)
@@ -284,8 +276,6 @@ SUBSTITUTE_SYM_BV(SymIntN)
 SUBSTITUTE_SYM_BV(SymWordN)
 SUBSTITUTE_SYM_FUN(=~>, SymTabularFun)
 SUBSTITUTE_SYM_FUN(-~>, SymGeneralFun)
-SUBSTITUTE_SYM_BV_SOME(SomeSymIntN, SymIntN)
-SUBSTITUTE_SYM_BV_SOME(SomeSymWordN, SymWordN)
 #endif
 
 -- | Auxiliary class for 'SubstituteSym' instance derivation

--- a/src/Grisette/Core/Data/Class/ToCon.hs
+++ b/src/Grisette/Core/Data/Class/ToCon.hs
@@ -54,8 +54,6 @@ import Generics.Deriving.Instances ()
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
 import Grisette.Core.Data.BV
   ( IntN (IntN),
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     WordN (WordN),
   )
 import Grisette.Core.Data.Class.Solvable (Solvable (conView), pattern Con)
@@ -66,9 +64,7 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
     type (-->),
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool,
+  ( SymBool,
     SymIntN,
     SymInteger,
     SymWordN,
@@ -123,8 +119,6 @@ CONCRETE_TOCON(Word8)
 CONCRETE_TOCON(Word16)
 CONCRETE_TOCON(Word32)
 CONCRETE_TOCON(Word64)
-CONCRETE_TOCON(SomeWordN)
-CONCRETE_TOCON(SomeIntN)
 CONCRETE_TOCON(B.ByteString)
 CONCRETE_TOCON(T.Text)
 CONCRETE_TOCON_BV(WordN)
@@ -256,8 +250,6 @@ TO_CON_SYMID_BV(SymIntN)
 TO_CON_SYMID_BV(SymWordN)
 TO_CON_SYMID_FUN(=~>)
 TO_CON_SYMID_FUN(-~>)
-TO_CON_SYMID_SIMPLE(SomeSymIntN)
-TO_CON_SYMID_SIMPLE(SomeSymWordN)
 
 #endif
 
@@ -273,10 +265,6 @@ instance (KnownNat n, 1 <= n) => ToCon (symtype n) (contype n) where \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ToCon (symop sa sb) (conop ca cb) where \
   toCon = conView
 
-#define TO_CON_FROMSYM_BV_SOME(contype, symtype) \
-instance ToCon symtype contype where \
-  toCon (symtype v) = contype <$> conView v
-
 #if 1
 TO_CON_FROMSYM_SIMPLE(Bool, SymBool)
 TO_CON_FROMSYM_SIMPLE(Integer, SymInteger)
@@ -284,8 +272,6 @@ TO_CON_FROMSYM_BV(IntN, SymIntN)
 TO_CON_FROMSYM_BV(WordN, SymWordN)
 TO_CON_FROMSYM_FUN((=->), (=~>))
 TO_CON_FROMSYM_FUN((-->), (-~>))
-TO_CON_FROMSYM_BV_SOME(SomeIntN, SomeSymIntN)
-TO_CON_FROMSYM_BV_SOME(SomeWordN, SomeSymWordN)
 #endif
 
 #define TOCON_MACHINE_INTEGER(sbvw, bvw, n, int) \

--- a/src/Grisette/Core/Data/Class/ToSym.hs
+++ b/src/Grisette/Core/Data/Class/ToSym.hs
@@ -54,8 +54,6 @@ import Generics.Deriving
 import Grisette.Core.Control.Exception (AssertionError, VerificationConditions)
 import Grisette.Core.Data.BV
   ( IntN,
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     WordN,
   )
 import Grisette.Core.Data.Class.Solvable (Solvable (con))
@@ -66,9 +64,7 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
     type (-->),
   )
 import Grisette.IR.SymPrim.Data.SymPrim
-  ( SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
-    SymBool,
+  ( SymBool,
     SymIntN,
     SymInteger,
     SymWordN,
@@ -113,8 +109,6 @@ CONCRETE_TOSYM(Word8)
 CONCRETE_TOSYM(Word16)
 CONCRETE_TOSYM(Word32)
 CONCRETE_TOSYM(Word64)
-CONCRETE_TOSYM(SomeIntN)
-CONCRETE_TOSYM(SomeWordN)
 CONCRETE_TOSYM(B.ByteString)
 CONCRETE_TOSYM(T.Text)
 CONCRETE_TOSYM_BV(IntN)
@@ -243,8 +237,6 @@ TO_SYM_SYMID_BV(SymIntN)
 TO_SYM_SYMID_BV(SymWordN)
 TO_SYM_SYMID_FUN(=~>)
 TO_SYM_SYMID_FUN(-~>)
-TO_SYM_SYMID_SIMPLE(SomeSymIntN)
-TO_SYM_SYMID_SIMPLE(SomeSymWordN)
 #endif
 
 #define TO_SYM_FROMCON_SIMPLE(contype, symtype) \
@@ -259,10 +251,6 @@ instance (KnownNat n, 1 <= n) => ToSym (contype n) (symtype n) where \
 instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => ToSym (conop ca cb) (symop sa sb) where \
   toSym = con
 
-#define TO_SYM_FROMCON_BV_SOME(contype, symtype) \
-instance ToSym contype symtype where \
-  toSym (contype v) = symtype (con v)
-
 #if 1
 TO_SYM_FROMCON_SIMPLE(Bool, SymBool)
 TO_SYM_FROMCON_SIMPLE(Integer, SymInteger)
@@ -270,26 +258,11 @@ TO_SYM_FROMCON_BV(IntN, SymIntN)
 TO_SYM_FROMCON_BV(WordN, SymWordN)
 TO_SYM_FROMCON_FUN((=->), (=~>))
 TO_SYM_FROMCON_FUN((-->), (-~>))
-TO_SYM_FROMCON_BV_SOME(SomeIntN, SomeSymIntN)
-TO_SYM_FROMCON_BV_SOME(SomeWordN, SomeSymWordN)
-#endif
-
-#define TO_SYM_FROMBV_SOME(somesymbv, bv) \
-instance (KnownNat n, 1 <= n) => ToSym (bv n) somesymbv where \
-  toSym = somesymbv . con
-
-#if 1
-TO_SYM_FROMBV_SOME(SomeSymIntN, IntN)
-TO_SYM_FROMBV_SOME(SomeSymWordN, WordN)
 #endif
 
 #define TOSYM_MACHINE_INTEGER(int, bv) \
 instance ToSym int (bv) where \
   toSym = fromIntegral
-
-#define TOSYM_MACHINE_INTEGER_SOME(int, somesymbv, bv, bitwidth) \
-instance ToSym int somesymbv where \
-  toSym v = somesymbv (con (fromIntegral v :: bv bitwidth))
 
 #if 1
 TOSYM_MACHINE_INTEGER(Int8, SymIntN 8)
@@ -302,17 +275,6 @@ TOSYM_MACHINE_INTEGER(Word32, SymWordN 32)
 TOSYM_MACHINE_INTEGER(Word64, SymWordN 64)
 TOSYM_MACHINE_INTEGER(Int, SymIntN $intBitwidthQ)
 TOSYM_MACHINE_INTEGER(Word, SymWordN $intBitwidthQ)
-
-TOSYM_MACHINE_INTEGER_SOME(Int8, SomeSymIntN, IntN, 8)
-TOSYM_MACHINE_INTEGER_SOME(Int16, SomeSymIntN, IntN, 16)
-TOSYM_MACHINE_INTEGER_SOME(Int32, SomeSymIntN, IntN, 32)
-TOSYM_MACHINE_INTEGER_SOME(Int64, SomeSymIntN, IntN, 64)
-TOSYM_MACHINE_INTEGER_SOME(Word8, SomeSymWordN, WordN, 8)
-TOSYM_MACHINE_INTEGER_SOME(Word16, SomeSymWordN, WordN, 16)
-TOSYM_MACHINE_INTEGER_SOME(Word32, SomeSymWordN, WordN, 32)
-TOSYM_MACHINE_INTEGER_SOME(Word64, SomeSymWordN, WordN, 64)
-TOSYM_MACHINE_INTEGER_SOME(Int, SomeSymIntN, IntN, $intBitwidthQ)
-TOSYM_MACHINE_INTEGER_SOME(Word, SomeSymWordN, WordN, $intBitwidthQ)
 #endif
 
 -- Exception

--- a/src/Grisette/Core/Data/SomeBV.hs
+++ b/src/Grisette/Core/Data/SomeBV.hs
@@ -1,0 +1,992 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- |
+-- Module      :   Grisette.Core.Data.SomeBV
+-- Copyright   :   (c) Sirui Lu 2024
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Core.Data.SomeBV
+  ( SomeBV (..),
+
+    -- * Constructing and pattern matching on SomeBV
+    unsafeSomeBV,
+    conBV,
+    conBVView,
+    pattern ConBV,
+    ssymBV,
+    isymBV,
+    sinfosymBV,
+    iinfosymBV,
+
+    -- * Synonyms
+    pattern SomeIntN,
+    type SomeIntN,
+    pattern SomeWordN,
+    type SomeWordN,
+    pattern SomeSymIntN,
+    type SomeSymIntN,
+    pattern SomeSymWordN,
+    type SomeSymWordN,
+
+    -- * Helpers for manipulating SomeBV
+    unarySomeBV,
+    unarySomeBVR1,
+    binSomeBV,
+    binSomeBVR1,
+    binSomeBVR2,
+    binSomeBVSafe,
+    binSomeBVSafeR1,
+    binSomeBVSafeR2,
+  )
+where
+
+import Control.DeepSeq (NFData (rnf))
+import Control.Exception (throw)
+import Control.Monad.Except (ExceptT, MonadError)
+import Data.Bifunctor (Bifunctor (bimap))
+import Data.Bits
+  ( Bits
+      ( bit,
+        bitSize,
+        bitSizeMaybe,
+        clearBit,
+        complement,
+        complementBit,
+        isSigned,
+        popCount,
+        rotate,
+        rotateL,
+        rotateR,
+        setBit,
+        shift,
+        shiftL,
+        shiftR,
+        testBit,
+        unsafeShiftL,
+        unsafeShiftR,
+        xor,
+        zeroBits,
+        (.&.),
+        (.|.)
+      ),
+    FiniteBits (countLeadingZeros, countTrailingZeros, finiteBitSize),
+  )
+import Data.Data (Proxy (Proxy), Typeable)
+import Data.Hashable (Hashable (hashWithSalt))
+import Data.Maybe (fromJust)
+import qualified Data.Text as T
+import Data.Type.Equality (type (:~:) (Refl))
+import GHC.TypeNats
+  ( KnownNat,
+    Nat,
+    natVal,
+    sameNat,
+    type (+),
+    type (<=),
+  )
+import Grisette.Core.Control.Monad.UnionM (UnionM)
+import Grisette.Core.Data.BV (BitwidthMismatch (BitwidthMismatch), IntN, WordN)
+import Grisette.Core.Data.Class.BitVector
+  ( BV (bv, bvConcat, bvExt, bvSelect, bvSext, bvZext),
+    SizedBV
+      ( sizedBVConcat,
+        sizedBVExt,
+        sizedBVFromIntegral,
+        sizedBVSelect,
+        sizedBVSext,
+        sizedBVZext
+      ),
+  )
+import Grisette.Core.Data.Class.EvaluateSym
+  ( EvaluateSym (evaluateSym),
+  )
+import Grisette.Core.Data.Class.ExtractSymbolics
+  ( ExtractSymbolics (extractSymbolics),
+  )
+import Grisette.Core.Data.Class.GPretty
+  ( GPretty (gpretty),
+  )
+import Grisette.Core.Data.Class.GenSym
+  ( GenSym (fresh),
+    GenSymSimple (simpleFresh),
+  )
+import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
+import Grisette.Core.Data.Class.Mergeable
+  ( Mergeable (rootStrategy),
+    MergingStrategy (SortedStrategy),
+    wrapStrategy,
+  )
+import Grisette.Core.Data.Class.SEq (SEq ((./=), (.==)))
+import Grisette.Core.Data.Class.SOrd
+  ( SOrd (symCompare, (.<), (.<=), (.>), (.>=)),
+  )
+import Grisette.Core.Data.Class.SafeDivision
+  ( SafeDivision (safeDiv, safeDivMod, safeMod, safeQuot, safeQuotRem, safeRem),
+  )
+import Grisette.Core.Data.Class.SafeLinearArith
+  ( SafeLinearArith (safeAdd, safeNeg, safeSub),
+  )
+import Grisette.Core.Data.Class.SafeSymRotate
+  ( SafeSymRotate (safeSymRotateL, safeSymRotateR),
+  )
+import Grisette.Core.Data.Class.SafeSymShift
+  ( SafeSymShift
+      ( safeSymShiftL,
+        safeSymShiftR,
+        safeSymStrictShiftL,
+        safeSymStrictShiftR
+      ),
+  )
+import Grisette.Core.Data.Class.SignConversion
+  ( SignConversion (toSigned, toUnsigned),
+  )
+import Grisette.Core.Data.Class.Solvable
+  ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
+  )
+import Grisette.Core.Data.Class.SubstituteSym
+  ( SubstituteSym (substituteSym),
+  )
+import Grisette.Core.Data.Class.SymRotate (SymRotate (symRotate))
+import Grisette.Core.Data.Class.SymShift (SymShift (symShift))
+import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
+import Grisette.Core.Data.Class.ToSym (ToSym (toSym))
+import Grisette.Core.Data.Class.TryMerge (TryMerge)
+import Grisette.IR.SymPrim.Data.SymPrim
+  ( AllSyms (allSyms, allSymsS),
+    SymIntN,
+    SymWordN,
+  )
+import Grisette.Lib.Control.Monad.Except (mrgModifyError, mrgThrowError)
+import Grisette.Lib.Data.Functor (mrgFmap)
+import Grisette.Utils.Parameterized
+  ( KnownProof (KnownProof),
+    LeqProof (LeqProof),
+    NatRepr,
+    Some (Some),
+    knownAdd,
+    leqAddPos,
+    mkNatRepr,
+    unsafeKnownProof,
+    unsafeLeqProof,
+    withKnownNat,
+  )
+import Language.Haskell.TH.Syntax (Lift (liftTyped))
+import Numeric.Natural (Natural)
+import Unsafe.Coerce (unsafeCoerce)
+
+-- $setup
+-- >>> import Grisette.Core
+-- >>> import Grisette.IR.SymPrim
+-- >>> :set -XDataKinds
+-- >>> :set -XBinaryLiterals
+-- >>> :set -XFlexibleContexts
+-- >>> :set -XFlexibleInstances
+-- >>> :set -XFunctionalDependencies
+
+-- | Non-indexed bitvectors.
+data SomeBV bv where
+  SomeBV :: (KnownNat n, 1 <= n) => bv n -> SomeBV bv
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Hashable (bv n)) =>
+  Hashable (SomeBV bv)
+  where
+  hashWithSalt s (SomeBV (bv :: bv n)) =
+    s `hashWithSalt` (natVal (Proxy @n)) `hashWithSalt` bv
+  {-# INLINE hashWithSalt #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Lift (bv n)) =>
+  Lift (SomeBV bv)
+  where
+  liftTyped (SomeBV bv) = [||SomeBV bv||]
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Show (bv n)) =>
+  Show (SomeBV bv)
+  where
+  show (SomeBV bv) = show bv
+  {-# INLINE show #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => NFData (bv n)) =>
+  NFData (SomeBV bv)
+  where
+  rnf (SomeBV bv) = rnf bv
+  {-# INLINE rnf #-}
+
+instance (forall n. (KnownNat n, 1 <= n) => Eq (bv n)) => Eq (SomeBV bv) where
+  (==) = binSomeBV (==)
+  {-# INLINE (==) #-}
+  (/=) = binSomeBV (/=)
+  {-# INLINE (/=) #-}
+
+instance (forall n. (KnownNat n, 1 <= n) => Ord (bv n)) => Ord (SomeBV bv) where
+  (<) = binSomeBV (<)
+  {-# INLINE (<) #-}
+  (<=) = binSomeBV (<=)
+  {-# INLINE (<=) #-}
+  (>) = binSomeBV (>)
+  {-# INLINE (>) #-}
+  (>=) = binSomeBV (>=)
+  {-# INLINE (>=) #-}
+  max = binSomeBVR1 max
+  {-# INLINE max #-}
+  min = binSomeBVR1 min
+  {-# INLINE min #-}
+  compare = binSomeBV compare
+  {-# INLINE compare #-}
+
+instance (forall n. (KnownNat n, 1 <= n) => Num (bv n)) => Num (SomeBV bv) where
+  (+) = binSomeBVR1 (+)
+  {-# INLINE (+) #-}
+  (-) = binSomeBVR1 (-)
+  {-# INLINE (-) #-}
+  (*) = binSomeBVR1 (*)
+  {-# INLINE (*) #-}
+  negate = unarySomeBVR1 negate
+  {-# INLINE negate #-}
+  abs = unarySomeBVR1 abs
+  {-# INLINE abs #-}
+  signum = unarySomeBVR1 signum
+  {-# INLINE signum #-}
+  fromInteger =
+    error $
+      "fromInteger is not defined for SomeBV as no bitwidth is known, use "
+        <> "(bv <bitwidth> <value>) instead"
+  {-# INLINE fromInteger #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Bits (bv n)) =>
+  Bits (SomeBV bv)
+  where
+  (.&.) = binSomeBVR1 (.&.)
+  (.|.) = binSomeBVR1 (.|.)
+  xor = binSomeBVR1 xor
+  complement = unarySomeBVR1 complement
+  shift s i = unarySomeBVR1 (`shift` i) s
+  rotate s i = unarySomeBVR1 (`rotate` i) s
+  zeroBits =
+    error $
+      "zeroBits is not defined for SomeBV as no bitwidth is known, use "
+        <> "(bv <bitwidth> 0) or (SomeBV (zeroBits :: bv <bitwidth>)) instead"
+  bit =
+    error $
+      "bit is not defined for SomeBV as no bitwidth is known, use "
+        <> "(SomeBV (bit <bit> :: bv <bitwidth>)) instead"
+  setBit s i = unarySomeBVR1 (`setBit` i) s
+  clearBit s i = unarySomeBVR1 (`clearBit` i) s
+  complementBit s i = unarySomeBVR1 (`complementBit` i) s
+  testBit s i = unarySomeBV (`testBit` i) s
+  bitSizeMaybe = unarySomeBV bitSizeMaybe
+  bitSize = fromJust . unarySomeBV bitSizeMaybe
+  isSigned _ = False
+  shiftL s i = unarySomeBVR1 (`shiftL` i) s
+  unsafeShiftL s i = unarySomeBVR1 (`unsafeShiftL` i) s
+  shiftR s i = unarySomeBVR1 (`shiftR` i) s
+  unsafeShiftR s i = unarySomeBVR1 (`unsafeShiftR` i) s
+  rotateL s i = unarySomeBVR1 (`rotateL` i) s
+  rotateR s i = unarySomeBVR1 (`rotateR` i) s
+  popCount = unarySomeBV popCount
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => FiniteBits (bv n)) =>
+  FiniteBits (SomeBV bv)
+  where
+  finiteBitSize = unarySomeBV finiteBitSize
+  {-# INLINE finiteBitSize #-}
+  countLeadingZeros = unarySomeBV countLeadingZeros
+  {-# INLINE countLeadingZeros #-}
+  countTrailingZeros = unarySomeBV countTrailingZeros
+  {-# INLINE countTrailingZeros #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Enum (bv n)) =>
+  Enum (SomeBV bv)
+  where
+  toEnum =
+    error $
+      "toEnum is not defined for SomeBV, use "
+        <> "(SomeBV (toEnum <value> :: bv <bitwidth>)) instead"
+  {-# INLINE toEnum #-}
+  fromEnum = unarySomeBV fromEnum
+  {-# INLINE fromEnum #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Real (bv n)) =>
+  Real (SomeBV bv)
+  where
+  toRational = unarySomeBV toRational
+  {-# INLINE toRational #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Integral (bv n)) =>
+  Integral (SomeBV bv)
+  where
+  toInteger = unarySomeBV toInteger
+  {-# INLINE toInteger #-}
+  quot = binSomeBVR1 quot
+  {-# INLINE quot #-}
+  rem = binSomeBVR1 rem
+  {-# INLINE rem #-}
+  div = binSomeBVR1 div
+  {-# INLINE div #-}
+  mod = binSomeBVR1 mod
+  {-# INLINE mod #-}
+  quotRem = binSomeBVR2 quotRem
+  {-# INLINE quotRem #-}
+  divMod = binSomeBVR2 divMod
+  {-# INLINE divMod #-}
+
+instance (SizedBV bv) => BV (SomeBV bv) where
+  bvConcat (SomeBV (a :: bv l)) (SomeBV (b :: bv r)) =
+    case ( leqAddPos (Proxy @l) (Proxy @r),
+           knownAdd @l @r KnownProof KnownProof
+         ) of
+      (LeqProof, KnownProof) ->
+        SomeBV $ sizedBVConcat a b
+  {-# INLINE bvConcat #-}
+  bvZext l (SomeBV (a :: bv n))
+    | l < n = error "bvZext: trying to zero extend a value to a smaller size"
+    | otherwise = res (Proxy @n)
+    where
+      n = fromIntegral $ natVal (Proxy @n)
+      res :: forall (l :: Nat). Proxy l -> SomeBV bv
+      res p =
+        case ( unsafeKnownProof @l (fromIntegral l),
+               unsafeLeqProof @1 @l,
+               unsafeLeqProof @n @l
+             ) of
+          (KnownProof, LeqProof, LeqProof) -> SomeBV $ sizedBVZext p a
+  {-# INLINE bvZext #-}
+  bvSext l (SomeBV (a :: bv n))
+    | l < n = error "bvSext: trying to zero extend a value to a smaller size"
+    | otherwise = res (Proxy @n)
+    where
+      n = fromIntegral $ natVal (Proxy @n)
+      res :: forall (l :: Nat). Proxy l -> SomeBV bv
+      res p =
+        case ( unsafeKnownProof @l (fromIntegral l),
+               unsafeLeqProof @1 @l,
+               unsafeLeqProof @n @l
+             ) of
+          (KnownProof, LeqProof, LeqProof) -> SomeBV $ sizedBVSext p a
+  {-# INLINE bvSext #-}
+  bvExt l (SomeBV (a :: bv n))
+    | l < n = error "bvExt: trying to zero extend a value to a smaller size"
+    | otherwise = res (Proxy @n)
+    where
+      n = fromIntegral $ natVal (Proxy @n)
+      res :: forall (l :: Nat). Proxy l -> SomeBV bv
+      res p =
+        case ( unsafeKnownProof @l (fromIntegral l),
+               unsafeLeqProof @1 @l,
+               unsafeLeqProof @n @l
+             ) of
+          (KnownProof, LeqProof, LeqProof) -> SomeBV $ sizedBVExt p a
+  {-# INLINE bvExt #-}
+  bvSelect ix w (SomeBV (a :: bv n))
+    | ix + w > n =
+        error $
+          "bvSelect: trying to select a bitvector outside the bounds of the "
+            <> "input"
+    | w == 0 = error "bvSelect: trying to select a bitvector of size 0"
+    | otherwise = res (Proxy @n) (Proxy @n)
+    where
+      n = fromIntegral $ natVal (Proxy @n)
+      res :: forall (w :: Nat) (ix :: Nat). Proxy w -> Proxy ix -> SomeBV bv
+      res _ _ =
+        case ( unsafeKnownProof @ix (fromIntegral ix),
+               unsafeKnownProof @w (fromIntegral w),
+               unsafeLeqProof @1 @w,
+               unsafeLeqProof @(ix + w) @n
+             ) of
+          (KnownProof, KnownProof, LeqProof, LeqProof) ->
+            SomeBV $ sizedBVSelect (Proxy @ix) (Proxy @w) a
+  bv n i = unsafeSomeBV n $ \_ -> sizedBVFromIntegral i
+  {-# INLINE bv #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => EvaluateSym (bv n)) =>
+  EvaluateSym (SomeBV bv)
+  where
+  evaluateSym fillDefault model = unarySomeBVR1 (evaluateSym fillDefault model)
+  {-# INLINE evaluateSym #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => ExtractSymbolics (bv n)) =>
+  ExtractSymbolics (SomeBV bv)
+  where
+  extractSymbolics = unarySomeBV extractSymbolics
+  {-# INLINE extractSymbolics #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => GPretty (bv n)) =>
+  GPretty (SomeBV bv)
+  where
+  gpretty (SomeBV bv) = gpretty bv
+  {-# INLINE gpretty #-}
+
+data CompileTimeNat where
+  CompileTimeNat :: (KnownNat n, 1 <= n) => Proxy n -> CompileTimeNat
+
+instance Show CompileTimeNat where
+  show (CompileTimeNat (Proxy :: Proxy n)) = show (natVal (Proxy @n))
+  {-# INLINE show #-}
+
+instance Eq CompileTimeNat where
+  CompileTimeNat (Proxy :: Proxy n) == CompileTimeNat (Proxy :: Proxy m) =
+    case sameNat (Proxy @n) (Proxy @m) of
+      Just Refl -> True
+      Nothing -> False
+  {-# INLINE (==) #-}
+
+instance Ord CompileTimeNat where
+  compare
+    (CompileTimeNat (Proxy :: Proxy n))
+    (CompileTimeNat (Proxy :: Proxy m)) =
+      compare (natVal (Proxy @n)) (natVal (Proxy @m))
+  {-# INLINE compare #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)) =>
+  Mergeable (SomeBV bv)
+  where
+  rootStrategy =
+    SortedStrategy @CompileTimeNat
+      (\(SomeBV (_ :: bv n)) -> CompileTimeNat (Proxy @n))
+      ( \(CompileTimeNat (_ :: proxy n)) ->
+          wrapStrategy
+            (rootStrategy @(bv n))
+            SomeBV
+            (\(SomeBV x) -> unsafeCoerce x)
+      )
+
+instance (forall n. (KnownNat n, 1 <= n) => SEq (bv n)) => SEq (SomeBV bv) where
+  (.==) = binSomeBV (.==)
+  {-# INLINE (.==) #-}
+  (./=) = binSomeBV (./=)
+  {-# INLINE (./=) #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => SOrd (bv n)) =>
+  SOrd (SomeBV bv)
+  where
+  (.<) = binSomeBV (.<)
+  {-# INLINE (.<) #-}
+  (.<=) = binSomeBV (.<=)
+  {-# INLINE (.<=) #-}
+  (.>) = binSomeBV (.>)
+  {-# INLINE (.>) #-}
+  (.>=) = binSomeBV (.>=)
+  {-# INLINE (.>=) #-}
+  symCompare = binSomeBV symCompare
+  {-# INLINE symCompare #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => SubstituteSym (bv n)) =>
+  SubstituteSym (SomeBV bv)
+  where
+  substituteSym c s = unarySomeBVR1 (substituteSym c s)
+  {-# INLINE substituteSym #-}
+
+instance
+  ( KnownNat n,
+    1 <= n,
+    forall m. (KnownNat m, 1 <= m) => GenSym () (bv m),
+    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+  ) =>
+  GenSym (Proxy n) (SomeBV bv)
+  where
+  fresh _ =
+    (\(i :: UnionM (bv n)) -> mrgFmap SomeBV i) <$> fresh ()
+  {-# INLINE fresh #-}
+
+instance
+  ( KnownNat n,
+    1 <= n,
+    forall m. (KnownNat m, 1 <= m) => GenSymSimple () (bv m),
+    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+  ) =>
+  GenSymSimple (Proxy n) (SomeBV bv)
+  where
+  simpleFresh _ = (\(i :: bv n) -> SomeBV i) <$> simpleFresh ()
+  {-# INLINE simpleFresh #-}
+
+instance
+  ( forall m. (KnownNat m, 1 <= m) => GenSym () (bv m),
+    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+  ) =>
+  GenSym (SomeBV bv) (SomeBV bv)
+  where
+  fresh (SomeBV (_ :: bv x)) = fresh (Proxy @x)
+  {-# INLINE fresh #-}
+
+instance
+  ( forall m. (KnownNat m, 1 <= m) => GenSymSimple () (bv m),
+    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+  ) =>
+  GenSymSimple (SomeBV bv) (SomeBV bv)
+  where
+  simpleFresh (SomeBV (_ :: bv x)) = simpleFresh (Proxy @x)
+  {-# INLINE simpleFresh #-}
+
+instance
+  ( forall n. (KnownNat n, 1 <= n) => GenSym () (bv n),
+    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+  ) =>
+  GenSym Natural (SomeBV bv)
+  where
+  fresh 0 = error "fresh: cannot generate a bitvector of size 0"
+  fresh n = case mkNatRepr n of
+    Some (natRepr :: NatRepr x) ->
+      case unsafeLeqProof @1 @x of
+        LeqProof -> withKnownNat natRepr $ fresh (Proxy @x)
+  {-# INLINE fresh #-}
+
+instance
+  ( forall n. (KnownNat n, 1 <= n) => GenSymSimple () (bv n),
+    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+  ) =>
+  GenSymSimple Natural (SomeBV bv)
+  where
+  simpleFresh 0 = error "fresh: cannot generate a bitvector of size 0"
+  simpleFresh n = case mkNatRepr n of
+    Some (natRepr :: NatRepr x) ->
+      case unsafeLeqProof @1 @x of
+        LeqProof -> withKnownNat natRepr $ simpleFresh (Proxy @x)
+  {-# INLINE simpleFresh #-}
+
+instance
+  ( forall n. (KnownNat n, 1 <= n) => SignConversion (ubv n) (sbv n),
+    -- Add this to help the type checker resolve the functional dependency
+    SignConversion (ubv 1) (sbv 1)
+  ) =>
+  SignConversion (SomeBV ubv) (SomeBV sbv)
+  where
+  toSigned (SomeBV (n :: ubv n)) = SomeBV (toSigned n :: sbv n)
+  {-# INLINE toSigned #-}
+  toUnsigned (SomeBV (n :: sbv n)) = SomeBV (toUnsigned n :: ubv n)
+  {-# INLINE toUnsigned #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => ToCon (sbv n) (cbv n)) =>
+  ToCon (SomeBV sbv) (SomeBV cbv)
+  where
+  toCon (SomeBV (n :: sbv n)) = SomeBV <$> (toCon n :: Maybe (cbv n))
+  {-# INLINE toCon #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => ToSym (cbv n) (sbv n)) =>
+  ToSym (SomeBV cbv) (SomeBV sbv)
+  where
+  toSym (SomeBV (n :: cbv n)) = SomeBV (toSym n :: sbv n)
+  {-# INLINE toSym #-}
+
+instance
+  ( forall n.
+    (KnownNat n, 1 <= n) =>
+    SafeDivision e (bv n) (ExceptT e m),
+    MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e
+  ) =>
+  SafeDivision (Either BitwidthMismatch e) (SomeBV bv) m
+  where
+  safeDiv = binSomeBVSafeR1 (safeDiv @e)
+  {-# INLINE safeDiv #-}
+  safeMod = binSomeBVSafeR1 (safeMod @e)
+  {-# INLINE safeMod #-}
+  safeQuot = binSomeBVSafeR1 (safeQuot @e)
+  {-# INLINE safeQuot #-}
+  safeRem = binSomeBVSafeR1 (safeRem @e)
+  {-# INLINE safeRem #-}
+  safeDivMod = binSomeBVSafeR2 (safeDivMod @e)
+  {-# INLINE safeDivMod #-}
+  safeQuotRem = binSomeBVSafeR2 (safeQuotRem @e)
+  {-# INLINE safeQuotRem #-}
+
+instance
+  ( forall n.
+    (KnownNat n, 1 <= n) =>
+    SafeLinearArith e (bv n) (ExceptT e m),
+    MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e
+  ) =>
+  SafeLinearArith (Either BitwidthMismatch e) (SomeBV bv) m
+  where
+  safeAdd = binSomeBVSafeR1 (safeAdd @e)
+  {-# INLINE safeAdd #-}
+  safeSub = binSomeBVSafeR1 (safeSub @e)
+  {-# INLINE safeSub #-}
+  safeNeg = unarySomeBV (mrgFmap SomeBV . mrgModifyError Right . safeNeg @e)
+  {-# INLINE safeNeg #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => SymShift (bv n)) =>
+  SymShift (SomeBV bv)
+  where
+  symShift = binSomeBVR1 symShift
+  {-# INLINE symShift #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => SymRotate (bv n)) =>
+  SymRotate (SomeBV bv)
+  where
+  symRotate = binSomeBVR1 symRotate
+  {-# INLINE symRotate #-}
+
+instance
+  ( forall n.
+    (KnownNat n, 1 <= n) =>
+    SafeSymShift e (bv n) (ExceptT e m),
+    MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e
+  ) =>
+  SafeSymShift (Either BitwidthMismatch e) (SomeBV bv) m
+  where
+  safeSymShiftL = binSomeBVSafeR1 (safeSymShiftL @e)
+  {-# INLINE safeSymShiftL #-}
+  safeSymShiftR = binSomeBVSafeR1 (safeSymShiftR @e)
+  {-# INLINE safeSymShiftR #-}
+  safeSymStrictShiftL = binSomeBVSafeR1 (safeSymStrictShiftL @e)
+  {-# INLINE safeSymStrictShiftL #-}
+  safeSymStrictShiftR = binSomeBVSafeR1 (safeSymStrictShiftR @e)
+  {-# INLINE safeSymStrictShiftR #-}
+
+instance
+  ( forall n.
+    (KnownNat n, 1 <= n) =>
+    SafeSymRotate e (bv n) (ExceptT e m),
+    MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e
+  ) =>
+  SafeSymRotate (Either BitwidthMismatch e) (SomeBV bv) m
+  where
+  safeSymRotateL = binSomeBVSafeR1 (safeSymRotateL @e)
+  {-# INLINE safeSymRotateL #-}
+  safeSymRotateR = binSomeBVSafeR1 (safeSymRotateR @e)
+  {-# INLINE safeSymRotateR #-}
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => ITEOp (bv n)) =>
+  ITEOp (SomeBV bv)
+  where
+  symIte cond = binSomeBVR1 (symIte cond)
+
+instance
+  (forall n. (KnownNat n, 1 <= n) => AllSyms (bv n)) =>
+  AllSyms (SomeBV bv)
+  where
+  allSyms = unarySomeBV allSyms
+  {-# INLINE allSyms #-}
+  allSymsS = unarySomeBV allSymsS
+  {-# INLINE allSymsS #-}
+
+-- Synonyms
+
+-- | Type synonym for 'SomeBV' with concrete signed bitvectors.
+type SomeIntN = SomeBV IntN
+
+-- | Pattern synonym for 'SomeBV' with concrete signed bitvectors.
+pattern SomeIntN :: () => (KnownNat n, 1 <= n) => IntN n -> SomeIntN
+pattern SomeIntN a = SomeBV a
+
+-- | Type synonym for 'SomeBV' with concrete unsigned bitvectors.
+type SomeWordN = SomeBV WordN
+
+-- | Pattern synonym for 'SomeBV' with concrete unsigned bitvectors.
+pattern SomeWordN :: () => (KnownNat n, 1 <= n) => WordN n -> SomeWordN
+pattern SomeWordN a = SomeBV a
+
+-- | Type synonym for 'SomeBV' with symbolic signed bitvectors.
+type SomeSymIntN = SomeBV SymIntN
+
+-- | Pattern synonym for 'SomeBV' with symbolic signed bitvectors.
+pattern SomeSymIntN :: () => (KnownNat n, 1 <= n) => SymIntN n -> SomeSymIntN
+pattern SomeSymIntN a = SomeBV a
+
+-- | Type synonym for 'SomeBV' with symbolic unsigned bitvectors.
+type SomeSymWordN = SomeBV SymWordN
+
+-- | Pattern synonym for 'SomeBV' with symbolic unsigned bitvectors.
+pattern SomeSymWordN :: () => (KnownNat n, 1 <= n) => SymWordN n -> SomeSymWordN
+pattern SomeSymWordN a = SomeBV a
+
+-- Construction
+
+-- | Construct a 'SomeBV' with a given run-time bitwidth and a polymorphic
+-- value for the underlying bitvector.
+unsafeSomeBV ::
+  forall bv.
+  Natural ->
+  (forall proxy n. (KnownNat n, 1 <= n) => proxy n -> bv n) ->
+  SomeBV bv
+unsafeSomeBV n i
+  | n == 0 = error "unsafeBV: trying to create a bitvector of size 0"
+  | otherwise = case mkNatRepr n of
+      Some (natRepr :: NatRepr x) ->
+        case unsafeLeqProof @1 @x of
+          LeqProof ->
+            withKnownNat natRepr $
+              SomeBV (i (Proxy @x))
+
+-- | Construct a symbolic 'SomeBV' with a given concrete 'SomeBV'. Similar to
+-- 'con' but for 'SomeBV'.
+--
+-- >>> a = bv 8 0x12 :: SomeIntN
+-- >>> conBV a :: SomeSymIntN
+-- 0x12
+conBV ::
+  forall cbv bv.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1)
+  ) =>
+  SomeBV cbv ->
+  SomeBV bv
+conBV (SomeBV (v :: cbv n)) = SomeBV $ con @(cbv n) @(bv n) v
+
+-- | View pattern for symbolic 'SomeBV' to see if it contains a concrete value
+-- and extract it. Similar to 'conView' but for 'SomeBV'.
+--
+-- >>> conBVView (bv 8 0x12 :: SomeSymIntN)
+-- Just 0x12
+-- >>> conBVView (ssymBV 4 "a" :: SomeSymIntN)
+-- Nothing
+conBVView ::
+  forall cbv bv.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1)
+  ) =>
+  SomeBV bv ->
+  Maybe (SomeBV cbv)
+conBVView (SomeBV (bv :: bv n)) = case conView @(cbv n) bv of
+  Just c -> Just $ SomeBV c
+  Nothing -> Nothing
+
+-- | Pattern synonym for symbolic 'SomeBV' to see if it contains a concrete
+-- value and extract it. Similar to 'Con' but for 'SomeBV'.
+--
+-- >>> case (bv 8 0x12 :: SomeSymIntN) of { ConBV c -> c; _ -> error "impossible" }
+-- 0x12
+pattern ConBV ::
+  forall cbv bv.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1)
+  ) =>
+  SomeBV cbv ->
+  SomeBV bv
+pattern ConBV c <- (conBVView -> Just c)
+  where
+    ConBV c = conBV c
+
+-- | Construct a symbolic 'SomeBV' with a given run-time bitwidth and a name.
+-- Similar to 'ssym' but for 'SomeBV'.
+--
+-- >>> ssymBV 8 "a" :: SomeSymIntN
+-- a
+ssymBV ::
+  forall cbv bv.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1)
+  ) =>
+  Natural ->
+  T.Text ->
+  SomeBV bv
+ssymBV n s = unsafeSomeBV n $ \(_ :: proxy n) -> ssym @(cbv n) s
+
+-- | Construct a symbolic 'SomeBV' with a given run-time bitwidth, a name and an
+-- index. Similar to 'isym' but for 'SomeBV'.
+--
+-- >>> isymBV 8 "a" 1 :: SomeSymIntN
+-- a@1
+isymBV ::
+  forall cbv bv.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1)
+  ) =>
+  Natural ->
+  T.Text ->
+  Int ->
+  SomeBV bv
+isymBV n s i = unsafeSomeBV n $ \(_ :: proxy n) -> isym @(cbv n) s i
+
+-- | Construct a symbolic 'SomeBV' with a given run-time bitwidth, a name and
+-- some extra info. Similar to 'sinfosym' but for 'SomeBV'.
+--
+-- >>> sinfosymBV 8 "a" "someinfo" :: SomeSymIntN
+-- a:"someinfo"
+sinfosymBV ::
+  forall cbv bv a.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1),
+    Typeable a,
+    Ord a,
+    Lift a,
+    NFData a,
+    Show a,
+    Hashable a
+  ) =>
+  Natural ->
+  T.Text ->
+  a ->
+  SomeBV bv
+sinfosymBV n s info =
+  unsafeSomeBV n $ \(_ :: proxy n) -> sinfosym @(cbv n) s info
+
+-- | Construct a symbolic 'SomeBV' with a given run-time bitwidth, a name, an
+-- index and some extra info. Similar to 'iinfosym' but for 'SomeBV'.
+--
+-- >>> iinfosymBV 8 "a" 1 "someinfo" :: SomeSymIntN
+-- a@1:"someinfo"
+iinfosymBV ::
+  forall cbv bv a.
+  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
+    Solvable (cbv 1) (bv 1),
+    Typeable a,
+    Ord a,
+    Lift a,
+    NFData a,
+    Show a,
+    Hashable a
+  ) =>
+  Natural ->
+  T.Text ->
+  Int ->
+  a ->
+  SomeBV bv
+iinfosymBV n s i info =
+  unsafeSomeBV n $ \(_ :: proxy n) -> iinfosym @(cbv n) s i info
+
+-- Helpers
+
+-- | Lift a unary operation on sized bitvectors that returns anything to
+-- 'SomeBV'.
+unarySomeBV :: (forall n. (KnownNat n, 1 <= n) => bv n -> r) -> SomeBV bv -> r
+unarySomeBV f (SomeBV bv) = f bv
+{-# INLINE unarySomeBV #-}
+
+-- | Lift a unary operation on sized bitvectors that returns a bitvector to
+-- 'SomeBV'. The result will also be wrapped with 'SomeBV'.
+unarySomeBVR1 ::
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n) -> SomeBV bv -> SomeBV bv
+unarySomeBVR1 f = unarySomeBV (SomeBV . f)
+{-# INLINE unarySomeBVR1 #-}
+
+-- | Lift a binary operation on sized bitvectors that returns anything to
+-- 'SomeBV'. Crash if the bitwidths do not match.
+binSomeBV ::
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n -> r) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  r
+binSomeBV f (SomeBV (l :: bv l)) (SomeBV (r :: bv r)) =
+  case sameNat (Proxy @l) (Proxy @r) of
+    Just Refl -> f l r
+    Nothing -> throw BitwidthMismatch
+{-# INLINE binSomeBV #-}
+
+-- | Lift a binary operation on sized bitvectors that returns a bitvector to
+-- 'SomeBV'. The result will also be wrapped with 'SomeBV'. Crash if the
+-- bitwidths do not match.
+binSomeBVR1 ::
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n -> bv n) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  SomeBV bv
+binSomeBVR1 f = binSomeBV (\a b -> SomeBV $ f a b)
+{-# INLINE binSomeBVR1 #-}
+
+-- | Lift a binary operation on sized bitvectors that returns two bitvectors to
+-- 'SomeBV'. The results will also be wrapped with 'SomeBV'. Crash if the
+-- bitwidths do not match.
+binSomeBVR2 ::
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n -> (bv n, bv n)) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  (SomeBV bv, SomeBV bv)
+binSomeBVR2 f = binSomeBV (\a b -> let (x, y) = f a b in (SomeBV x, SomeBV y))
+{-# INLINE binSomeBVR2 #-}
+
+-- | Lift a binary operation on sized bitvectors that returns anything wrapped
+-- with 'ExceptT' to 'SomeBV'. If the bitwidths do not match, throw an
+-- `BitwidthMismatch` error to the monadic context.
+binSomeBVSafe ::
+  ( MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e,
+    Mergeable r
+  ) =>
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n -> ExceptT e m r) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  m r
+binSomeBVSafe f (SomeBV (l :: bv l)) (SomeBV (r :: bv r)) =
+  case sameNat (Proxy @l) (Proxy @r) of
+    Just Refl -> mrgModifyError Right $ f l r
+    Nothing -> mrgThrowError $ Left BitwidthMismatch
+{-# INLINE binSomeBVSafe #-}
+
+-- | Lift a binary operation on sized bitvectors that returns a bitvector
+-- wrapped with 'ExceptT' to 'SomeBV'. The result will also be wrapped with
+-- 'SomeBV'.
+--
+-- If the bitwidths do not match, throw an `BitwidthMismatch` error to the
+-- monadic context.
+binSomeBVSafeR1 ::
+  ( MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e,
+    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+  ) =>
+  (forall n. (KnownNat n, 1 <= n) => bv n -> bv n -> ExceptT e m (bv n)) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  m (SomeBV bv)
+binSomeBVSafeR1 f = binSomeBVSafe (\l r -> mrgFmap SomeBV $ f l r)
+{-# INLINE binSomeBVSafeR1 #-}
+
+-- | Lift a binary operation on sized bitvectors that returns two bitvectors
+-- wrapped with 'ExceptT' to 'SomeBV'. The results will also be wrapped with
+-- 'SomeBV'.
+--
+-- If the bitwidths do not match, throw an `BitwidthMismatch` error to the
+-- monadic context.
+binSomeBVSafeR2 ::
+  ( MonadError (Either BitwidthMismatch e) m,
+    TryMerge m,
+    Mergeable e,
+    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+  ) =>
+  ( forall n.
+    (KnownNat n, 1 <= n) =>
+    bv n ->
+    bv n ->
+    ExceptT e m (bv n, bv n)
+  ) ->
+  SomeBV bv ->
+  SomeBV bv ->
+  m (SomeBV bv, SomeBV bv)
+binSomeBVSafeR2 f =
+  binSomeBVSafe (\l r -> mrgFmap (bimap SomeBV SomeBV) $ f l r)
+{-# INLINE binSomeBVSafeR2 #-}

--- a/src/Grisette/Core/Data/SomeBV.hs
+++ b/src/Grisette/Core/Data/SomeBV.hs
@@ -511,7 +511,7 @@ instance
   ( KnownNat n,
     1 <= n,
     forall m. (KnownNat m, 1 <= m) => GenSym () (bv m),
-    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+    Mergeable (SomeBV bv)
   ) =>
   GenSym (Proxy n) (SomeBV bv)
   where
@@ -523,7 +523,7 @@ instance
   ( KnownNat n,
     1 <= n,
     forall m. (KnownNat m, 1 <= m) => GenSymSimple () (bv m),
-    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+    Mergeable (SomeBV bv)
   ) =>
   GenSymSimple (Proxy n) (SomeBV bv)
   where
@@ -532,7 +532,7 @@ instance
 
 instance
   ( forall m. (KnownNat m, 1 <= m) => GenSym () (bv m),
-    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+    Mergeable (SomeBV bv)
   ) =>
   GenSym (SomeBV bv) (SomeBV bv)
   where
@@ -541,7 +541,7 @@ instance
 
 instance
   ( forall m. (KnownNat m, 1 <= m) => GenSymSimple () (bv m),
-    forall m. (KnownNat m, 1 <= m) => Mergeable (bv m)
+    Mergeable (SomeBV bv)
   ) =>
   GenSymSimple (SomeBV bv) (SomeBV bv)
   where
@@ -550,7 +550,7 @@ instance
 
 instance
   ( forall n. (KnownNat n, 1 <= n) => GenSym () (bv n),
-    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+    Mergeable (SomeBV bv)
   ) =>
   GenSym Natural (SomeBV bv)
   where
@@ -563,7 +563,7 @@ instance
 
 instance
   ( forall n. (KnownNat n, 1 <= n) => GenSymSimple () (bv n),
-    forall n. (KnownNat n, 1 <= n) => Mergeable (bv n)
+    Mergeable (SomeBV bv)
   ) =>
   GenSymSimple Natural (SomeBV bv)
   where
@@ -882,7 +882,7 @@ iinfosymBV n s i info =
 
 -- | Lift a unary operation on sized bitvectors that returns anything to
 -- 'SomeBV'.
-unarySomeBV :: (forall n. (KnownNat n, 1 <= n) => bv n -> r) -> SomeBV bv -> r
+unarySomeBV :: forall bv r. (forall n. (KnownNat n, 1 <= n) => bv n -> r) -> SomeBV bv -> r
 unarySomeBV f (SomeBV bv) = f bv
 {-# INLINE unarySomeBV #-}
 

--- a/src/Grisette/IR/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE PatternSynonyms #-}
 -- Disable this warning because we are re-exporting things.
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
 -- |
 -- Module      :   Grisette.IR.SymPrim
--- Copyright   :   (c) Sirui Lu 2021-2023
+-- Copyright   :   (c) Sirui Lu 2021-2024
 -- License     :   BSD-3-Clause (see the LICENSE file)
 --
 -- Maintainer  :   siruilu@cs.washington.edu
@@ -16,11 +17,30 @@ module Grisette.IR.SymPrim
     -- ** Extended types
     IntN,
     WordN,
-    SomeWordN (..),
-    SomeIntN (..),
+    SomeBV (..),
+    pattern SomeIntN,
+    type SomeIntN,
+    pattern SomeWordN,
+    type SomeWordN,
     type (=->) (..),
     type (-->),
     (-->),
+    unsafeSomeBV,
+    unarySomeBV,
+    unarySomeBVR1,
+    binSomeBV,
+    binSomeBVR1,
+    binSomeBVR2,
+    binSomeBVSafe,
+    binSomeBVSafeR1,
+    binSomeBVSafeR2,
+    conBV,
+    conBVView,
+    pattern ConBV,
+    ssymBV,
+    isymBV,
+    sinfosymBV,
+    iinfosymBV,
 
     -- ** Symbolic types
     SupportedPrim,
@@ -31,8 +51,10 @@ module Grisette.IR.SymPrim
     SymInteger (..),
     SymWordN (..),
     SymIntN (..),
-    SomeSymWordN (..),
-    SomeSymIntN (..),
+    SomeSymIntN,
+    SomeSymWordN,
+    pattern SomeSymIntN,
+    pattern SomeSymWordN,
     type (=~>) (..),
     type (-~>) (..),
     TypedSymbol (..),
@@ -51,9 +73,34 @@ where
 
 import Grisette.Core.Data.BV
   ( IntN,
-    SomeIntN (..),
-    SomeWordN (..),
     WordN,
+  )
+import Grisette.Core.Data.SomeBV
+  ( SomeBV (..),
+    binSomeBV,
+    binSomeBVR1,
+    binSomeBVR2,
+    binSomeBVSafe,
+    binSomeBVSafeR1,
+    binSomeBVSafeR2,
+    conBV,
+    conBVView,
+    iinfosymBV,
+    isymBV,
+    sinfosymBV,
+    ssymBV,
+    unarySomeBV,
+    unarySomeBVR1,
+    unsafeSomeBV,
+    pattern ConBV,
+    pattern SomeIntN,
+    pattern SomeSymIntN,
+    pattern SomeSymWordN,
+    pattern SomeWordN,
+    type SomeIntN,
+    type SomeSymIntN,
+    type SomeSymWordN,
+    type SomeWordN,
   )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
   ( ConRep (..),
@@ -71,8 +118,6 @@ import Grisette.IR.SymPrim.Data.Prim.Model
 import Grisette.IR.SymPrim.Data.SymPrim
   ( AllSyms (..),
     ModelSymPair (..),
-    SomeSymIntN (..),
-    SomeSymWordN (..),
     SymBool (..),
     SymIntN (..),
     SymInteger (..),

--- a/test/Grisette/Core/Data/BVTests.hs
+++ b/test/Grisette/Core/Data/BVTests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BinaryLiterals #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE NegativeLiterals #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -46,8 +47,6 @@ import Data.Word (Word8)
 import GHC.Stack (HasCallStack)
 import Grisette.Core.Data.BV
   ( IntN (IntN),
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     WordN (unWordN),
   )
 import Grisette.Core.Data.Class.BitVector
@@ -59,6 +58,12 @@ import Grisette.Core.Data.Class.BitVector
         sizedBVSext,
         sizedBVZext
       ),
+  )
+import Grisette.Core.Data.SomeBV
+  ( SomeIntN,
+    SomeWordN,
+    pattern SomeIntN,
+    pattern SomeWordN,
   )
 import Test.Framework (Test, TestName, testGroup)
 import Test.Framework.Providers.HUnit (testCase)

--- a/test/Grisette/Core/Data/Class/GPrettyTests.hs
+++ b/test/Grisette/Core/Data/Class/GPrettyTests.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Grisette.Core.Data.Class.GPrettyTests (gprettyTests) where
@@ -15,12 +16,14 @@ import GHC.Stack (HasCallStack)
 import Generics.Deriving (Default (Default))
 import Grisette.Core.Data.BV
   ( IntN,
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     WordN,
   )
 import Grisette.Core.Data.Class.GPretty (GPretty (gpretty))
 import Grisette.Core.Data.Class.LogicalOp (LogicalOp ((.&&)))
+import Grisette.Core.Data.SomeBV
+  ( pattern SomeIntN,
+    pattern SomeWordN,
+  )
 import Grisette.IR.SymPrim.Data.SymPrim (SymBool)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)

--- a/test/Grisette/Core/Data/Class/SafeDivisionTests.hs
+++ b/test/Grisette/Core/Data/Class/SafeDivisionTests.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -20,14 +21,18 @@ import Grisette
     IntN,
     Mergeable,
     SafeDivision (safeDiv, safeDivMod, safeMod, safeQuot, safeQuotRem, safeRem),
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     UnionM,
     WordN,
     mrgPure,
   )
 import Grisette.Core.Control.Monad.UnionM (isMerged)
 import Grisette.Core.Data.BV (BitwidthMismatch (BitwidthMismatch))
+import Grisette.Core.Data.SomeBV
+  ( SomeIntN,
+    SomeWordN,
+    pattern SomeIntN,
+    pattern SomeWordN,
+  )
 import Grisette.Lib.Control.Monad.Except (mrgThrowError)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)

--- a/test/Grisette/Core/Data/Class/SafeLinearArithTests.hs
+++ b/test/Grisette/Core/Data/Class/SafeLinearArithTests.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -18,8 +19,6 @@ import Grisette.Core.Control.Monad.UnionM (UnionM)
 import Grisette.Core.Data.BV
   ( BitwidthMismatch (BitwidthMismatch),
     IntN,
-    SomeIntN (SomeIntN),
-    SomeWordN (SomeWordN),
     WordN,
   )
 import Grisette.Core.Data.Class.BitVector (BV (bv))
@@ -28,6 +27,12 @@ import Grisette.Core.Data.Class.SafeLinearArith
   ( SafeLinearArith (safeAdd, safeNeg, safeSub),
   )
 import Grisette.Core.Data.Class.TryMerge (TryMerge, mrgPure)
+import Grisette.Core.Data.SomeBV
+  ( SomeIntN,
+    SomeWordN,
+    pattern SomeIntN,
+    pattern SomeWordN,
+  )
 import Grisette.Lib.Control.Monad.Except (mrgModifyError, mrgThrowError)
 import Grisette.Lib.Data.Functor (mrgFmap)
 import Test.Framework (Test, testGroup)

--- a/test/Grisette/Core/Data/SomeBVTests.hs
+++ b/test/Grisette/Core/Data/SomeBVTests.hs
@@ -1,0 +1,387 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Grisette.Core.Data.SomeBVTests (someBVTests) where
+
+import Control.DeepSeq (NFData, force)
+import Control.Exception (ArithException (Overflow), catch, evaluate)
+import Control.Monad.Except (ExceptT)
+import Data.Proxy (Proxy (Proxy))
+import qualified Data.Text as T
+import Grisette (ITEOp (symIte))
+import Grisette.Core.Control.Monad.UnionM (UnionM (UMrg))
+import Grisette.Core.Data.BV (BitwidthMismatch (BitwidthMismatch), IntN)
+import Grisette.Core.Data.Class.BitVector
+  ( BV (bv, bvConcat, bvExt, bvSelect, bvSext, bvZext),
+  )
+import Grisette.Core.Data.Class.GenSym (genSym, genSymSimple)
+import Grisette.Core.Data.Class.LogicalOp (LogicalOp (symNot))
+import Grisette.Core.Data.Class.Mergeable (Mergeable (rootStrategy))
+import Grisette.Core.Data.Class.SafeLinearArith
+  ( SafeLinearArith (safeAdd, safeSub),
+  )
+import Grisette.Core.Data.Class.SimpleMergeable (mrgIf)
+import Grisette.Core.Data.Class.Solvable
+  ( Solvable (iinfosym, isym, sinfosym, ssym),
+  )
+import Grisette.Core.Data.Class.TryMerge (mrgPure)
+import Grisette.Core.Data.SomeBV
+  ( SomeBV (SomeBV),
+    SomeIntN,
+    SomeSymIntN,
+    SomeWordN,
+    binSomeBV,
+    binSomeBVR1,
+    binSomeBVR2,
+    binSomeBVSafe,
+    binSomeBVSafeR1,
+    conBV,
+    conBVView,
+    iinfosymBV,
+    isymBV,
+    sinfosymBV,
+    ssymBV,
+    unarySomeBV,
+    unarySomeBVR1,
+    pattern ConBV,
+    pattern SomeIntN,
+  )
+import Grisette.Core.Data.Union (Union (UnionSingle), ifWithLeftMost)
+import Grisette.IR.SymPrim.Data.SymPrim (SymIntN)
+import Grisette.Lib.Control.Monad.Except (mrgThrowError)
+import Grisette.Lib.Data.Functor (mrgFmap)
+import Numeric.Natural (Natural)
+import Test.Framework (Test, testGroup)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@?=))
+
+testFuncMatch ::
+  (Eq r, Show r) =>
+  (SomeIntN -> SomeIntN -> r) ->
+  SomeIntN ->
+  SomeIntN ->
+  r ->
+  Test
+testFuncMatch f a b r = testCase "bit width match" $ do
+  let actual = f a b
+  let expected = r
+  actual @?= expected
+
+testFuncMisMatch ::
+  (NFData r, Show r, Eq r) =>
+  (SomeIntN -> SomeIntN -> r) ->
+  SomeIntN ->
+  SomeIntN ->
+  r ->
+  Test
+testFuncMisMatch f a b r = testCase "bit width mismatch" $ do
+  actual <-
+    evaluate (force $ f a b)
+      `catch` \(_ :: BitwidthMismatch) -> return r
+  let expected = r
+  actual @?= expected
+
+testSafeFuncMatchException ::
+  (Eq r, Show r, Mergeable r) =>
+  ( SomeIntN ->
+    SomeIntN ->
+    ExceptT (Either BitwidthMismatch ArithException) UnionM r
+  ) ->
+  SomeIntN ->
+  SomeIntN ->
+  ArithException ->
+  Test
+testSafeFuncMatchException f a b e = testCase "bit width match" $ do
+  let actual = f a b
+  let expected = mrgThrowError (Right e)
+  actual @?= expected
+
+testSafeFuncMatch ::
+  (Eq r, Show r, Mergeable r) =>
+  ( SomeIntN ->
+    SomeIntN ->
+    ExceptT (Either BitwidthMismatch ArithException) UnionM r
+  ) ->
+  SomeIntN ->
+  SomeIntN ->
+  r ->
+  Test
+testSafeFuncMatch f a b r = testCase "bit width match" $ do
+  let actual = f a b
+  let expected = mrgPure r
+  actual @?= expected
+
+testSafeFuncMisMatch ::
+  (Eq r, Show r, Mergeable r) =>
+  ( SomeIntN ->
+    SomeIntN ->
+    ExceptT (Either BitwidthMismatch ArithException) UnionM r
+  ) ->
+  SomeIntN ->
+  SomeIntN ->
+  Test
+testSafeFuncMisMatch f a b = testCase "bit width mismatch" $ do
+  let actual = f a b
+  let expected = mrgThrowError (Left BitwidthMismatch)
+  actual @?= expected
+
+someBVTests :: Test
+someBVTests =
+  testGroup
+    "SomeBV"
+    [ testGroup
+        "Helpers"
+        [ testCase "conBV" $ do
+            let actual = conBV (bv 4 5)
+            let expected = bv 4 5 :: SomeSymIntN
+            actual @?= expected,
+          testGroup
+            "conBVView"
+            [ testCase "is concrete" $ do
+                let value = bv 4 5 :: SomeSymIntN
+                let actual = conBVView value
+                let expected = Just (bv 4 5)
+                actual @?= expected
+                case value of
+                  ConBV v -> v @?= bv 4 5
+                  _ -> fail "is concrete",
+              testCase "is not concrete" $ do
+                let value = ssymBV 4 "a" :: SomeSymIntN
+                let actual = conBVView value
+                let expected = Nothing
+                actual @?= expected
+                case value of
+                  ConBV _ -> fail "is not concrete"
+                  _ -> return ()
+            ],
+          testCase "ssymBV" $ ssymBV 4 "a" @?= SomeBV (ssym "a" :: SymIntN 4),
+          testCase "isymBV" $
+            isymBV 4 "a" 1 @?= SomeBV (isym "a" 1 :: SymIntN 4),
+          testCase "sinfosymBV" $ do
+            let info = "abc" :: T.Text
+            let actual = sinfosymBV 4 "a" info
+            let expected = SomeBV (sinfosym "a" info :: SymIntN 4)
+            actual @?= expected,
+          testCase "iinfosymBV" $ do
+            let info = "abc" :: T.Text
+            let actual = iinfosymBV 4 "a" 3 info
+            let expected = SomeBV (iinfosym "a" 3 info :: SymIntN 4)
+            actual @?= expected,
+          testCase "unarySomeBV" $ do
+            let actual = unarySomeBV (SomeIntN . negate) (bv 4 5 :: SomeIntN)
+            let expected = bv 4 (-5)
+            actual @?= expected,
+          testCase "unarySomeBVR1" $ do
+            let actual = unarySomeBVR1 (negate) (bv 4 5 :: SomeIntN)
+            let expected = bv 4 (-5)
+            actual @?= expected,
+          testGroup
+            "binSomeBV"
+            [ testFuncMatch
+                (binSomeBV (\l r -> SomeIntN $ l + r))
+                (bv 4 5)
+                (bv 4 2)
+                (bv 4 7),
+              testFuncMisMatch
+                (binSomeBV (\l r -> SomeIntN $ l + r))
+                (bv 4 5)
+                (bv 5 4)
+                (bv 3 0)
+            ],
+          testGroup
+            "binSomeBVR1"
+            [ testFuncMatch (binSomeBVR1 (+)) (bv 4 5) (bv 4 2) (bv 4 7),
+              testFuncMisMatch (binSomeBVR1 (+)) (bv 4 5) (bv 5 4) (bv 3 0)
+            ],
+          testGroup
+            "binSomeBVR2"
+            [ testFuncMatch
+                (binSomeBVR2 (\l r -> (l + r, l - r)))
+                (bv 4 5)
+                (bv 4 2)
+                (bv 4 7, bv 4 3),
+              testFuncMisMatch
+                (binSomeBVR2 (\l r -> (l + r, l - r)))
+                (bv 4 5)
+                (bv 5 4)
+                (bv 3 0, bv 6 1)
+            ],
+          testGroup "binSomeBVSafe" $ do
+            let func l r = mrgFmap SomeIntN $ safeAdd l r
+            [ testSafeFuncMatch
+                (binSomeBVSafe func)
+                (bv 4 5)
+                (bv 4 2)
+                (bv 4 7),
+              testSafeFuncMatchException
+                (binSomeBVSafe func)
+                (bv 4 5)
+                (bv 4 5)
+                Overflow,
+              testSafeFuncMisMatch
+                (binSomeBVSafe func)
+                (bv 4 5)
+                (bv 5 4)
+              ],
+          testGroup
+            "binSomeBVSafeR1"
+            [ testSafeFuncMatch
+                (binSomeBVSafeR1 safeAdd)
+                (bv 4 5)
+                (bv 4 2)
+                (bv 4 7),
+              testSafeFuncMatchException
+                (binSomeBVSafeR1 safeAdd)
+                (bv 4 5)
+                (bv 4 5)
+                Overflow,
+              testSafeFuncMisMatch (binSomeBVSafeR1 safeAdd) (bv 4 5) (bv 5 4)
+            ],
+          testGroup "binSomeBVSafeR2" $ do
+            let func l r = do
+                  a <- safeAdd l r
+                  b <- safeSub l r
+                  mrgPure (a, b)
+            [ testSafeFuncMatch
+                func
+                (bv 4 5)
+                (bv 4 2)
+                (bv 4 7, bv 4 3),
+              testSafeFuncMatchException
+                func
+                (bv 4 5)
+                (bv 4 5)
+                Overflow,
+              testSafeFuncMisMatch func (bv 4 5) (bv 5 4)
+              ]
+        ],
+      testGroup
+        "BV"
+        [ testCase "bvConcat" $ do
+            bvConcat (bv 8 0x14 :: SomeIntN) (bv 4 2) @?= bv 12 0x142,
+          testCase "bvZext" $ do
+            bvZext 8 (bv 4 0x8 :: SomeIntN) @?= bv 8 0x08,
+          testCase "bvSext" $ do
+            bvSext 8 (bv 4 0x8 :: SomeIntN) @?= bv 8 0xF8,
+          testCase "bvExt" $ do
+            bvExt 8 (bv 4 0x8 :: SomeIntN) @?= bv 8 0xF8
+            bvExt 8 (bv 4 0x8 :: SomeWordN) @?= bv 8 0x08,
+          testCase "bvSelect" $ do
+            bvSelect 1 4 (bv 8 0x17 :: SomeIntN) @?= bv 4 0xB,
+          testCase "bv" $ bv 8 0x14 @?= (SomeIntN (0x14 :: IntN 8))
+        ],
+      testGroup
+        "Mergeable"
+        [ testGroup "SomeIntN" $ do
+            (name, l, r, merged) <-
+              [ ( "same bitwidth",
+                  bv 4 3,
+                  bv 4 5,
+                  ifWithLeftMost
+                    True
+                    "cond"
+                    (UnionSingle $ bv 4 3)
+                    (UnionSingle $ bv 4 5)
+                ),
+                ( "same bitwidth, should invert",
+                  bv 4 5,
+                  bv 4 2,
+                  ifWithLeftMost
+                    True
+                    (symNot "cond")
+                    (UnionSingle $ bv 4 2)
+                    (UnionSingle $ bv 4 5)
+                ),
+                ( "different bitwidth",
+                  bv 4 5,
+                  bv 5 4,
+                  ifWithLeftMost
+                    True
+                    "cond"
+                    (UnionSingle $ bv 4 5)
+                    (UnionSingle $ bv 5 4)
+                ),
+                ( "different bitwidth, should invert",
+                  bv 5 4,
+                  bv 4 5,
+                  ifWithLeftMost
+                    True
+                    (symNot "cond")
+                    (UnionSingle $ bv 4 5)
+                    (UnionSingle $ bv 5 4)
+                )
+                ]
+            return $ testCase name $ do
+              let actual =
+                    mrgIf "cond" (return l) (return r) :: UnionM SomeIntN
+              let expected = UMrg rootStrategy merged
+              actual @?= expected,
+          testGroup "SomeSymIntN" $ do
+            (name, l, r, merged) <-
+              [ ( "same bitwidth",
+                  ssymBV 4 "a",
+                  ssymBV 4 "b",
+                  (UnionSingle $ symIte "cond" (ssymBV 4 "a") (ssymBV 4 "b"))
+                ),
+                ( "different bitwidth",
+                  ssymBV 4 "a",
+                  ssymBV 5 "b",
+                  ifWithLeftMost
+                    True
+                    "cond"
+                    (UnionSingle $ ssymBV 4 "a")
+                    (UnionSingle $ ssymBV 5 "b")
+                ),
+                ( "different bitwidth, should invert",
+                  ssymBV 5 "b",
+                  ssymBV 4 "a",
+                  ifWithLeftMost
+                    True
+                    (symNot "cond")
+                    (UnionSingle $ ssymBV 4 "a")
+                    (UnionSingle $ ssymBV 5 "b")
+                )
+                ]
+            return $ testCase name $ do
+              let actual =
+                    mrgIf "cond" (return l) (return r) :: UnionM SomeSymIntN
+              let expected = UMrg rootStrategy merged
+              actual @?= expected
+        ],
+      testGroup
+        "GenSym"
+        [ testCase "Proxy n" $ do
+            let actual = genSym (Proxy :: Proxy 4) "a" :: UnionM SomeSymIntN
+            let expected = mrgPure $ isymBV 4 "a" 0
+            actual @?= expected,
+          testCase "SomeBV" $ do
+            let actual =
+                  genSym (bv 4 1 :: SomeSymIntN) "a" :: UnionM SomeSymIntN
+            let expected = mrgPure $ isymBV 4 "a" 0
+            actual @?= expected,
+          testCase "Natural" $ do
+            let actual =
+                  genSym (4 :: Natural) "a" :: UnionM SomeSymIntN
+            let expected = mrgPure $ isymBV 4 "a" 0
+            actual @?= expected
+        ],
+      testGroup
+        "GenSymSimple"
+        [ testCase "Proxy n" $ do
+            let actual = genSymSimple (Proxy :: Proxy 4) "a" :: SomeSymIntN
+            let expected = isymBV 4 "a" 0
+            actual @?= expected,
+          testCase "SomeBV" $ do
+            let actual =
+                  genSymSimple (bv 4 1 :: SomeSymIntN) "a" :: SomeSymIntN
+            let expected = isymBV 4 "a" 0
+            actual @?= expected,
+          testCase "Natural" $ do
+            let actual = genSymSimple (4 :: Natural) "a" :: SomeSymIntN
+            let expected = isymBV 4 "a" 0
+            actual @?= expected
+        ]
+    ]

--- a/test/Grisette/Core/Data/SomeBVTests.hs
+++ b/test/Grisette/Core/Data/SomeBVTests.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Grisette.Core.Data.SomeBVTests (someBVTests) where
 
@@ -171,7 +173,10 @@ someBVTests =
             let expected = SomeBV (iinfosym "a" 3 info :: SymIntN 4)
             actual @?= expected,
           testCase "unarySomeBV" $ do
-            let actual = unarySomeBV (SomeIntN . negate) (bv 4 5 :: SomeIntN)
+            let actual =
+                  unarySomeBV @IntN @SomeIntN
+                    (SomeIntN . negate)
+                    (bv 4 5 :: SomeIntN)
             let expected = bv 4 (-5)
             actual @?= expected,
           testCase "unarySomeBVR1" $ do
@@ -180,12 +185,12 @@ someBVTests =
             actual @?= expected,
           testGroup
             "binSomeBV"
-            [ testFuncMatch
+            [ testFuncMatch @SomeIntN
                 (binSomeBV (\l r -> SomeIntN $ l + r))
                 (bv 4 5)
                 (bv 4 2)
                 (bv 4 7),
-              testFuncMisMatch
+              testFuncMisMatch @SomeIntN
                 (binSomeBV (\l r -> SomeIntN $ l + r))
                 (bv 4 5)
                 (bv 5 4)
@@ -211,17 +216,17 @@ someBVTests =
             ],
           testGroup "binSomeBVSafe" $ do
             let func l r = mrgFmap SomeIntN $ safeAdd l r
-            [ testSafeFuncMatch
+            [ testSafeFuncMatch @SomeIntN
                 (binSomeBVSafe func)
                 (bv 4 5)
                 (bv 4 2)
                 (bv 4 7),
-              testSafeFuncMatchException
+              testSafeFuncMatchException @SomeIntN
                 (binSomeBVSafe func)
                 (bv 4 5)
                 (bv 4 5)
                 Overflow,
-              testSafeFuncMisMatch
+              testSafeFuncMisMatch @SomeIntN
                 (binSomeBVSafe func)
                 (bv 4 5)
                 (bv 5 4)

--- a/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -105,6 +105,12 @@ import Grisette.Core.Data.Class.Solvable
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
 import Grisette.Core.Data.Class.ToSym (ToSym (toSym))
 import Grisette.Core.Data.Class.TryMerge (mrgPure, tryMerge)
+import Grisette.Core.Data.SomeBV
+  ( SomeSymIntN,
+    SomeSymWordN,
+    pattern SomeSymIntN,
+    pattern SomeSymWordN,
+  )
 import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
   ( conTerm,
     isymTerm,
@@ -173,8 +179,6 @@ import Grisette.IR.SymPrim.Data.Prim.PartialEval.TabularFun
   )
 import Grisette.IR.SymPrim.Data.SymPrim
   ( ModelSymPair ((:=)),
-    SomeSymIntN (SomeSymIntN),
-    SomeSymWordN (SomeSymWordN),
     SymBool (SymBool),
     SymIntN (SymIntN),
     SymInteger (SymInteger),

--- a/test/Grisette/Lib/Control/Monad/Trans/State/Common.hs
+++ b/test/Grisette/Lib/Control/Monad/Trans/State/Common.hs
@@ -81,9 +81,7 @@ stateAB state =
 mergePropagatedIf' :: (MonadUnion m) => SymBool -> m b -> m b -> m b
 mergePropagatedIf' c a b = do
   x <- mrgIf c (return True) (return False)
-  case x of
-    True -> a
-    False -> b
+  if x then a else b
 
 mrgStateTest ::
   (MonadUnion (stateT SymBool UnionM)) =>

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,6 +31,7 @@ import Grisette.Core.Data.Class.SymShiftTests (symShiftTests)
 import Grisette.Core.Data.Class.ToConTests (toConTests)
 import Grisette.Core.Data.Class.ToSymTests (toSymTests)
 import Grisette.Core.Data.Class.TryMergeTests (tryMergeTests)
+import Grisette.Core.Data.SomeBVTests (someBVTests)
 import qualified Grisette.IR.SymPrim.Data.Prim.BVTests
 import Grisette.IR.SymPrim.Data.Prim.BitsTests (bitsTests)
 import qualified Grisette.IR.SymPrim.Data.Prim.BoolTests
@@ -111,7 +112,8 @@ coreTests =
               toSymTests,
               tryMergeTests
             ],
-          Grisette.Core.Data.BVTests.bvTests
+          Grisette.Core.Data.BVTests.bvTests,
+          someBVTests
         ]
     ]
 


### PR DESCRIPTION
This pull request unifies all the `SomeIntN`, `SomeWordN`, `SomeSymIntN`, `SomeSymWordN` implementations with a single `SomeBV` type.

These legacy types are now type and pattern synonyms.
