### PR TITLE
Add generation of fresh strings from MonadFresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Control.Monad`, `Control.Applicative`, `Data.Foldable`, `Data.List`, and `Data.Traversable`.
   ([#182](https://github.com/lsrcz/grisette/pull/182))
 - Added `mrgIfPropagatedStrategy`. ([#184](https://github.com/lsrcz/grisette/pull/184))
+- Added `freshString`. ([#188](https://github.com/lsrcz/grisette/pull/188))
 
 ### Fixed
 
 - Fixed the merging for safe division. ([#173](https://github.com/lsrcz/grisette/pull/173))
 - Fixed the behavior for safe `mod` and `rem` for signed, bounded concrete types. ([#173](https://github.com/lsrcz/grisette/pull/173))
+- Fixed merging in `mrg*` operations for monad transformers to ensure that they merge the results. ([#187](https://github.com/lsrcz/grisette/pull/187))
+
 
 ### Changed
 
@@ -36,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Breaking] Added `Mergeable` constraints to some `mrg*` list operators
   ([#182](https://github.com/lsrcz/grisette/pull/182))
 - [Breaking] Refactored the `mrg*` constructor related template haskell code.
-  ([#185](https://github.com/lsrc/grisette/pull/185))
+  ([#185](https://github.com/lsrcz/grisette/pull/185))
+- [Breaking] Dropped symbols with extra information. ([#188](https://github.com/lsrcz/grisette/pull/188))
 
 ## [0.4.1.0] -- 2024-01-10
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -713,8 +713,6 @@ module Grisette.Core
     FreshIndex (..),
     FreshIdent (..),
     name,
-    nameWithInfo,
-    FileLocation (..),
     nameWithLoc,
 
     -- ** Symbolic Generation Monad
@@ -1128,7 +1126,6 @@ import Grisette.Core.Data.Class.GenSym
     liftFresh,
     mrgRunFreshT,
     name,
-    nameWithInfo,
     nextFreshIndex,
     runFresh,
     runFreshT,
@@ -1214,8 +1211,7 @@ import Grisette.Core.Data.Class.TryMerge
     tryMerge,
   )
 import Grisette.Core.Data.FileLocation
-  ( FileLocation (..),
-    ilocsym,
+  ( ilocsym,
     nameWithLoc,
     slocsym,
   )

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -724,6 +724,7 @@ module Grisette.Core
     runFresh,
     runFreshT,
     mrgRunFreshT,
+    freshString,
 
     -- ** Symbolic Generation Class
     GenSym (..),
@@ -1121,6 +1122,7 @@ import Grisette.Core.Data.Class.GenSym
     derivedNoSpecFresh,
     derivedNoSpecSimpleFresh,
     derivedSameShapeSimpleFresh,
+    freshString,
     genSym,
     genSymSimple,
     liftFresh,

--- a/src/Grisette/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Core/Control/Monad/UnionM.hs
@@ -85,7 +85,7 @@ import Grisette.Core.Data.Class.SimpleMergeable
     mrgIf,
   )
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
+  ( Solvable (con, conView, isym, ssym),
     pattern Con,
   )
 import Grisette.Core.Data.Class.Solver (UnionWithExcept (extractUnionExcept))
@@ -541,10 +541,6 @@ instance (Solvable c t, Mergeable t) => Solvable c (UnionM t) where
   {-# INLINE ssym #-}
   isym s i = mrgSingle $ isym s i
   {-# INLINE isym #-}
-  sinfosym s info = mrgSingle $ sinfosym s info
-  {-# INLINE sinfosym #-}
-  iinfosym i s info = mrgSingle $ iinfosym i s info
-  {-# INLINE iinfosym #-}
   conView v = do
     c <- singleView $ tryMerge v
     conView c

--- a/src/Grisette/Core/Data/Class/GenSym.hs
+++ b/src/Grisette/Core/Data/Class/GenSym.hs
@@ -42,6 +42,7 @@ module Grisette.Core.Data.Class.GenSym
     runFreshT,
     runFresh,
     mrgRunFreshT,
+    freshString,
 
     -- * Symbolic value generation
     GenSym (..),
@@ -243,6 +244,18 @@ liftFresh (FreshT f) = do
   let (a, newIdx) = runIdentity $ f ident index
   setFreshIndex newIdx
   return a
+
+-- | Generate a fresh string with the given postfix.
+--
+-- >>> runFresh (freshString "b") "a" :: String
+-- "a@0[b]"
+freshString :: (MonadFresh m, IsString s) => String -> m s
+freshString postfix = do
+  FreshIdent ident <- getFreshIdent
+  FreshIndex index <- nextFreshIndex
+  return $
+    fromString $
+      T.unpack ident <> "@" <> show index <> "[" <> postfix <> "]"
 
 -- | A symbolic generation monad transformer.
 -- It is a reader monad transformer for identifiers and

--- a/src/Grisette/Core/Data/Class/Solvable.hs
+++ b/src/Grisette/Core/Data/Class/Solvable.hs
@@ -21,12 +21,8 @@ module Grisette.Core.Data.Class.Solvable
   )
 where
 
-import Control.DeepSeq (NFData)
-import Data.Hashable (Hashable)
 import Data.String (IsString)
 import qualified Data.Text as T
-import Data.Typeable (Typeable)
-import Language.Haskell.TH.Syntax (Lift)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -74,27 +70,6 @@ class (IsString t) => Solvable c t | t -> c where
   -- >>> isym "a" 1 :: SymBool
   -- a@1
   isym :: T.Text -> Int -> t
-
-  -- | Generate simply-named symbolic constants with some extra information for
-  -- disambiguation.
-  --
-  -- Two symbolic constants with the same name but different extra information
-  -- (including info with different types) are considered to be different.
-  --
-  -- >>> sinfosym "a" "someInfo" :: SymInteger
-  -- a:"someInfo"
-  sinfosym :: (Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) => T.Text -> a -> t
-
-  -- | Generate indexed symbolic constants with some extra information for
-  -- disambiguation.
-  --
-  -- Two symbolic constants with the same name and index but different extra
-  -- information (including info with different types) are considered to be
-  -- different.
-  --
-  -- >>> iinfosym "a" 1 "someInfo" :: SymInteger
-  -- a@1:"someInfo"
-  iinfosym :: (Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) => T.Text -> Int -> a -> t
 
 -- | Extract the concrete value from a solvable value with 'conView'.
 --

--- a/src/Grisette/Core/Data/FileLocation.hs
+++ b/src/Grisette/Core/Data/FileLocation.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE Trustworthy #-}
 
@@ -16,23 +17,19 @@
 -- Portability :   GHC only
 module Grisette.Core.Data.FileLocation
   ( -- * Symbolic constant generation with location
-    FileLocation (..),
     nameWithLoc,
     slocsym,
     ilocsym,
   )
 where
 
-import Control.DeepSeq (NFData)
-import Data.Hashable (Hashable)
 import qualified Data.Text as T
 import Debug.Trace.LocationTH (__LOCATION__)
-import GHC.Generics (Generic)
-import Grisette.Core.Data.Class.GenSym (FreshIdent, nameWithInfo)
+import Grisette.Core.Data.Class.GenSym (FreshIdent (unFreshIdent), name)
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (iinfosym, sinfosym),
+  ( Solvable (isym, ssym),
   )
-import Language.Haskell.TH.Syntax (Lift, unsafeTExpCoerce)
+import Language.Haskell.TH.Syntax (unsafeTExpCoerce)
 import Language.Haskell.TH.Syntax.Compat (SpliceQ, liftSplice)
 
 -- $setup
@@ -40,35 +37,24 @@ import Language.Haskell.TH.Syntax.Compat (SpliceQ, liftSplice)
 -- >>> import Grisette.IR.SymPrim
 -- >>> :set -XTemplateHaskell
 
--- File location type.
-data FileLocation = FileLocation {locPath :: String, locLineno :: Int, locSpan :: (Int, Int)}
-  deriving (Eq, Ord, Generic, Lift, NFData, Hashable)
-
-instance Show FileLocation where
-  show (FileLocation p l (s1, s2)) = p ++ ":" ++ show l ++ ":" ++ show s1 ++ "-" ++ show s2
-
-parseFileLocation :: String -> FileLocation
-parseFileLocation str =
-  let r = reverse str
-      (s2, r1) = break (== '-') r
-      (s1, r2) = break (== ':') $ tail r1
-      (l, p) = break (== ':') $ tail r2
-   in FileLocation (reverse $ tail p) (read $ reverse l) (read $ reverse s1, read $ reverse s2)
-
 -- | Identifier with the current location as extra information.
 --
 -- >>> $$(nameWithLoc "a") -- a sample result could be "a:<interactive>:18:4-18"
--- a:<interactive>:...
+-- a[<interactive>:...]
 --
 -- The uniqueness is ensured for the call to 'nameWithLoc' at different location.
 nameWithLoc :: T.Text -> SpliceQ FreshIdent
-nameWithLoc s = [||nameWithInfo s (parseFileLocation $$(liftSplice $ unsafeTExpCoerce __LOCATION__))||]
+nameWithLoc s =
+  [||
+  name $
+    s <> "[" <> (T.pack $$(liftSplice $ unsafeTExpCoerce __LOCATION__)) <> "]"
+  ||]
 
 -- | Generate simply-named symbolic variables. The file location will be
 -- attached to the identifier.
 --
 -- >>> $$(slocsym "a") :: SymBool
--- a:<interactive>:...
+-- a[<interactive>:...]
 --
 -- Calling 'slocsymb' with the same name at different location will always
 -- generate different symbolic constants. Calling 'slocsymb' at the same
@@ -80,15 +66,15 @@ nameWithLoc s = [||nameWithInfo s (parseFileLocation $$(liftSplice $ unsafeTExpC
 -- >>> f () == f ()
 -- True
 slocsym :: (Solvable c s) => T.Text -> SpliceQ s
-slocsym nm = [||sinfosym nm (parseFileLocation $$(liftSplice $ unsafeTExpCoerce __LOCATION__))||]
+slocsym nm = [||ssym (unFreshIdent $$(nameWithLoc nm))||]
 
 -- | Generate indexed symbolic variables. The file location will be attached to identifier.
 --
 -- >>> $$(ilocsym "a" 1) :: SymBool
--- a@1:<interactive>:...
+-- a[<interactive>:...]@1
 --
 -- Calling 'ilocsymb' with the same name and index at different location will
 -- always generate different symbolic constants. Calling 'slocsymb' at the same
 -- location for multiple times will generate the same symbolic constants.
 ilocsym :: (Solvable c s) => T.Text -> Int -> SpliceQ s
-ilocsym nm idx = [||iinfosym nm idx (parseFileLocation $$(liftSplice $ unsafeTExpCoerce __LOCATION__))||]
+ilocsym nm idx = [||isym (unFreshIdent $$(nameWithLoc nm)) idx||]

--- a/src/Grisette/Core/Data/SomeBV.hs
+++ b/src/Grisette/Core/Data/SomeBV.hs
@@ -32,8 +32,6 @@ module Grisette.Core.Data.SomeBV
     pattern ConBV,
     ssymBV,
     isymBV,
-    sinfosymBV,
-    iinfosymBV,
     arbitraryBV,
 
     -- * Synonyms
@@ -89,7 +87,7 @@ import Data.Bits
       ),
     FiniteBits (countLeadingZeros, countTrailingZeros, finiteBitSize),
   )
-import Data.Data (Proxy (Proxy), Typeable)
+import Data.Data (Proxy (Proxy))
 import Data.Hashable (Hashable (hashWithSalt))
 import Data.Maybe (fromJust)
 import qualified Data.Text as T
@@ -159,7 +157,7 @@ import Grisette.Core.Data.Class.SignConversion
   ( SignConversion (toSigned, toUnsigned),
   )
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
+  ( Solvable (con, conView, isym, ssym),
   )
 import Grisette.Core.Data.Class.SubstituteSym
   ( SubstituteSym (substituteSym),
@@ -828,53 +826,6 @@ isymBV ::
   Int ->
   SomeBV bv
 isymBV n s i = unsafeSomeBV n $ \(_ :: proxy n) -> isym @(cbv n) s i
-
--- | Construct a symbolic 'SomeBV' with a given run-time bitwidth, a name and
--- some extra info. Similar to 'sinfosym' but for 'SomeBV'.
---
--- >>> sinfosymBV 8 "a" "someinfo" :: SomeSymIntN
--- a:"someinfo"
-sinfosymBV ::
-  forall cbv bv a.
-  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
-    Solvable (cbv 1) (bv 1),
-    Typeable a,
-    Ord a,
-    Lift a,
-    NFData a,
-    Show a,
-    Hashable a
-  ) =>
-  Int ->
-  T.Text ->
-  a ->
-  SomeBV bv
-sinfosymBV n s info =
-  unsafeSomeBV n $ \(_ :: proxy n) -> sinfosym @(cbv n) s info
-
--- | Construct a symbolic 'SomeBV' with a given run-time bitwidth, a name, an
--- index and some extra info. Similar to 'iinfosym' but for 'SomeBV'.
---
--- >>> iinfosymBV 8 "a" 1 "someinfo" :: SomeSymIntN
--- a@1:"someinfo"
-iinfosymBV ::
-  forall cbv bv a.
-  ( forall n. (KnownNat n, 1 <= n) => Solvable (cbv n) (bv n),
-    Solvable (cbv 1) (bv 1),
-    Typeable a,
-    Ord a,
-    Lift a,
-    NFData a,
-    Show a,
-    Hashable a
-  ) =>
-  Int ->
-  T.Text ->
-  Int ->
-  a ->
-  SomeBV bv
-iinfosymBV n s i info =
-  unsafeSomeBV n $ \(_ :: proxy n) -> iinfosym @(cbv n) s i info
 
 -- | Generate an arbitrary 'SomeBV' with a given run-time bitwidth.
 arbitraryBV ::

--- a/src/Grisette/IR/SymPrim.hs
+++ b/src/Grisette/IR/SymPrim.hs
@@ -39,8 +39,6 @@ module Grisette.IR.SymPrim
     pattern ConBV,
     ssymBV,
     isymBV,
-    sinfosymBV,
-    iinfosymBV,
     arbitraryBV,
 
     -- ** Symbolic types
@@ -87,9 +85,7 @@ import Grisette.Core.Data.SomeBV
     binSomeBVSafeR2,
     conBV,
     conBVView,
-    iinfosymBV,
     isymBV,
-    sinfosymBV,
     ssymBV,
     unarySomeBV,
     unarySomeBVR1,

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs
@@ -25,8 +25,6 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     symTerm,
     ssymTerm,
     isymTerm,
-    sinfosymTerm,
-    iinfosymTerm,
     notTerm,
     orTerm,
     andTerm,
@@ -67,7 +65,6 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
   )
 where
 
-import Control.DeepSeq (NFData)
 import Data.Array ((!))
 import Data.Bits (Bits, FiniteBits)
 import qualified Data.HashMap.Strict as M
@@ -94,7 +91,7 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
     SupportedPrim,
     Term,
     TernaryOp,
-    TypedSymbol (IndexedSymbol, SimpleSymbol, WithInfo),
+    TypedSymbol (IndexedSymbol, SimpleSymbol),
     UTerm
       ( UAbsNumTerm,
         UAddNumTerm,
@@ -143,7 +140,6 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import Grisette.IR.SymPrim.Data.TabularFun
   ( type (=->),
   )
-import Language.Haskell.TH.Syntax (Lift)
 import Type.Reflection (Typeable, typeRep)
 
 internTerm :: forall t. (SupportedPrim t) => Uninterned (Term t) -> Term t
@@ -203,23 +199,6 @@ ssymTerm = symTerm . SimpleSymbol
 isymTerm :: (SupportedPrim t, Typeable t) => T.Text -> Int -> Term t
 isymTerm str idx = symTerm $ IndexedSymbol str idx
 {-# INLINE isymTerm #-}
-
-sinfosymTerm ::
-  (SupportedPrim t, Typeable t, Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) =>
-  T.Text ->
-  a ->
-  Term t
-sinfosymTerm s info = symTerm $ WithInfo (SimpleSymbol s) info
-{-# INLINE sinfosymTerm #-}
-
-iinfosymTerm ::
-  (SupportedPrim t, Typeable t, Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) =>
-  T.Text ->
-  Int ->
-  a ->
-  Term t
-iinfosymTerm str idx info = symTerm $ WithInfo (IndexedSymbol str idx) info
-{-# INLINE iinfosymTerm #-}
 
 notTerm :: Term Bool -> Term Bool
 notTerm = internTerm . UNotTerm

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/InternedCtors.hs-boot
@@ -14,8 +14,6 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     symTerm,
     ssymTerm,
     isymTerm,
-    sinfosymTerm,
-    iinfosymTerm,
     notTerm,
     orTerm,
     andTerm,
@@ -56,7 +54,6 @@ module Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
   )
 where
 
-import Control.DeepSeq (NFData)
 import Data.Bits (Bits, FiniteBits)
 import Data.Hashable (Hashable)
 import qualified Data.Text as T
@@ -80,7 +77,6 @@ import {-# SOURCE #-} Grisette.IR.SymPrim.Data.Prim.InternedTerm.Term
 import Grisette.IR.SymPrim.Data.TabularFun
   ( type (=->),
   )
-import Language.Haskell.TH.Syntax (Lift)
 
 constructUnary ::
   forall tag arg t.
@@ -107,17 +103,6 @@ conTerm :: (SupportedPrim t, Typeable t, Hashable t, Eq t, Show t) => t -> Term 
 symTerm :: (SupportedPrim t, Typeable t) => TypedSymbol t -> Term t
 ssymTerm :: (SupportedPrim t, Typeable t) => T.Text -> Term t
 isymTerm :: (SupportedPrim t, Typeable t) => T.Text -> Int -> Term t
-sinfosymTerm ::
-  (SupportedPrim t, Typeable t, Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) =>
-  T.Text ->
-  a ->
-  Term t
-iinfosymTerm ::
-  (SupportedPrim t, Typeable t, Typeable a, Ord a, Lift a, NFData a, Show a, Hashable a) =>
-  T.Text ->
-  Int ->
-  a ->
-  Term t
 notTerm :: Term Bool -> Term Bool
 orTerm :: Term Bool -> Term Bool -> Term Bool
 andTerm :: Term Bool -> Term Bool -> Term Bool

--- a/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
+++ b/src/Grisette/IR/SymPrim/Data/Prim/InternedTerm/Term.hs-boot
@@ -129,19 +129,6 @@ class
 data TypedSymbol t where
   SimpleSymbol :: (SupportedPrim t) => T.Text -> TypedSymbol t
   IndexedSymbol :: (SupportedPrim t) => T.Text -> Int -> TypedSymbol t
-  WithInfo ::
-    forall t a.
-    ( SupportedPrim t,
-      Typeable a,
-      Ord a,
-      Lift a,
-      NFData a,
-      Show a,
-      Hashable a
-    ) =>
-    TypedSymbol t ->
-    a ->
-    TypedSymbol t
 
 data SomeTypedSymbol where
   SomeTypedSymbol :: forall t. TypeRep t -> TypedSymbol t -> SomeTypedSymbol

--- a/src/Grisette/Internal/IR/SymPrim.hs
+++ b/src/Grisette/Internal/IR/SymPrim.hs
@@ -35,8 +35,6 @@ module Grisette.Internal.IR.SymPrim
     symTerm,
     ssymTerm,
     isymTerm,
-    sinfosymTerm,
-    iinfosymTerm,
     termSize,
     termsSize,
     extractSymbolicsTerm,
@@ -102,9 +100,7 @@ import Grisette.IR.SymPrim.Data.Prim.InternedTerm.InternedCtors
     constructBinary,
     constructTernary,
     constructUnary,
-    iinfosymTerm,
     isymTerm,
-    sinfosymTerm,
     ssymTerm,
     symTerm,
   )

--- a/test/Grisette/Core/Control/Monad/UnionMTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionMTests.hs
@@ -44,7 +44,7 @@ import Grisette.Core.Data.Class.SimpleMergeable
     mrgIte1,
   )
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (con, conView, iinfosym, isym, sinfosym, ssym),
+  ( Solvable (con, conView, isym, ssym),
   )
 import Grisette.Core.Data.Class.SubstituteSym (SubstituteSym (substituteSym))
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
@@ -335,12 +335,6 @@ unionMTests =
           testCase "sym" $ (ssym "a" :: UnionM SymBool) @?= mrgSingle (ssym "a"),
           testCase "isym" $
             (isym "a" 1 :: UnionM SymBool) @?= mrgSingle (isym "a" 1),
-          testCase "sinfoym" $
-            (sinfosym "a" () :: UnionM SymBool) @?= mrgSingle (sinfosym "a" ()),
-          testCase "iinfosym" $ do
-            let actual = iinfosym "a" 1 () :: UnionM SymBool
-            let expected = mrgSingle (iinfosym "a" 1 ())
-            actual @?= expected,
           testGroup
             "conView"
             [ testCase "is concrete" $ do

--- a/test/Grisette/Core/Data/Class/GenSymTests.hs
+++ b/test/Grisette/Core/Data/Class/GenSymTests.hs
@@ -3,6 +3,7 @@
 
 module Grisette.Core.Data.Class.GenSymTests (genSymTests) where
 
+import Control.Monad (replicateM)
 import Control.Monad.Except (ExceptT (ExceptT))
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Grisette.Core.Control.Monad.UnionM (UnionM)
@@ -20,6 +21,7 @@ import Grisette.Core.Data.Class.GenSym
     chooseSimpleFresh,
     chooseUnion,
     chooseUnionFresh,
+    freshString,
     genSym,
     genSymSimple,
     liftFresh,
@@ -1259,5 +1261,7 @@ genSymTests =
                       (isymBool "a" 2, isymBool "a" 3)
                     )
             actual @?= expected
-        ]
+        ],
+      testCase "freshString" $ do
+        runFresh (replicateM 2 $ freshString "a") "b" @?= ["b@0[a]", "b@1[a]"]
     ]

--- a/test/Grisette/Core/Data/SomeBVTests.hs
+++ b/test/Grisette/Core/Data/SomeBVTests.hs
@@ -13,7 +13,6 @@ import Control.Exception (ArithException (Overflow), catch, evaluate)
 import Control.Monad.Except (ExceptT)
 import Data.Bits (FiniteBits (finiteBitSize))
 import Data.Proxy (Proxy (Proxy))
-import qualified Data.Text as T
 import Grisette (ITEOp (symIte))
 import Grisette.Core.Control.Monad.UnionM (UnionM (UMrg))
 import Grisette.Core.Data.BV (BitwidthMismatch (BitwidthMismatch), IntN)
@@ -28,7 +27,7 @@ import Grisette.Core.Data.Class.SafeLinearArith
   )
 import Grisette.Core.Data.Class.SimpleMergeable (mrgIf)
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (iinfosym, isym, sinfosym, ssym),
+  ( Solvable (isym, ssym),
   )
 import Grisette.Core.Data.Class.TryMerge (mrgSingle)
 import Grisette.Core.Data.SomeBV
@@ -44,9 +43,7 @@ import Grisette.Core.Data.SomeBV
     binSomeBVSafeR1,
     conBV,
     conBVView,
-    iinfosymBV,
     isymBV,
-    sinfosymBV,
     ssymBV,
     unarySomeBV,
     unarySomeBVR1,
@@ -165,16 +162,6 @@ someBVTests =
           testCase "ssymBV" $ ssymBV 4 "a" @?= SomeBV (ssym "a" :: SymIntN 4),
           testCase "isymBV" $
             isymBV 4 "a" 1 @?= SomeBV (isym "a" 1 :: SymIntN 4),
-          testCase "sinfosymBV" $ do
-            let info = "abc" :: T.Text
-            let actual = sinfosymBV 4 "a" info
-            let expected = SomeBV (sinfosym "a" info :: SymIntN 4)
-            actual @?= expected,
-          testCase "iinfosymBV" $ do
-            let info = "abc" :: T.Text
-            let actual = iinfosymBV 4 "a" 3 info
-            let expected = SomeBV (iinfosym "a" 3 info :: SymIntN 4)
-            actual @?= expected,
           testCase "unarySomeBV" $ do
             let actual =
                   unarySomeBV @IntN @SomeIntN

--- a/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
+++ b/test/Grisette/IR/SymPrim/Data/SymPrimTests.hs
@@ -59,7 +59,6 @@ import Grisette.Core.Data.Class.Function (Apply (apply), Function ((#)))
 import Grisette.Core.Data.Class.GenSym
   ( genSym,
     genSymSimple,
-    nameWithInfo,
   )
 import Grisette.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Core.Data.Class.LogicalOp
@@ -99,7 +98,7 @@ import Grisette.Core.Data.Class.SimpleMergeable
     mrgIf,
   )
 import Grisette.Core.Data.Class.Solvable
-  ( Solvable (con, conView, iinfosym, isym, ssym),
+  ( Solvable (con, conView, isym, ssym),
     pattern Con,
   )
 import Grisette.Core.Data.Class.ToCon (ToCon (toCon))
@@ -520,9 +519,7 @@ symPrimTests =
             (genSym () "a" :: UnionM SymBool) @=? mrgSingle (isym "a" 0)
             (genSymSimple () "a" :: SymBool) @=? isym "a" 0
             (genSym (ssym "a" :: SymBool) "a" :: UnionM SymBool) @=? mrgSingle (isym "a" 0)
-            (genSymSimple (ssym "a" :: SymBool) "a" :: SymBool) @=? isym "a" 0
-            (genSym () (nameWithInfo "a" True) :: UnionM SymBool) @=? mrgSingle (iinfosym "a" 0 True)
-            (genSymSimple () (nameWithInfo "a" True) :: SymBool) @=? iinfosym "a" 0 True,
+            (genSymSimple (ssym "a" :: SymBool) "a" :: SymBool) @=? isym "a" 0,
           testCase "SEq" $ do
             (ssym "a" :: SymBool) .== ssym "b" @=? SymBool (pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
             (ssym "a" :: SymBool) ./= ssym "b" @=? SymBool (pevalNotTerm $ pevalEqvTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))


### PR DESCRIPTION
Added generation of fresh strings from `MonadFresh` via `freshString`. Dropped support for symbols with info, which can be confusing and rarely used.