### PR TITLE
Change to use Int instead of Natural for SomeBV creations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added the creation of unparameterized bit vectors from run-time bit-widths. ([#168])(https://github.com/lsrcz/grisette/pull/168), ([#177](https://github.com/lsrcz/grisette/pull/177))
+- Added the creation of unparameterized bit vectors from run-time bit-widths. ([#168](https://github.com/lsrcz/grisette/pull/168), [#177](https://github.com/lsrcz/grisette/pull/177))
 - Added all the functions available for the exception transformer in `transformers` and `mtl` packages. ([#171](https://github.com/lsrcz/grisette/pull/171))
 - Improved the partial evaluation for bit vectors. ([#176](https://github.com/lsrcz/grisette/pull/176))
 
@@ -26,13 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Refined the safe operations interface using `TryMerge`. ([#172](https://github.com/lsrcz/grisette/pull/172))
 - [Breaking] Renamed `safeMinus` to `safeSub` to be more consistent. ([#172](https://github.com/lsrcz/grisette/pull/172))
 - [Breaking] Unifies the implementation for all symbolic non-indexed
-  bit-vectors. The legacy types are now type and pattern synonyms. ([#174])(https://github.com/lsrcz/grisette/pull/174)
+  bit-vectors. The legacy types are now type and pattern synonyms. ([#174](https://github.com/lsrcz/grisette/pull/174), [#179](https://github.com/lsrcz/grisette/pull/179))
+- [Breaking] Use functional dependency instead of type family for the `Function` class. ([#178](https://github.com/lsrcz/grisette/pull/178))
 
 ## [0.4.1.0] -- 2024-01-10
 
 ### Added
 
-- Added `cegisForAll` interfaces. ([#165])(https://github.com/lsrcz/grisette/pull/165)
+- Added `cegisForAll` interfaces. ([#165](https://github.com/lsrcz/grisette/pull/165))
 
 ## [0.4.0.0] -- 2024-01-08
 

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -38,7 +38,6 @@ import Grisette.Utils.Parameterized
     subNat,
     unsafeLeqProof,
   )
-import Numeric.Natural (Natural)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -122,7 +121,7 @@ class BV bv where
   --
   -- >>> bv 12 21 :: SomeSymIntN
   -- 0x015
-  bv :: Natural -> Integer -> bv
+  bv :: Int -> Integer -> bv
 
 -- | Slicing out a smaller bit vector from a larger one, extract a slice from
 -- bit @i@ down to @j@.

--- a/test/Grisette/Core/Data/SomeBVTests.hs
+++ b/test/Grisette/Core/Data/SomeBVTests.hs
@@ -57,7 +57,6 @@ import Grisette.Core.Data.Union (Union (UnionSingle), ifWithLeftMost)
 import Grisette.IR.SymPrim.Data.SymPrim (SymIntN)
 import Grisette.Lib.Control.Monad.Except (mrgThrowError)
 import Grisette.Lib.Data.Functor (mrgFmap)
-import Numeric.Natural (Natural)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
@@ -371,9 +370,9 @@ someBVTests =
                   genSym (bv 4 1 :: SomeSymIntN) "a" :: UnionM SomeSymIntN
             let expected = mrgPure $ isymBV 4 "a" 0
             actual @?= expected,
-          testCase "Natural" $ do
+          testCase "Int" $ do
             let actual =
-                  genSym (4 :: Natural) "a" :: UnionM SomeSymIntN
+                  genSym (4 :: Int) "a" :: UnionM SomeSymIntN
             let expected = mrgPure $ isymBV 4 "a" 0
             actual @?= expected
         ],
@@ -388,8 +387,8 @@ someBVTests =
                   genSymSimple (bv 4 1 :: SomeSymIntN) "a" :: SomeSymIntN
             let expected = isymBV 4 "a" 0
             actual @?= expected,
-          testCase "Natural" $ do
-            let actual = genSymSimple (4 :: Natural) "a" :: SomeSymIntN
+          testCase "Int" $ do
+            let actual = genSymSimple (4 :: Int) "a" :: SomeSymIntN
             let expected = isymBV 4 "a" 0
             actual @?= expected
         ],


### PR DESCRIPTION
In #174, we introduced the unified `SomeBV` implementation and provided its creation with a run-time bit width. The run-time bit width was particularly hard to use in my experience.

This pull request changed it to use `Int`.