### PR TITLE
Bump version to 0.5.0.0

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           grisette
-version:        0.4.1.0
+version:        0.5.0.0
 synopsis:       Symbolic evaluation as a library
 description:    Grisette is a reusable symbolic evaluation library for Haskell. By
                 translating programs into constraints, Grisette can help the development of

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: grisette
-version: 0.4.1.0
+version: 0.5.0.0
 synopsis: Symbolic evaluation as a library
 description: |
   Grisette is a reusable symbolic evaluation library for Haskell. By


### PR DESCRIPTION
As multiple breaking changes has been introduced, we should bump the version tag to the next PVP major.