### PR TITLE
Use functional dependency instead of type family for Function class

### DIFF
--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -62,7 +62,7 @@ import Grisette.Core.Data.Class.EvaluateSym (EvaluateSym (evaluateSym))
 import Grisette.Core.Data.Class.ExtractSymbolics
   ( ExtractSymbolics (extractSymbolics),
   )
-import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Grisette.Core.Data.Class.GPretty
   ( GPretty (gpretty),
     groupedEnclose,
@@ -555,11 +555,9 @@ instance (Solvable c t, Mergeable t) => Solvable c (UnionM t) where
   {-# INLINE conView #-}
 
 instance
-  (Function f, Mergeable f, Mergeable a, Ret f ~ a) =>
-  Function (UnionM f)
+  (Function f arg ret, Mergeable f, Mergeable ret) =>
+  Function (UnionM f) arg (UnionM ret)
   where
-  type Arg (UnionM f) = Arg f
-  type Ret (UnionM f) = UnionM (Ret f)
   f # a = do
     f1 <- f
     mrgPure $ f1 # a

--- a/src/Grisette/Core/Data/Class/Function.hs
+++ b/src/Grisette/Core/Data/Class/Function.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -28,13 +30,7 @@ where
 -- >>> :set -XTypeOperators
 
 -- | Abstraction for function-like types.
-class Function f where
-  -- | Argument type
-  type Arg f
-
-  -- | Return type
-  type Ret f
-
+class Function f arg ret | f -> arg ret where
   -- | Function application operator.
   --
   -- The operator is not right associated (like `($)`). It is left associated,
@@ -45,13 +41,11 @@ class Function f where
   --
   -- >>> (+) # 2 # 3
   -- 5
-  (#) :: f -> Arg f -> Ret f
+  (#) :: f -> arg -> ret
 
   infixl 9 #
 
-instance Function (a -> b) where
-  type Arg (a -> b) = a
-  type Ret (a -> b) = b
+instance Function (a -> b) a b where
   f # a = f a
 
 -- | Applying an uninterpreted function.

--- a/src/Grisette/Core/Data/Class/PlainUnion.hs
+++ b/src/Grisette/Core/Data/Class/PlainUnion.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Grisette.Core.Data.Class.PlainUnion
@@ -19,7 +22,7 @@ where
 
 import Data.Bifunctor (Bifunctor (first))
 import Data.Kind (Type)
-import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Grisette.Core.Data.Class.LogicalOp
   ( LogicalOp (symNot, (.&&)),
   )
@@ -115,10 +118,10 @@ simpleMerge u = case tryMerge u of
 -- >>> f .# (mrgIf (ssym "b" :: SymBool) (mrgSingle 0) (mrgSingle 2) :: UnionM Integer)
 -- {If (&& b a) 1 (If b 2 (If a 3 4))}
 (.#) ::
-  (Function f, SimpleMergeable (Ret f), PlainUnion u) =>
+  (Function f a r, SimpleMergeable r, PlainUnion u) =>
   f ->
-  u (Arg f) ->
-  Ret f
+  u a ->
+  r
 (.#) f u = simpleMerge $ fmap (f #) u
 {-# INLINE (.#) #-}
 

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs
@@ -70,7 +70,7 @@ import Grisette.Core.Data.BV (IntN, WordN)
 import Grisette.Core.Data.Class.BitVector
   ( SizedBV,
   )
-import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Grisette.Core.Data.Class.SignConversion (SignConversion)
 import Grisette.Core.Data.Class.SymRotate (SymRotate)
 import Grisette.Core.Data.Class.SymShift (SymShift)
@@ -1167,9 +1167,7 @@ instance (KnownNat w, 1 <= w) => SupportedPrim (WordN w) where
 data (-->) a b where
   GeneralFun :: (SupportedPrim a, SupportedPrim b) => TypedSymbol a -> Term b -> a --> b
 
-instance (LinkedRep a sa, LinkedRep b sb) => Function (a --> b) where
-  type Arg (a --> b) = SymType a
-  type Ret (a --> b) = SymType b
+instance (LinkedRep a sa, LinkedRep b sb) => Function (a --> b) sa sb where
   (GeneralFun s t) # x = wrapTerm $ substTerm s (underlyingTerm x) t
 
 {-

--- a/src/Grisette/IR/SymPrim/Data/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim/Data/SymPrim.hs
@@ -105,7 +105,7 @@ import Grisette.Core.Data.BV
 import Grisette.Core.Data.Class.BitVector
   ( SizedBV (sizedBVConcat, sizedBVExt, sizedBVSelect, sizedBVSext, sizedBVZext),
   )
-import Grisette.Core.Data.Class.Function (Apply (FunType, apply), Function (Arg, Ret, (#)))
+import Grisette.Core.Data.Class.Function (Apply (FunType, apply), Function ((#)))
 import Grisette.Core.Data.Class.ModelOps
   ( ModelOps (emptyModel, insertValue),
     ModelRep (buildModel),
@@ -335,9 +335,7 @@ instance (LinkedRep ca sa, LinkedRep cb sb) => LinkedRep (ca =-> cb) (sa =~> sb)
   underlyingTerm (SymTabularFun a) = a
   wrapTerm = SymTabularFun
 
-instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Function (sa =~> sb) where
-  type Arg (sa =~> sb) = sa
-  type Ret (sa =~> sb) = sb
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Function (sa =~> sb) sa sb where
   (SymTabularFun f) # t = wrapTerm $ pevalTabularFunApplyTerm f (underlyingTerm t)
 
 instance (LinkedRep ca sa, LinkedRep ct st, Apply st) => Apply (sa =~> st) where
@@ -380,9 +378,7 @@ instance (LinkedRep ca sa, LinkedRep cb sb) => LinkedRep (ca --> cb) (sa -~> sb)
   underlyingTerm (SymGeneralFun a) = a
   wrapTerm = SymGeneralFun
 
-instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Function (sa -~> sb) where
-  type Arg (sa -~> sb) = sa
-  type Ret (sa -~> sb) = sb
+instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb) => Function (sa -~> sb) sa sb where
   (SymGeneralFun f) # t = wrapTerm $ pevalGeneralFunApplyTerm f (underlyingTerm t)
 
 instance (LinkedRep ca sa, LinkedRep ct st, Apply st) => Apply (sa -~> st) where

--- a/src/Grisette/IR/SymPrim/Data/TabularFun.hs
+++ b/src/Grisette/IR/SymPrim/Data/TabularFun.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -21,7 +23,7 @@ where
 import Control.DeepSeq (NFData, NFData1)
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic, Generic1)
-import Grisette.Core.Data.Class.Function (Function (Arg, Ret, (#)))
+import Grisette.Core.Data.Class.Function (Function ((#)))
 import Language.Haskell.TH.Syntax (Lift)
 
 -- $setup
@@ -44,9 +46,7 @@ data (=->) a b = TabularFun {funcTable :: [(a, b)], defaultFuncValue :: b}
 
 infixr 0 =->
 
-instance (Eq a) => Function (a =-> b) where
-  type Arg (a =-> b) = a
-  type Ret (a =-> b) = b
+instance (Eq a) => Function (a =-> b) a b where
   (TabularFun table d) # a = go table
     where
       go [] = d


### PR DESCRIPTION
This pull request improves the interface to the `Function` class by using functional dependency instead of type families.