### PR TITLE
`withSolver` should forcifully terminate the solver when exiting the scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [Breaking] Equality test for `SomeBV` with different bit widths will now
   return false rather than crash.
   ([#200](https://github.com/lsrcz/grisette/pull/200))
-- [Breaking] Improved the generic CEGIS interface. ([#201](https://github.com/lsrcz/grisette/pull/201))
+- [Breaking] More intuitive CEGIS interface.
+  ([#201](https://github.com/lsrcz/grisette/pull/201))
 
 ## [0.5.0.1] -- 2024-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Added solving procedures with solver handles. ([#198](https://github.com/lsrcz/grisette/pull/198))
 - Added `overestimateUnionValues`. ([#203](https://github.com/lsrcz/grisette/pull/203))
 
+### Fixed
+
+- `withSolver` now forcifully terminate the solver when exiting the scope.
+  ([#199](https://github.com/lsrcz/grisette/pull/199))
+
 ### Changed
 
 - [Breaking] Equality test for `SomeBV` with different bit widths will now

--- a/src/Grisette/Internal/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Solver.hs
@@ -266,7 +266,7 @@ withSolver ::
   config ->
   (handle -> IO a) ->
   IO a
-withSolver config = bracket (newSolver config) solverTerminate
+withSolver config = bracket (newSolver config) solverForceTerminate
 
 -- | Solve a single formula. Find an assignment to it to make it true.
 --

--- a/src/Grisette/Internal/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Solver.hs
@@ -268,7 +268,7 @@ class
 -- long-running or zombie solver instances.
 --
 -- This was due to a bug in sbv, which is fixed in
--- https://github.com/LeventErkok/sbv/pull/695. 
+-- https://github.com/LeventErkok/sbv/pull/695.
 withSolver ::
   (ConfigurableSolver config handle) =>
   config ->

--- a/src/Grisette/Internal/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Solver.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -261,6 +262,13 @@ class
 
 -- | Start a solver, run a computation with the solver, and terminate the
 -- solver after the computation finishes.
+--
+-- Note: if Grisette is compiled with sbv < 10.10, the solver likely won't be
+-- killed before it has finished the last action, and this will result in
+-- long-running or zombie solver instances.
+--
+-- This was due to a bug in sbv, which is fixed in
+-- https://github.com/LeventErkok/sbv/pull/695. 
 withSolver ::
   (ConfigurableSolver config handle) =>
   config ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,6 +40,9 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 # extra-deps: []
+extra-deps:
+  - git: https://github.com/lsrcz/sbv.git
+    commit: 2b25b54d9531bafff930520e7bd923277700a501
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,8 +41,7 @@ packages:
 #
 # extra-deps: []
 extra-deps:
-  - git: https://github.com/lsrcz/sbv.git
-    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
+  - sbv-10.10
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,7 @@ packages:
 # extra-deps: []
 extra-deps:
   - git: https://github.com/lsrcz/sbv.git
-    commit: 2b25b54d9531bafff930520e7bd923277700a501
+    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,15 @@
 
 packages:
 - completed:
-    commit: 2b25b54d9531bafff930520e7bd923277700a501
+    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
     git: https://github.com/lsrcz/sbv.git
     name: sbv
     pantry-tree:
-      sha256: fee881031058a4fa7a20d5d83a058f09db23236c17eae6149e03ebc243a7f50b
+      sha256: 498cd42ce9d1a58be44a3ad8c51ee16b7727a0418ac5fe907e74e6bc5350fa49
       size: 73472
-    version: '10.9'
+    version: '10.10'
   original:
-    commit: 2b25b54d9531bafff930520e7bd923277700a501
+    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
     git: https://github.com/lsrcz/sbv.git
 snapshots:
 - completed:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,16 +5,12 @@
 
 packages:
 - completed:
-    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
-    git: https://github.com/lsrcz/sbv.git
-    name: sbv
+    hackage: sbv-10.10@sha256:c5f31007e6641d9acbb766cfcff93a5a39a09d72878babaa6dfa384e33fc04aa,23716
     pantry-tree:
-      sha256: 498cd42ce9d1a58be44a3ad8c51ee16b7727a0418ac5fe907e74e6bc5350fa49
-      size: 73472
-    version: '10.10'
+      sha256: 4da8ff7eebcd5bedc19dd6fe1dd3d7f23e33beb0b3da2cf40b08b4f99fe1509e
+      size: 72605
   original:
-    commit: ca5b7865008d812db66a923ca72103de1eb7ceba
-    git: https://github.com/lsrcz/sbv.git
+    hackage: sbv-10.10
 snapshots:
 - completed:
     sha256: 629fdd46125079fa6d355106005b2ab88bd39332169dd416fda06d5c0aaa63e2

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,18 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    commit: 2b25b54d9531bafff930520e7bd923277700a501
+    git: https://github.com/lsrcz/sbv.git
+    name: sbv
+    pantry-tree:
+      sha256: fee881031058a4fa7a20d5d83a058f09db23236c17eae6149e03ebc243a7f50b
+      size: 73472
+    version: '10.9'
+  original:
+    commit: 2b25b54d9531bafff930520e7bd923277700a501
+    git: https://github.com/lsrcz/sbv.git
 snapshots:
 - completed:
     sha256: 629fdd46125079fa6d355106005b2ab88bd39332169dd416fda06d5c0aaa63e2


### PR DESCRIPTION
`withSolver` should forcifully terminate the solver when exiting the scope due to an exception.