### PR TITLE
:sparkles: Introduce overestimateUnionValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Added solving procedures with solver handles. ([#198](https://github.com/lsrcz/grisette/pull/198))
+- Added `overestimateUnionValues`. ([#203](https://github.com/lsrcz/grisette/pull/203))
 
 ### Changed
 
 - [Breaking] Equality test for `SomeBV` with different bit widths will now
   return false rather than crash.
   ([#200](https://github.com/lsrcz/grisette/pull/200))
+- [Breaking] Improved the generic CEGIS interface. ([#201](https://github.com/lsrcz/grisette/pull/201))
 
 ## [0.5.0.1] -- 2024-04-18
 


### PR DESCRIPTION
This pull request `overestimateUnionValues`, which returns the list of values in an `UnionM` and drops the path conditions.