### PR TITLE
Ensure that the `mrg*` for monad transformers merge the results

### DIFF
--- a/src/Grisette/Lib/Control/Monad/Except.hs
+++ b/src/Grisette/Lib/Control/Monad/Except.hs
@@ -68,7 +68,7 @@ mrgWithError ::
   m a ->
   m a
 mrgWithError f action =
-  mrgTryError action >>= either (mrgThrowError . f) mrgReturn
+  tryMerge $ mrgTryError action >>= either (mrgThrowError . f) mrgReturn
 {-# INLINE mrgWithError #-}
 
 -- | 'Control.Monad.Except.handleError' with 'MergingStrategy' knowledge
@@ -111,5 +111,6 @@ mrgModifyError ::
   (e -> e') ->
   ExceptT e m a ->
   m a
-mrgModifyError f m = mrgRunExceptT m >>= either (mrgThrowError . f) mrgReturn
+mrgModifyError f m =
+  tryMerge $ mrgRunExceptT m >>= either (mrgThrowError . f) mrgReturn
 {-# INLINE mrgModifyError #-}

--- a/src/Grisette/Lib/Control/Monad/State/Class.hs
+++ b/src/Grisette/Lib/Control/Monad/State/Class.hs
@@ -42,7 +42,7 @@ mrgState ::
   (MonadState s m, TryMerge m, Mergeable s, Mergeable a) =>
   (s -> (a, s)) ->
   m a
-mrgState f = do
+mrgState f = tryMerge $ do
   s <- mrgGet
   let ~(a, s') = f s
   mrgPut s'

--- a/src/Grisette/Lib/Control/Monad/Trans/State/Lazy.hs
+++ b/src/Grisette/Lib/Control/Monad/Trans/State/Lazy.hs
@@ -48,7 +48,7 @@ mrgRunStateT ::
   StateT s m a ->
   s ->
   m (a, s)
-mrgRunStateT m s = runStateT m s >>= mrgReturn
+mrgRunStateT m s = tryMerge $ runStateT m s
 {-# INLINE mrgRunStateT #-}
 
 -- | 'Control.Monad.Trans.State.Lazy.evalStateT' with 'MergingStrategy'
@@ -58,9 +58,9 @@ mrgEvalStateT ::
   StateT s m a ->
   s ->
   m a
-mrgEvalStateT m s = do
+mrgEvalStateT m s = tryMerge $ do
   ~(a, _) <- runStateT m s
-  mrgReturn a
+  return a
 {-# INLINE mrgEvalStateT #-}
 
 -- | 'Control.Monad.Trans.State.Lazy.execStateT' with 'MergingStrategy'
@@ -70,9 +70,9 @@ mrgExecStateT ::
   StateT s m a ->
   s ->
   m s
-mrgExecStateT m s = do
+mrgExecStateT m s = tryMerge $ do
   ~(_, s') <- runStateT m s
-  mrgReturn s'
+  return s'
 {-# INLINE mrgExecStateT #-}
 
 -- | 'Control.Monad.Trans.State.Lazy.mapStateT' with 'MergingStrategy' knowledge

--- a/src/Grisette/Lib/Control/Monad/Trans/State/Strict.hs
+++ b/src/Grisette/Lib/Control/Monad/Trans/State/Strict.hs
@@ -48,7 +48,7 @@ mrgRunStateT ::
   StateT s m a ->
   s ->
   m (a, s)
-mrgRunStateT m s = runStateT m s >>= mrgReturn
+mrgRunStateT m s = tryMerge $ runStateT m s
 {-# INLINE mrgRunStateT #-}
 
 -- | 'Control.Monad.Trans.State.Strict.evalStateT' with 'MergingStrategy'
@@ -58,9 +58,9 @@ mrgEvalStateT ::
   StateT s m a ->
   s ->
   m a
-mrgEvalStateT m s = do
+mrgEvalStateT m s = tryMerge $ do
   (a, _) <- runStateT m s
-  mrgReturn a
+  return a
 {-# INLINE mrgEvalStateT #-}
 
 -- | 'Control.Monad.Trans.State.Strict.execStateT' with 'MergingStrategy'
@@ -70,9 +70,9 @@ mrgExecStateT ::
   StateT s m a ->
   s ->
   m s
-mrgExecStateT m s = do
+mrgExecStateT m s = tryMerge $ do
   (_, s') <- runStateT m s
-  mrgReturn s'
+  return s'
 {-# INLINE mrgExecStateT #-}
 
 -- | 'Control.Monad.Trans.State.Strict.mapStateT' with 'MergingStrategy'


### PR DESCRIPTION
This pull request fixes a bug causing unmerged values to be returned by `mrg*` functions for monad transformers.