### PR TITLE
Allow integral value to be converted to bv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Refined the safe operations interface using `TryMerge`. ([#172](https://github.com/lsrcz/grisette/pull/172))
 - [Breaking] Renamed `safeMinus` to `safeSub` to be more consistent. ([#172](https://github.com/lsrcz/grisette/pull/172))
 - [Breaking] Unifies the implementation for all symbolic non-indexed
-  bit-vectors. The legacy types are now type and pattern synonyms. ([#174](https://github.com/lsrcz/grisette/pull/174), [#179](https://github.com/lsrcz/grisette/pull/179))
+  bit-vectors. The legacy types are now type and pattern synonyms. ([#174](https://github.com/lsrcz/grisette/pull/174), [#179](https://github.com/lsrcz/grisette/pull/179), [#180](https://github.com/lsrcz/grisette/pull/180))
 - [Breaking] Use functional dependency instead of type family for the `Function` class. ([#178](https://github.com/lsrcz/grisette/pull/178))
 
 ## [0.4.1.0] -- 2024-01-10

--- a/src/Grisette/Core/Data/Class/BitVector.hs
+++ b/src/Grisette/Core/Data/Class/BitVector.hs
@@ -121,7 +121,13 @@ class BV bv where
   --
   -- >>> bv 12 21 :: SomeSymIntN
   -- 0x015
-  bv :: Int -> Integer -> bv
+  bv ::
+    (Integral a) =>
+    -- | Bit width
+    Int ->
+    -- | Integral value
+    a ->
+    bv
 
 -- | Slicing out a smaller bit vector from a larger one, extract a slice from
 -- bit @i@ down to @j@.


### PR DESCRIPTION
This pull request makes the `bv` function accepts `Integral` value instead of just `Integer` value.