### PR TITLE
Add true and false in LogicalOp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.1.0] -- 2024-06-12
+## [0.6.1.0]
 
 ### Fixed
 
@@ -14,6 +14,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#209](https://github.com/lsrcz/grisette/pull/209))
 - Exported the `FP` constructs in the `Grisette` module.
   ([#209](https://github.com/lsrcz/grisette/pull/209))
+- Added `true` and `false` in `LogicalOp`.
+  ([#211](https://github.com/lsrcz/grisette/pull/211))
 
 ## [0.6.0.0] -- 2024-06-07
 

--- a/src/Grisette/Internal/Core/Control/Monad/UnionM.hs
+++ b/src/Grisette/Internal/Core/Control/Monad/UnionM.hs
@@ -61,7 +61,7 @@ import Grisette.Internal.Core.Data.Class.GPretty
   )
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.Core.Data.Class.LogicalOp
-  ( LogicalOp (symImplies, symNot, symXor, (.&&), (.||)),
+  ( LogicalOp (false, symImplies, symNot, symXor, true, (.&&), (.||)),
   )
 import Grisette.Internal.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
@@ -509,6 +509,8 @@ instance (ITEOp a, Mergeable a) => ITEOp (UnionM a) where
   symIte = mrgIf
 
 instance (LogicalOp a, Mergeable a) => LogicalOp (UnionM a) where
+  true = mrgSingle true
+  false = mrgSingle false
   (.||) = unionMBinOp (.||)
   (.&&) = unionMBinOp (.&&)
   symNot = unionMUnaryOp symNot

--- a/src/Grisette/Internal/Core/Data/Class/LogicalOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/LogicalOp.hs
@@ -3,6 +3,7 @@ module Grisette.Internal.Core.Data.Class.LogicalOp
   )
 where
 
+import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.SymPrim.Prim.Term
   ( pevalAndTerm,
     pevalImplyTerm,
@@ -23,8 +24,8 @@ import Grisette.Internal.SymPrim.SymBool (SymBool (SymBool))
 
 -- | Symbolic logical operators for symbolic booleans.
 --
--- >>> let t = con True :: SymBool
--- >>> let f = con False :: SymBool
+-- >>> let t = true :: SymBool
+-- >>> let f = false :: SymBool
 -- >>> let a = "a" :: SymBool
 -- >>> let b = "b" :: SymBool
 -- >>> t .|| f
@@ -60,6 +61,11 @@ import Grisette.Internal.SymPrim.SymBool (SymBool (SymBool))
 -- >>> a `symXor` b
 -- (|| (&& (! a) b) (&& a (! b)))
 class LogicalOp b where
+  true :: b
+  true = symNot false
+  false :: b
+  false = symNot true
+
   -- | Symbolic disjunction
   (.||) :: b -> b -> b
   a .|| b = symNot $ symNot a .&& symNot b
@@ -87,10 +93,12 @@ class LogicalOp b where
   a `symImplies` b = symNot a .|| b
   {-# INLINE symImplies #-}
 
-  {-# MINIMAL (.||), symNot | (.&&), symNot #-}
+  {-# MINIMAL (true | false), ((.||), symNot | (.&&), symNot) #-}
 
 -- LogicalOp instances
 instance LogicalOp Bool where
+  true = True
+  false = False
   (.||) = (||)
   {-# INLINE (.||) #-}
   (.&&) = (&&)
@@ -99,6 +107,8 @@ instance LogicalOp Bool where
   {-# INLINE symNot #-}
 
 instance LogicalOp SymBool where
+  true = con True
+  false = con False
   (SymBool l) .|| (SymBool r) = SymBool $ pevalOrTerm l r
   (SymBool l) .&& (SymBool r) = SymBool $ pevalAndTerm l r
   symNot (SymBool v) = SymBool $ pevalNotTerm v

--- a/test/Grisette/Core/Data/Class/BoolTests.hs
+++ b/test/Grisette/Core/Data/Class/BoolTests.hs
@@ -1,30 +1,36 @@
 module Grisette.Core.Data.Class.BoolTests (boolTests) where
 
 import Grisette
-  ( LogicalOp (symImplies, symNot, symXor, (.&&), (.||)),
+  ( LogicalOp (false, symImplies, symNot, symXor, true, (.&&), (.||)),
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@?=))
 
 data CustomAndBool
-  = CASBool String
+  = CACBool Bool
+  | CASBool String
   | CAAnd CustomAndBool CustomAndBool
   | CANot CustomAndBool
   deriving (Show, Eq)
 
 instance LogicalOp CustomAndBool where
+  true = CACBool True
+  symNot (CACBool b) = CACBool $ not b
   symNot (CANot x) = x
   symNot x = CANot x
   (.&&) = CAAnd
 
 data CustomOrBool
-  = COSBool String
+  = COCBool Bool
+  | COSBool String
   | COOr CustomOrBool CustomOrBool
   | CONot CustomOrBool
   deriving (Show, Eq)
 
 instance LogicalOp CustomOrBool where
+  false = COCBool False
+  symNot (COCBool b) = COCBool $ not b
   symNot (CONot x) = x
   symNot x = CONot x
   (.||) = COOr


### PR DESCRIPTION
We should provide `true` and `false` instead of using `con True` and `con False`.