### PR TITLE
Add `symShiftNegated` and `symRotateNegated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the creation of unparameterized bit vectors from run-time bit-widths. ([#168](https://github.com/lsrcz/grisette/pull/168), [#177](https://github.com/lsrcz/grisette/pull/177))
 - Added all the functions available for the exception transformer in `transformers` and `mtl` packages. ([#171](https://github.com/lsrcz/grisette/pull/171))
 - Improved the partial evaluation for bit vectors. ([#176](https://github.com/lsrcz/grisette/pull/176))
+- Added `symRotateNegated` and `symShiftNegated`. ([#181](https://github.com/lsrcz/grisette/pull/181))
 
 ### Fixed
 

--- a/src/Grisette/Core/Data/Class/SymShift.hs
+++ b/src/Grisette/Core/Data/Class/SymShift.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE InstanceSigs #-}
 
 module Grisette.Core.Data.Class.SymShift
   ( SymShift (..),
@@ -16,6 +16,16 @@ import Data.Bits (Bits (isSigned, shift, shiftR), FiniteBits (finiteBitSize))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 
+-- | A class for shifting operations.
+--
+-- The `symShift` function shifts the value to the left if the shift amount is
+-- positive, and to the right if the shift amount is negative. If shifting
+-- beyond the bit width of the value, the result is the same as shifting with
+-- the bit width.
+--
+-- The `symShiftNegated` function shifts the value to the right if the shift
+-- amount is positive, and to the left if the shift amount is negative. This
+-- function is introduced to handle the asymmetry of the range of values.
 class (Bits a) => SymShift a where
   symShift :: a -> a -> a
   symShiftNegated :: a -> a -> a

--- a/src/Grisette/Core/Data/SomeBV.hs
+++ b/src/Grisette/Core/Data/SomeBV.hs
@@ -164,7 +164,7 @@ import Grisette.Core.Data.Class.Solvable
 import Grisette.Core.Data.Class.SubstituteSym
   ( SubstituteSym (substituteSym),
   )
-import Grisette.Core.Data.Class.SymRotate (SymRotate (symRotate))
+import Grisette.Core.Data.Class.SymRotate (SymRotate (symRotate, symRotateNegated))
 import Grisette.Core.Data.Class.SymShift (SymShift (symShift, symShiftNegated))
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
 import Grisette.Core.Data.Class.ToSym (ToSym (toSym))
@@ -653,6 +653,8 @@ instance
   where
   symRotate = binSomeBVR1 symRotate
   {-# INLINE symRotate #-}
+  symRotateNegated = binSomeBVR1 symRotateNegated
+  {-# INLINE symRotateNegated #-}
 
 instance
   ( forall n.

--- a/src/Grisette/Core/Data/SomeBV.hs
+++ b/src/Grisette/Core/Data/SomeBV.hs
@@ -165,7 +165,7 @@ import Grisette.Core.Data.Class.SubstituteSym
   ( SubstituteSym (substituteSym),
   )
 import Grisette.Core.Data.Class.SymRotate (SymRotate (symRotate))
-import Grisette.Core.Data.Class.SymShift (SymShift (symShift))
+import Grisette.Core.Data.Class.SymShift (SymShift (symShift, symShiftNegated))
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
 import Grisette.Core.Data.Class.ToSym (ToSym (toSym))
 import Grisette.Core.Data.Class.TryMerge (TryMerge)
@@ -644,6 +644,8 @@ instance
   where
   symShift = binSomeBVR1 symShift
   {-# INLINE symShift #-}
+  symShiftNegated = binSomeBVR1 symShiftNegated
+  {-# INLINE symShiftNegated #-}
 
 instance
   (forall n. (KnownNat n, 1 <= n) => SymRotate (bv n)) =>

--- a/test/Grisette/Core/Data/Class/SymRotateTests.hs
+++ b/test/Grisette/Core/Data/Class/SymRotateTests.hs
@@ -10,7 +10,9 @@ import Data.Word (Word16, Word32, Word64, Word8)
 import Grisette (IntN, LinkedRep, Solvable, SymIntN, SymWordN)
 import Grisette.Core.Data.BV (WordN)
 import Grisette.Core.Data.Class.Solvable (Solvable (con))
-import Grisette.Core.Data.Class.SymRotate (SymRotate (symRotate))
+import Grisette.Core.Data.Class.SymRotate
+  ( SymRotate (symRotate, symRotateNegated),
+  )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
@@ -27,6 +29,19 @@ concreteRotateIsCorrect a s =
       a
       ( fromIntegral $
           (fromIntegral s :: Integer) `mod` fromIntegral (finiteBitSize a)
+      )
+
+concreteRotateNegatedIsCorrect ::
+  (SymRotate a, Show a, Integral a, FiniteBits a) =>
+  a ->
+  a ->
+  Assertion
+concreteRotateNegatedIsCorrect a s =
+  symRotateNegated a s
+    @?= rotate
+      a
+      ( fromIntegral $
+          (-fromIntegral s :: Integer) `mod` fromIntegral (finiteBitSize a)
       )
 
 concreteUnsignedTypeSymRotateTests ::
@@ -52,8 +67,14 @@ concreteUnsignedTypeSymRotateTests p =
             forAll (chooseInt (0, finiteBitSize x)) $
               \(s :: Int) ->
                 ioProperty $ concreteRotateIsCorrect x (fromIntegral s),
+          testProperty "symRotateNegated" $ \(x :: a) ->
+            forAll (chooseInt (0, finiteBitSize x)) $
+              \(s :: Int) ->
+                ioProperty $ concreteRotateNegatedIsCorrect x (fromIntegral s),
           testProperty "symRotate max" $ \(x :: a) ->
-            ioProperty $ concreteRotateIsCorrect x maxBound
+            ioProperty $ concreteRotateIsCorrect x maxBound,
+          testProperty "symRotateNegated max" $ \(x :: a) ->
+            ioProperty $ concreteRotateNegatedIsCorrect x maxBound
         ]
     ]
 
@@ -80,10 +101,18 @@ concreteSignedTypeSymRotateTests p =
             forAll (chooseInt (-finiteBitSize x, finiteBitSize x)) $
               \(s :: Int) ->
                 ioProperty $ concreteRotateIsCorrect x (fromIntegral s),
+          testProperty "symRotateNegated" $ \(x :: a) ->
+            forAll (chooseInt (-finiteBitSize x, finiteBitSize x)) $
+              \(s :: Int) ->
+                ioProperty $ concreteRotateNegatedIsCorrect x (fromIntegral s),
           testProperty "symRotate max" $ \(x :: a) ->
             ioProperty $ concreteRotateIsCorrect x maxBound,
+          testProperty "symRotateNegated max" $ \(x :: a) ->
+            ioProperty $ concreteRotateNegatedIsCorrect x maxBound,
           testProperty "symRotate min" $ \(x :: a) ->
-            ioProperty $ concreteRotateIsCorrect x minBound
+            ioProperty $ concreteRotateIsCorrect x minBound,
+          testProperty "symRotateNegated min" $ \(x :: a) ->
+            ioProperty $ concreteRotateNegatedIsCorrect x minBound
         ]
     ]
 
@@ -138,6 +167,7 @@ symRotateTests =
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy Word),
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 1)),
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 2)),
+      concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 3)),
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 63)),
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 64)),
       concreteUnsignedTypeSymRotateTests (Proxy :: Proxy (WordN 65)),
@@ -149,18 +179,21 @@ symRotateTests =
       concreteSignedTypeSymRotateTests (Proxy :: Proxy Int),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 1)),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 2)),
+      concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 3)),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 63)),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 64)),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 65)),
       concreteSignedTypeSymRotateTests (Proxy :: Proxy (IntN 128)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 1)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 2)),
+      symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 3)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 63)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 64)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 65)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymWordN 128)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 1)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 2)),
+      symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 3)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 63)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 64)),
       symbolicTypeSymRotateTests (Proxy :: Proxy (SymIntN 65)),


### PR DESCRIPTION
The asymmetricity of the range of integral values is making the `symShift` interface hard to use, especially for unsigned types. This pull request adds negated versions `symShiftNegated` and `symRotateNegated` that shifts or rotate in the opposite direction.