### PR TITLE
Discourage the use of approximation with GrisetteSMTConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#217](https://github.com/lsrcz/grisette/pull/217))
 - [Breaking] Renamed `GPretty` to `Format`.
   ([#217](https://github.com/lsrcz/grisette/pull/217))
+- [Breaking] Discourage the use of approximation with `approx`. `precise` is now
+  the default and we do not require `precise` to be used everytime we call a
+  solver.
+  ([#218](https://github.com/lsrcz/grisette/pull/218))
 
 ## [0.6.0.0] -- 2024-06-07
 

--- a/src/Grisette/Backend.hs
+++ b/src/Grisette/Backend.hs
@@ -10,29 +10,30 @@
 -- Stability   :   Experimental
 -- Portability :   GHC only
 module Grisette.Backend
-  ( -- * Grisette.Internal.SBV backend configuration
+  ( -- * SMT backend configuration
+    GrisetteSMTConfig (..),
+    boolector,
+    bitwuzla,
+    cvc4,
+    cvc5,
+    yices,
+    dReal,
+    z3,
+    mathSAT,
+    abc,
+
+    -- * Changing the extra configurations
     ApproximationConfig (..),
     ExtraConfig (..),
     precise,
-    approx,
+    approximate,
     withTimeout,
     clearTimeout,
-    withApprox,
-    clearApprox,
-    GrisetteSMTConfig (..),
 
     -- * SBV backend solver configuration
     SBV.SMTConfig (..),
-    SBV.boolector,
-    SBV.bitwuzla,
-    SBV.cvc4,
-    SBV.cvc5,
-    SBV.yices,
-    SBV.dReal,
-    SBV.z3,
-    SBV.mathSAT,
-    SBV.abc,
     SBV.Timing (..),
+    SBV.SMTSolver (..),
   )
 where
 
@@ -41,10 +42,17 @@ import Grisette.Internal.Backend.Solving
   ( ApproximationConfig (..),
     ExtraConfig (..),
     GrisetteSMTConfig (..),
-    approx,
-    clearApprox,
+    abc,
+    approximate,
+    bitwuzla,
+    boolector,
     clearTimeout,
+    cvc4,
+    cvc5,
+    dReal,
+    mathSAT,
     precise,
-    withApprox,
     withTimeout,
+    yices,
+    z3,
   )

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -1012,7 +1012,7 @@ module Grisette.Core
     -- >>> res = mrgIf a (throwError Error1) (mrgIf b (return c) (throwError Error2)) :: ExceptT Error Union SymBool
     -- >>> res
     -- ExceptT {If (|| a (! b)) (If a (Left Error1) (Left Error2)) (Right c)}
-    -- >>> solveExcept (precise z3) (\case Left _ -> con False; Right x -> x) res
+    -- >>> solveExcept z3 (\case Left _ -> con False; Right x -> x) res
     -- Right (Model {a -> False :: Bool, b -> True :: Bool, c -> True :: Bool})
     --
     -- The solver call in the above example means that we want the solver to
@@ -1082,16 +1082,16 @@ module Grisette.Core
     -- >>> import Grisette.Backend
     -- >>> let x = "x" :: SymInteger
     -- >>> let y = "y" :: SymInteger
-    -- >>> solve (precise z3) (x + y .== 6 .&& x - y .== 20)
+    -- >>> solve z3 (x + y .== 6 .&& x - y .== 20)
     -- Right (Model {x -> 13 :: Integer, y -> -7 :: Integer})
-    -- >>> solve (precise z3) (x + y .== 6 .&& x - y .== 19)
+    -- >>> solve z3 (x + y .== 6 .&& x - y .== 19)
     -- Left Unsat
     --
-    -- The first parameter of 'solve' is the solver configuration.
-    -- Here it means that we should not perform any approximation, and should
-    -- use the Z3 solver.
+    -- The first parameter of 'solve' is the solver configuration. Here we are
+    -- using the configuration for the Z3 solver.
     --
-    -- The second parameter is the formula to be solved. It have the type 'SymBool'.
+    -- The second parameter is the formula to be solved. It has the type
+    -- 'SymBool'.
     --
     -- The 'solve' function would return a model if the formula is satisfiable.
     -- The model is a mapping from symbolic variables to concrete values,
@@ -1103,7 +1103,7 @@ module Grisette.Core
     -- evaluate symbolic values. The following code evaluates the product of
     -- x and y under the solution of the equation system.
     --
-    -- >>> Right m <- solve (precise z3) (x + y .== 6 .&& x - y .== 20)
+    -- >>> Right m <- solve z3 (x + y .== 6 .&& x - y .== 20)
     -- >>> evalSym False m (x * y)
     -- -91
     --

--- a/src/Grisette/Internal/Core/Data/Class/CEGISSolver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/CEGISSolver.hs
@@ -797,7 +797,7 @@ cegisMultiInputs config inputs toCEGISCondition =
 --
 -- >>> :set -XOverloadedStrings
 -- >>> let [x,c] = ["x","c"] :: [SymInteger]
--- >>> cegis (precise z3) x (\x -> cegisPrePost (x .> 0) (x * c .< 0 .&& c .> -2))
+-- >>> cegis z3 x (\x -> cegisPrePost (x .> 0) (x * c .< 0 .&& c .> -2))
 -- (...,CEGISSuccess (Model {c -> -1 :: Integer}))
 cegis ::
   ( ConfigurableSolver config handle,
@@ -934,7 +934,7 @@ cegisExceptStdVCMultiInputs config cexes f =
 --   translation _ = cegisPostCond (con True)
 -- :}
 --
--- >>> cegisExcept (precise z3) x translation res
+-- >>> cegisExcept z3 x translation res
 -- ([...],CEGISSuccess (Model {c -> -1 :: Integer}))
 cegisExcept ::
   ( UnionWithExcept t u e v,
@@ -1004,7 +1004,7 @@ cegisExceptVC config inputs f v =
 --     symAssert $ c .> -2
 -- :}
 --
--- >>> cegisExceptStdVC (precise z3) x res
+-- >>> cegisExceptStdVC z3 x res
 -- ([...],CEGISSuccess (Model {c -> -1 :: Integer}))
 cegisExceptStdVC ::
   ( UnionWithExcept t u VerificationConditions (),
@@ -1033,7 +1033,7 @@ cegisExceptStdVC config inputs f =
 --
 -- >>> :set -XOverloadedStrings
 -- >>> let [x,c] = ["x","c"] :: [SymInteger]
--- >>> cegisForAll (precise z3) x $ cegisPrePost (x .> 0) (x * c .< 0 .&& c .> -2)
+-- >>> cegisForAll z3 x $ cegisPrePost (x .> 0) (x * c .< 0 .&& c .> -2)
 -- (...,CEGISSuccess (Model {c -> -1 :: Integer}))
 cegisForAll ::
   ( ExtractSym forallInput,

--- a/src/Grisette/Internal/Core/Data/Class/Solver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Solver.hs
@@ -164,7 +164,7 @@ class Solver handle where
   --
   -- The solver keeps all the assertions used in the previous commands:
   --
-  -- >>> solver <- newSolver (precise z3)
+  -- >>> solver <- newSolver z3
   -- >>> solverSolve solver "a"
   -- Right (Model {a -> True :: Bool})
   -- >>> solverSolve solver $ symNot "a"
@@ -311,9 +311,9 @@ withSolver config action =
 
 -- | Solve a single formula. Find an assignment to it to make it true.
 --
--- >>> solve (precise z3) ("a" .&& ("b" :: SymInteger) .== 1)
+-- >>> solve z3 ("a" .&& ("b" :: SymInteger) .== 1)
 -- Right (Model {a -> True :: Bool, b -> 1 :: Integer})
--- >>> solve (precise z3) ("a" .&& symNot "a")
+-- >>> solve z3 ("a" .&& symNot "a")
 -- Left Unsat
 solve ::
   (ConfigurableSolver config handle) =>
@@ -327,7 +327,7 @@ solve config formula = withSolver config (`solverSolve` formula)
 -- | Solve a single formula while returning multiple models to make it true.
 -- The maximum number of desired models are given.
 --
--- > >>> solveMulti (precise z3) 4 ("a" .|| "b")
+-- > >>> solveMulti z3 4 ("a" .|| "b")
 -- > [Model {a -> True :: Bool, b -> False :: Bool},Model {a -> False :: Bool, b -> True :: Bool},Model {a -> True :: Bool, b -> True :: Bool}]
 solveMulti ::
   (ConfigurableSolver config handle) =>
@@ -368,7 +368,7 @@ instance UnionWithExcept (ExceptT e u v) u e v where
 --   translate _ = con True         -- non-errors are desirable
 -- :}
 --
--- >>> solveExcept (precise z3) translate res
+-- >>> solveExcept z3 translate res
 -- Right (Model {x -> 1 :: Integer})
 solveExcept ::
   ( UnionWithExcept t u e v,

--- a/test/Grisette/Backend/CEGISTests.hs
+++ b/test/Grisette/Backend/CEGISTests.hs
@@ -10,7 +10,6 @@ module Grisette.Backend.CEGISTests (cegisTests) where
 
 import Control.Monad.Except (ExceptT)
 import Data.Proxy (Proxy (Proxy))
-import qualified Data.SBV as SBV
 import Data.String (IsString (fromString))
 import GHC.Stack (HasCallStack)
 import Grisette
@@ -37,7 +36,6 @@ import Grisette
     cegisMultiInputs,
     cegisPostCond,
     mrgIf,
-    precise,
     solve,
     symAssert,
     symAssume,
@@ -106,7 +104,7 @@ testCegis config shouldSuccess inputs bs = do
 
 cegisTests :: Test
 cegisTests =
-  let unboundedConfig = precise SBV.z3
+  let unboundedConfig = z3
    in testGroup
         "CEGIS"
         [ testGroup
@@ -114,10 +112,10 @@ cegisTests =
             [ testCase "Empty symbolic inputs makes cegis work like solve" $ do
                 (_, CEGISSuccess m1) <-
                   cegisMultiInputs
-                    (precise z3)
+                    z3
                     [1 :: Integer, 2]
                     (\idx -> cegisPostCond $ fromString $ "a" ++ show idx)
-                Right m2 <- solve (precise z3) ("a1" .&& "a2")
+                Right m2 <- solve z3 ("a1" .&& "a2")
                 m1 @=? m2,
               testCase "Lowering of TabularFun" $ do
                 let s1 = "s1" :: SymInteger =~> SymInteger

--- a/test/Grisette/Backend/LoweringTests.hs
+++ b/test/Grisette/Backend/LoweringTests.hs
@@ -36,10 +36,10 @@ import Grisette
   )
 import Grisette.Internal.Backend.Solving
   ( GrisetteSMTConfig (sbvConfig),
-    approx,
+    approximate,
     lowerSinglePrim,
     lowerSinglePrimCached,
-    precise,
+    z3,
   )
 import Grisette.Internal.Backend.SymBiMap
   ( SymBiMap (biMapToSBV),
@@ -49,7 +49,20 @@ import Grisette.Internal.SymPrim.Prim.SomeTerm
   ( SomeTerm (SomeTerm),
   )
 import Grisette.Internal.SymPrim.Prim.Term
-  ( FPTrait (FPIsInfinite, FPIsNaN, FPIsNegative, FPIsNegativeInfinite, FPIsNegativeZero, FPIsNormal, FPIsPoint, FPIsPositive, FPIsPositiveInfinite, FPIsPositiveZero, FPIsSubnormal, FPIsZero),
+  ( FPTrait
+      ( FPIsInfinite,
+        FPIsNaN,
+        FPIsNegative,
+        FPIsNegativeInfinite,
+        FPIsNegativeZero,
+        FPIsNormal,
+        FPIsPoint,
+        FPIsPositive,
+        FPIsPositiveInfinite,
+        FPIsPositiveZero,
+        FPIsSubnormal,
+        FPIsZero
+      ),
     SBVRep (SBVType),
     SupportedPrim,
     Term,
@@ -260,8 +273,8 @@ testTernaryOpLowering config precond f name sbvfun = do
 
 loweringTests :: Test
 loweringTests =
-  let unboundedConfig = precise SBV.z3
-      boundedConfig = approx (Proxy @5) SBV.z3
+  let unboundedConfig = z3
+      boundedConfig = approximate (Proxy @5) z3
    in testGroup
         "Lowering"
         [ testGroup


### PR DESCRIPTION
Using `approx` for approximation isn't the preferred way, and we should almost always stick with `precise` and control the reasoning bit width with the types used during symbolic evaluation.

This pull request discouraged the use of `approx`, and we no longer require to use `precise` to indicate that we are doing precise reasoning. It is now the default.

Also, `approx` is renamed to `approximate`.