### PR TITLE
Add localFreshIdent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#182](https://github.com/lsrcz/grisette/pull/182))
 - Added `mrgIfPropagatedStrategy`. ([#184](https://github.com/lsrcz/grisette/pull/184))
 - Added `freshString`. ([#188](https://github.com/lsrcz/grisette/pull/188))
+- Added `localFreshIdent`. ([#190](https://github.com/lsrcz/grisette/pull/190))
 
 ### Fixed
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,14 +8,14 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
 
-        hPkgs = pkgs.haskell.packages."ghc982";
+        hPkgs = pkgs.haskell.packages."ghc964";
 
         myDevTools = [
           hPkgs.ghc # GHC compiler in the desired version (will be available on PATH)
           # hPkgs.ghcid # Continuous terminal Haskell compile checker
           # hPkgs.ormolu # Haskell formatter
-          # hPkgs.hlint # Haskell codestyle checker
-          # hPkgs.haskell-language-server # LSP server for editor
+          hPkgs.hlint # Haskell codestyle checker
+          hPkgs.haskell-language-server # LSP server for editor
           hPkgs.cabal-install
           stack-wrapped
           # (pkgs.ihaskell.override {


### PR DESCRIPTION
This pull request adds a combinator to locally change the identifier for the `MonadFresh`. It also resets the index in the local block.