### PR TITLE
Introduce IEEEFPRoundingMode, fix printing of FP terms, and refine symbolic primitive documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
    [#217](https://github.com/lsrcz/grisette/pull/217))
 - Added `IEEEFPRoundingMode`.
   ([#219](https://github.com/lsrcz/grisette/pull/219))
+- Added `Show` instance for `SomeSym`.
+  ([#219](https://github.com/lsrcz/grisette/pull/219))
 
 ### Fixed
 - Fixed the printing of FP terms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
    [#214](https://github.com/lsrcz/grisette/pull/214),
    [#215](https://github.com/lsrcz/grisette/pull/215),
    [#217](https://github.com/lsrcz/grisette/pull/217))
+- Added `IEEEFPRoundingMode`.
+  ([#219](https://github.com/lsrcz/grisette/pull/219))
+
+### Fixed
+- Fixed the printing of FP terms.
+  ([#219](https://github.com/lsrcz/grisette/pull/219))
 
 ### Changed
 - [Breaking] Relaxed constraints for type classes, according to

--- a/src/Grisette.hs
+++ b/src/Grisette.hs
@@ -11,20 +11,20 @@
 -- Portability :   GHC only
 module Grisette
   ( -- | Grisette is a tool for performing symbolic evaluation on programs. With
-    -- Grisette, you can construct your own symbolic DSL, and get the symbolic
-    -- evaluator for it without the need of manually implementing the symbolic
-    -- evaluation algorithms. A brief introduction to symbolic evaluation is
-    -- available in the "Grisette.Core" module.
+    -- Grisette, you can construct your own symbolic DSL and obtain the symbolic
+    -- evaluator for it without manually implementing the symbolic evaluation
+    -- algorithms. A brief introduction to symbolic evaluation is available in
+    -- the "Grisette.Core" module.
     --
-    -- This module exports most of the Grisette core APIs. There are more
-    -- lifted library constructs in the submodules of @Grisette.Lib@.
-    -- Those modules are not exported here and should be imported explicitly.
-    -- For example, to use the lifted "Data.List" functions, you should import
+    -- This module exports most of the Grisette APIs. Additional lifted library
+    -- constructs are in the submodules of @Grisette.Lib@, which are not
+    -- exported here and should be imported explicitly. For example, to use
+    -- the lifted "Data.List" functions, you should import
     -- "Grisette.Lib.Data.List" explicitly.
     --
     -- Grisette also provides an experimental API for unifying symbolic and
     -- concrete code to avoid code duplication. This API is exported in the
-    -- "Grisette.Unified" module. This module should be imported qualified as
+    -- "Grisette.Unified" module. The module should be imported qualified, as
     -- it intentionally uses the same names as the "Grisette" module.
     --
     -- The following shows a typical import list:
@@ -34,9 +34,9 @@ module Grisette
     -- > import qualified Grisette.Unified as U
     -- > import qualified Grisette.Unified.Lib.Data.List as U
     --
-    -- Other highly experimental APIs are exported in the
-    -- "Grisette.Experimental" and its submodules. These APIs are not stable,
-    -- may be buggy, and does not follow the PVP rules.
+    -- Other highly experimental APIs are exported in "Grisette.Experimental"
+    -- and its submodules. These APIs are not stable, may be buggy and poorly
+    -- maintained, and do not follow the PVP rules.
 
     -- * Core modules
 

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -16,26 +16,30 @@ module Grisette.Core
   ( -- * Organization of the module
 
     -- | The module is organized by first introducing symbolic values, which
-    -- includes solvable types and unsolvable types. Solvable types are those
-    -- directly supported by the underlying solver. Other types are unsolvable.
-    -- They need 'Union' monadic container and 'Mergeable' instances to be
-    -- merged.
+    -- includes [solvable (primitive)](#g:solvable) types and
+    -- [unsolvable (non-primitive)](#g:unsolvable) types.
+    -- Solvable types are those directly supported by the underlying solver.
+    -- Examples include symbolic Booleans ('Grisette.SymPrim.SymBool'), integers
+    -- ('Grisette.SymPrim.SymInteger'), and bit vectors
+    -- (@'Grisette.SymPrim.SymWordN' n@). Other types are unsolvable. They need
+    -- 'Union' monadic container and 'Mergeable' instances to be merged.
     --
-    -- We elaborated the internal details of the symbolic values in the
+    -- We will elaborate the internal details of the symbolic values in the
     -- documentation, but it is likely that you can skip them and directly go
     -- through the APIs and the operations to start using Grisette.
     --
-    -- Various operations are provided for manipulating symbolic values,
-    -- including solvable and unsolvable types. Apart from the basic operations
-    -- for each type of symbolic values, we also provide generic operations for:
+    -- [Various operations](#g:symops) are provided for
+    -- manipulating symbolic values, including solvable and unsolvable types.
+    -- Apart from the basic operations for each type of symbolic values, we also
+    -- provide generic operations for:
     --
     -- * Symbolic equality and comparison ('SymEq', 'SymOrd')
     -- * Conversion between concrete and symbolic values ('ToCon', 'ToSym')
     -- * Merging of symbolic values ('Mergeable', 'SimpleMergeable', 'TryMerge')
     -- * Symbolic branching ('SymBranching')
     --
-    -- Additional utilities for building symbolic evaluation based applications
-    -- are also provided:
+    -- Additional tools for building symbolic evaluation based applications are
+    -- also provided:
     --
     -- * Pretty printing (e.g., 'Format')
     -- * Symbolic generation, or generating fresh symbolic values (e.g.,
@@ -45,8 +49,8 @@ module Grisette.Core
     -- * Substitutions for symbolic values given the solving results (e.g.,
     --  'ExtractSym', 'EvalSym', 'SubstSym').
     --
-    -- Finally some helpers for deriving instances for the type classes are
-    -- provided.
+    -- Finally [some utilities](#g:utils), including helpers for
+    -- deriving instances for the type classes are provided in this module.
 
     -- * Note for the examples in the documentation
 
@@ -137,7 +141,7 @@ module Grisette.Core
     -- >>> x + 1
     -- (+ 1 (ite a b c))
 
-    -- ** Unsolvable types (non-solver-primitive types)
+    -- ** Unsolvable types (non-solver-primitive types) #unsolvable#
 
     -- | __/Unsolvable types/__, on the other hand, are types that are not
     -- directly supported by the solver and cannot be fully merged into a
@@ -490,7 +494,8 @@ module Grisette.Core
     -- {If (&& a f) 1 (If (|| a f) 2 3)}
     --
     -- For more details on this, see the documentation for 'Union',
-    -- 'MergingStrategy', and "Grisette.Core#merging"
+    -- 'MergingStrategy', and the [merging section](#g:merging) in
+    -- this module.
 
     -- ** Working with user-defined types
 
@@ -986,7 +991,7 @@ module Grisette.Core
     ListSpec (..),
     SimpleListSpec (..),
 
-    -- * Error Handling
+    -- * Error Handling #errors#
 
     -- |
     -- Grisette supports using 'Control.Monad.Except.ExceptT' to handle errors,
@@ -1020,15 +1025,13 @@ module Grisette.Core
     -- The solver call in the above example means that we want the solver to
     -- find the conditions under which no error is thrown, and the result is
     -- true. For more details, please refer to the
-    -- [documentation of the solver APIs](#solver).
+    -- [documentation of the solver APIs](#g:solver).
     --
     -- For those who prefer to encode errors as assertions and assumptions,
     -- we provide the 'symAssert' and 'symAssume' functions. These functions
     -- relies on the 'TransformError' type class to transform the assertions
     -- and assumptions to the user-defined error type.
     -- See their documentation for details.
-
-    -- | #errors#
 
     -- ** Predefined errors
     AssertionError (..),
@@ -1049,9 +1052,7 @@ module Grisette.Core
     mapCBMCExceptT,
     withCBMCExceptT,
 
-    -- * Solver backend
-
-    -- | #solver#
+    -- * Solver backend #solver#
 
     -- | Grisette abstracts the solver backend with the 'Solver' type class,
     -- and the most basic solver call is the 'solve' function.
@@ -1282,7 +1283,7 @@ module Grisette.Core
     SubstSym2 (..),
     substSym2,
 
-    -- * Utilities
+    -- * Utilities #utils#
 
     -- ** Memoization
     htmemo,

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -236,11 +236,12 @@ module Grisette.Core
     --   symbolic IEEE-754 floating point numbers with @eb@ exponent bits and
     --   @sb@ significand bits)
     -- * @'Grisette.SymPrim.SymBool' t'Grisette.SymPrim.=~>' 'Grisette.SymPrim.SymBool'@
-    --   (@'Bool' t'Grisette.SymPrim.=->' 'Bool'@, symbolic uninterpreted functions)
+    --   (@'Bool' t'Grisette.SymPrim.=->' 'Bool'@, symbolic functions,
+    --   uninterpreted or represented as a table for the input-outputs
+    --   relations).
     -- * @'Grisette.SymPrim.SymBool' t'Grisette.SymPrim.-~>' 'Grisette.SymPrim.SymBool'@
     --   (@'Bool' t'Grisette.SymPrim.-->' 'Bool'@, symbolic functions,
-    --   uninterpreted or represented as a formula over some variables to
-    --   substitute.
+    --   uninterpreted or represented as a formula over some bound variables.
     --
     -- The bit-width of bit vector types and floating point types have their
     -- are checked at compile time.
@@ -311,7 +312,7 @@ module Grisette.Core
     slocsym,
     ilocsym,
 
-    -- * Basic symbolic operations
+    -- * Basic symbolic operations #symops#
 
     -- ** Basic logical operators
     LogicalOp (..),
@@ -370,6 +371,7 @@ module Grisette.Core
     fpIsPoint,
     SymIEEEFPTraits (..),
     IEEEConstants (..),
+    IEEEFPRoundingMode (..),
     IEEEFPOp (..),
     IEEEFPRoundingOp (..),
 
@@ -1519,6 +1521,7 @@ import Grisette.Internal.Core.Data.Class.GenSym
 import Grisette.Internal.Core.Data.Class.IEEEFP
   ( IEEEConstants (..),
     IEEEFPOp (..),
+    IEEEFPRoundingMode (..),
     IEEEFPRoundingOp (..),
     SymIEEEFPTraits (..),
     fpIsInfinite,

--- a/src/Grisette/Internal/Core/Data/Class/IEEEFP.hs
+++ b/src/Grisette/Internal/Core/Data/Class/IEEEFP.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}

--- a/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
@@ -48,7 +48,7 @@ import Grisette.Internal.SymPrim.TabularFun (type (=->))
 -- >>> :set -XFlexibleInstances
 -- >>> :set -XFunctionalDependencies
 
--- | ITE operator for solvable (see "Grisette.Core#solvable")s, including
+-- | ITE operator for solvable (see "Grisette.Core#g:solvable")s, including
 -- symbolic boolean, integer, etc.
 --
 -- >>> let a = "a" :: SymBool

--- a/src/Grisette/Internal/SymPrim/AllSyms.hs
+++ b/src/Grisette/Internal/SymPrim/AllSyms.hs
@@ -86,7 +86,8 @@ import Grisette.Internal.SymPrim.Prim.SomeTerm
   ( SomeTerm (SomeTerm),
   )
 import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep (underlyingTerm), pformat,
+  ( LinkedRep (underlyingTerm),
+    pformat,
   )
 import Grisette.Internal.SymPrim.Prim.TermUtils
   ( someTermsSize,

--- a/src/Grisette/Internal/SymPrim/AllSyms.hs
+++ b/src/Grisette/Internal/SymPrim/AllSyms.hs
@@ -86,7 +86,7 @@ import Grisette.Internal.SymPrim.Prim.SomeTerm
   ( SomeTerm (SomeTerm),
   )
 import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep (underlyingTerm),
+  ( LinkedRep (underlyingTerm), pformat,
   )
 import Grisette.Internal.SymPrim.Prim.TermUtils
   ( someTermsSize,
@@ -104,12 +104,22 @@ import Grisette.Internal.Utils.Derive (Arity0, Arity1)
 -- >>> import Grisette.SymPrim
 -- >>> import Grisette.Backend
 -- >>> import Data.Proxy
+-- >>> :set -XOverloadedStrings
 
 -- | Some symbolic value with 'LinkedRep' constraint.
 data SomeSym where
   SomeSym :: (LinkedRep con sym) => sym -> SomeSym
 
+instance Show SomeSym where
+  show (SomeSym s) = pformat $ underlyingTerm s
+
 -- | Extract all symbolic primitive values that are represented as SMT terms.
+--
+-- >>> allSyms (["a" + 1 :: SymInteger, -"b"], "c" :: SymBool)
+-- [(+ 1 a),(- b),c]
+--
+-- This is usually used for getting a statistical summary of the size of
+-- a symbolic value with 'allSymsSize'.
 --
 -- __Note:__ This type class can be derived for algebraic data types. You may
 -- need the @DerivingVia@ and @DerivingStrategies@ extenstions.
@@ -163,6 +173,8 @@ someSymsSize = someTermsSize . fmap someUnderlyingTerm
 --
 -- >>> allSymsSize ("a" :: SymInteger, "a" + "b" :: SymInteger, ("a" + "b") * "c" :: SymInteger)
 -- 5
+--
+-- The 5 terms are @a@, @b@, @(+ a b)@, @c@, and @(* (+ a b) c)@.
 allSymsSize :: (AllSyms a) => a -> Int
 allSymsSize = someSymsSize . allSyms
 

--- a/src/Grisette/Internal/SymPrim/BV.hs
+++ b/src/Grisette/Internal/SymPrim/BV.hs
@@ -130,6 +130,12 @@ import Text.ParserCombinators.ReadPrec
 import Text.Read (lift)
 import qualified Text.Read.Lex as L
 
+-- $setup
+-- >>> import Grisette.Core
+-- >>> import Grisette.SymPrim
+-- >>> import Grisette.Backend
+-- >>> import Data.Proxy
+
 -- | An exception that would be thrown when operations are performed on
 -- incompatible bit widths.
 data BitwidthMismatch = BitwidthMismatch
@@ -139,7 +145,21 @@ instance Exception BitwidthMismatch where
   displayException BitwidthMismatch = "Bit width does not match"
 
 -- |
--- Symbolic unsigned bit vectors.
+-- Unsigned bit vector type. Indexed with the bit width. Signedness affect the
+-- semantics of the operations, including comparison/extension, etc.
+--
+-- >>> :set -XOverloadedStrings -XDataKinds -XBinaryLiterals
+-- >>> 3 + 5 :: WordN 5
+-- 0b01000
+-- >>> sizedBVConcat (0b101 :: WordN 3) (0b110 :: WordN 3)
+-- 0b101110
+-- >>> sizedBVExt (Proxy @6) (0b101 :: WordN 3)
+-- 0b000101
+-- >>> (8 :: WordN 4) < (7 :: WordN 4)
+-- False
+--
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype WordN (n :: Nat) = WordN {unWordN :: Integer}
   deriving (Eq, Ord, Generic, Lift, Hashable, NFData)
 
@@ -193,7 +213,21 @@ instance (KnownNat n, 1 <= n) => Read (WordN n) where
   readList = readListDefault
 
 -- |
--- Symbolic signed bit vectors.
+-- Signed bit vector type. Indexed with the bit width. Signedness affects the
+-- semantics of the operations, including comparison/extension, etc.
+--
+-- >>> :set -XOverloadedStrings -XDataKinds -XBinaryLiterals
+-- >>> 3 + 5 :: IntN 5
+-- 0b01000
+-- >>> sizedBVConcat (0b101 :: IntN 3) (0b110 :: IntN 3)
+-- 0b101110
+-- >>> sizedBVExt (Proxy @6) (0b101 :: IntN 3)
+-- 0b111101
+-- >>> (8 :: IntN 4) < (7 :: IntN 4)
+-- True
+--
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype IntN (n :: Nat) = IntN {unIntN :: Integer}
   deriving (Eq, Generic, Lift, Hashable, NFData)
 

--- a/src/Grisette/Internal/SymPrim/BV.hs
+++ b/src/Grisette/Internal/SymPrim/BV.hs
@@ -158,7 +158,7 @@ instance Exception BitwidthMismatch where
 -- >>> (8 :: WordN 4) < (7 :: WordN 4)
 -- False
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype WordN (n :: Nat) = WordN {unWordN :: Integer}
   deriving (Eq, Ord, Generic, Lift, Hashable, NFData)
@@ -226,7 +226,7 @@ instance (KnownNat n, 1 <= n) => Read (WordN n) where
 -- >>> (8 :: IntN 4) < (7 :: IntN 4)
 -- True
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype IntN (n :: Nat) = IntN {unIntN :: Integer}
   deriving (Eq, Generic, Lift, Hashable, NFData)

--- a/src/Grisette/Internal/SymPrim/FP.hs
+++ b/src/Grisette/Internal/SymPrim/FP.hs
@@ -80,6 +80,12 @@ import Language.Haskell.TH.Syntax (Lift (liftTyped))
 import Test.QuickCheck (frequency, oneof)
 import qualified Test.QuickCheck as QC
 
+-- $setup
+-- >>> import Grisette.Core
+-- >>> import Grisette.SymPrim
+-- >>> import Grisette.Backend
+-- >>> import Data.Proxy
+
 bvIsNonZeroFromGEq1 ::
   forall w r proxy.
   (1 <= w) =>
@@ -95,6 +101,13 @@ type ValidFP (eb :: Nat) (sb :: Nat) = ValidFloat eb sb
 
 -- | IEEE 754 floating-point number with @eb@ exponent bits and @sb@ significand
 -- bits.
+--
+-- >>> :set -XDataKinds
+-- >>> 1.0 + 2.0 :: FP 11 53
+-- 3.0
+--
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype FP (eb :: Nat) (sb :: Nat) = FP {unFP :: FloatingPoint eb sb}
   deriving newtype (Eq, Show)
 
@@ -276,8 +289,15 @@ data FPRoundingMode
     RTN
   | -- | Round towards zero.
     RTZ
-  deriving (Eq, Ord, Show, Generic, Lift)
+  deriving (Eq, Ord, Generic, Lift)
   deriving anyclass (Hashable, NFData)
+
+instance Show FPRoundingMode where
+  show RNE = "rne"
+  show RNA = "rna"
+  show RTP = "rtp"
+  show RTN = "rtn"
+  show RTZ = "rtz"
 
 -- | All IEEE 754 rounding modes.
 allFPRoundingMode :: [FPRoundingMode]

--- a/src/Grisette/Internal/SymPrim/FP.hs
+++ b/src/Grisette/Internal/SymPrim/FP.hs
@@ -106,7 +106,7 @@ type ValidFP (eb :: Nat) (sb :: Nat) = ValidFloat eb sb
 -- >>> 1.0 + 2.0 :: FP 11 53
 -- 3.0
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype FP (eb :: Nat) (sb :: Nat) = FP {unFP :: FloatingPoint eb sb}
   deriving newtype (Eq, Show)

--- a/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/PEvalFP.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/PEvalFP.hs
@@ -156,7 +156,7 @@ sbvFPBinaryTerm FPMax = SBV.fpMax
 {-# INLINE sbvFPBinaryTerm #-}
 
 pevalFPRoundingUnaryTerm ::
-  (ValidFP eb sb, SupportedPrim (FP eb sb)) =>
+  (ValidFP eb sb, SupportedPrim (FP eb sb), SupportedPrim FPRoundingMode) =>
   FPRoundingUnaryOp ->
   Term FPRoundingMode ->
   Term (FP eb sb) ->
@@ -175,7 +175,7 @@ sbvFPRoundingUnaryTerm FPRoundToIntegral = SBV.fpRoundToIntegral
 {-# INLINE sbvFPRoundingUnaryTerm #-}
 
 pevalFPRoundingBinaryTerm ::
-  (ValidFP eb sb, SupportedPrim (FP eb sb)) =>
+  (ValidFP eb sb, SupportedPrim (FP eb sb), SupportedPrim FPRoundingMode) =>
   FPRoundingBinaryOp ->
   Term FPRoundingMode ->
   Term (FP eb sb) ->

--- a/src/Grisette/Internal/SymPrim/Prim/Model.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Model.hs
@@ -185,7 +185,10 @@ import Unsafe.Coerce (unsafeCoerce)
 -- >>> import Grisette.SymPrim
 -- >>> :set -XFlexibleContexts
 
--- | Symbolic constant set.
+-- | Set of symbols.
+--
+-- Check 'Grisette.Core.SymbolSetOps' for operations, and
+-- 'Grisette.Core.SymbolSetRep' for manual constructions.
 newtype SymbolSet = SymbolSet {unSymbolSet :: S.HashSet SomeTypedSymbol}
   deriving (Eq, Generic, Hashable)
 
@@ -207,6 +210,9 @@ instance Show SymbolSet where
       go0 (x : xs) = x ++ ", " ++ go0 xs
 
 -- | Model returned by the solver.
+--
+-- Check 'Grisette.Core.ModelOps' for operations, and 'Grisette.Core.ModelRep'
+-- for manual constructions.
 newtype Model = Model {unModel :: M.HashMap SomeTypedSymbol ModelValue}
   deriving (Eq, Generic, Hashable)
 

--- a/src/Grisette/Internal/SymPrim/SomeBV.hs
+++ b/src/Grisette/Internal/SymPrim/SomeBV.hs
@@ -752,31 +752,31 @@ instance
 
 -- Synonyms
 
--- | Type synonym for 'SomeBV' with concrete signed bitvectors.
+-- | Type synonym for 'SomeBV' for concrete signed bitvectors.
 type SomeIntN = SomeBV IntN
 
--- | Pattern synonym for 'SomeBV' with concrete signed bitvectors.
+-- | Pattern synonym for 'SomeBV' for concrete signed bitvectors.
 pattern SomeIntN :: () => (KnownNat n, 1 <= n) => IntN n -> SomeIntN
 pattern SomeIntN a = SomeBV a
 
--- | Type synonym for 'SomeBV' with concrete unsigned bitvectors.
+-- | Type synonym for 'SomeBV' for concrete unsigned bitvectors.
 type SomeWordN = SomeBV WordN
 
--- | Pattern synonym for 'SomeBV' with concrete unsigned bitvectors.
+-- | Pattern synonym for 'SomeBV' for concrete unsigned bitvectors.
 pattern SomeWordN :: () => (KnownNat n, 1 <= n) => WordN n -> SomeWordN
 pattern SomeWordN a = SomeBV a
 
--- | Type synonym for 'SomeBV' with symbolic signed bitvectors.
+-- | Type synonym for 'SomeBV' for symbolic signed bitvectors.
 type SomeSymIntN = SomeBV SymIntN
 
--- | Pattern synonym for 'SomeBV' with symbolic signed bitvectors.
+-- | Pattern synonym for 'SomeBV' for symbolic signed bitvectors.
 pattern SomeSymIntN :: () => (KnownNat n, 1 <= n) => SymIntN n -> SomeSymIntN
 pattern SomeSymIntN a = SomeBV a
 
--- | Type synonym for 'SomeBV' with symbolic unsigned bitvectors.
+-- | Type synonym for 'SomeBV' for symbolic unsigned bitvectors.
 type SomeSymWordN = SomeBV SymWordN
 
--- | Pattern synonym for 'SomeBV' with symbolic unsigned bitvectors.
+-- | Pattern synonym for 'SomeBV' for symbolic unsigned bitvectors.
 pattern SomeSymWordN :: () => (KnownNat n, 1 <= n) => SymWordN n -> SomeSymWordN
 pattern SomeSymWordN a = SomeBV a
 

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -162,8 +162,8 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> (8 :: SymIntN 4) .< (7 :: SymIntN 4)
 -- true
 --
--- More symbolic operations are available. Please refer to the documentation
--- for the type class instances.
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype SymIntN (n :: Nat) = SymIntN {underlyingIntNTerm :: Term (IntN n)}
   deriving (Lift, NFData, Generic)
 
@@ -193,8 +193,8 @@ type SymIntN64 = SymIntN 64
 -- >>> (8 :: SymWordN 4) .< (7 :: SymWordN 4)
 -- false
 --
--- More symbolic operations are available. Please refer to the documentation
--- for the type class instances.
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype SymWordN (n :: Nat) = SymWordN {underlyingWordNTerm :: Term (WordN n)}
   deriving (Lift, NFData, Generic)
 

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -162,7 +162,7 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> (8 :: SymIntN 4) .< (7 :: SymIntN 4)
 -- true
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype SymIntN (n :: Nat) = SymIntN {underlyingIntNTerm :: Term (IntN n)}
   deriving (Lift, NFData, Generic)
@@ -193,7 +193,7 @@ type SymIntN64 = SymIntN 64
 -- >>> (8 :: SymWordN 4) .< (7 :: SymWordN 4)
 -- false
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype SymWordN (n :: Nat) = SymWordN {underlyingWordNTerm :: Term (WordN n)}
   deriving (Lift, NFData, Generic)

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -27,12 +27,12 @@
 -- Stability   :   Experimental
 -- Portability :   GHC only
 module Grisette.Internal.SymPrim.SymBV
-  ( SymWordN (..),
+  ( SymWordN (SymWordN),
     SymWordN8,
     SymWordN16,
     SymWordN32,
     SymWordN64,
-    SymIntN (..),
+    SymIntN (SymIntN),
     SymIntN8,
     SymIntN16,
     SymIntN32,

--- a/src/Grisette/Internal/SymPrim/SymBool.hs
+++ b/src/Grisette/Internal/SymPrim/SymBool.hs
@@ -46,7 +46,7 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> "a" .&& "b" :: SymBool
 -- (&& a b)
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype SymBool = SymBool {underlyingBoolTerm :: Term Bool}
   deriving (Lift, NFData, Generic)

--- a/src/Grisette/Internal/SymPrim/SymBool.hs
+++ b/src/Grisette/Internal/SymPrim/SymBool.hs
@@ -46,8 +46,8 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> "a" .&& "b" :: SymBool
 -- (&& a b)
 --
--- More symbolic operations are available. Please refer to the documentation
--- for the type class instances.
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype SymBool = SymBool {underlyingBoolTerm :: Term Bool}
   deriving (Lift, NFData, Generic)
 

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -20,7 +20,7 @@ module Grisette.Internal.SymPrim.SymFP
     SymFP16,
     SymFP32,
     SymFP64,
-    SymFPRoundingMode (..),
+    SymFPRoundingMode (SymFPRoundingMode),
   )
 where
 

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -55,8 +55,23 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
   )
 import Language.Haskell.TH.Syntax (Lift)
 
+-- $setup
+-- >>> import Grisette.Core
+-- >>> import Grisette.SymPrim
+-- >>> import Grisette.Backend
+-- >>> import Data.Proxy
+
 -- | Symbolic IEEE 754 floating-point number with @eb@ exponent bits and @sb@
 -- significand bits.
+--
+-- >>> :set -XOverloadedStrings -XDataKinds
+-- >>> "a" + 2.0 :: SymFP 11 53
+-- (+ a 2.0)
+-- >>> symFpAdd rne "a" 2.0 :: SymFP 11 53
+-- (fp.add rne a 2.0)
+--
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype SymFP eb sb = SymFP {underlyingFPTerm :: Term (FP eb sb)}
   deriving (Lift, Generic)
   deriving anyclass (NFData)

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -70,7 +70,7 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> symFpAdd rne "a" 2.0 :: SymFP 11 53
 -- (fp.add rne a 2.0)
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype SymFP eb sb = SymFP {underlyingFPTerm :: Term (FP eb sb)}
   deriving (Lift, Generic)

--- a/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
@@ -94,8 +94,11 @@ infixr 0 -~>
 -- \(a:ARG :: Integer) -> (+ 1 a:ARG)
 --
 -- This general symbolic function needs to be applied to symbolic values:
+--
 -- >>> f # ("a" :: SymInteger)
 -- (+ 1 a)
+-- >>> f # (2 :: SymInteger)
+-- 3
 (-->) ::
   (SupportedPrim ca, SupportedPrim cb, LinkedRep cb sb) =>
   TypedSymbol ca ->

--- a/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
@@ -22,7 +22,7 @@
 -- Stability   :   Experimental
 -- Portability :   GHC only
 module Grisette.Internal.SymPrim.SymGeneralFun
-  ( type (-~>) (..),
+  ( type (-~>) (SymGeneralFun),
     (-->),
   )
 where

--- a/src/Grisette/Internal/SymPrim/SymInteger.hs
+++ b/src/Grisette/Internal/SymPrim/SymInteger.hs
@@ -51,8 +51,8 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> "a" + 1 :: SymInteger
 -- (+ 1 a)
 --
--- More symbolic operations are available. Please refer to the documentation
--- for the type class instances.
+-- More operations are available. Please refer to "Grisette.Core#symops" for
+-- more information.
 newtype SymInteger = SymInteger {underlyingIntegerTerm :: Term Integer}
   deriving (Lift, NFData, Generic)
 

--- a/src/Grisette/Internal/SymPrim/SymInteger.hs
+++ b/src/Grisette/Internal/SymPrim/SymInteger.hs
@@ -51,7 +51,7 @@ import Language.Haskell.TH.Syntax (Lift)
 -- >>> "a" + 1 :: SymInteger
 -- (+ 1 a)
 --
--- More operations are available. Please refer to "Grisette.Core#symops" for
+-- More operations are available. Please refer to "Grisette.Core#g:symops" for
 -- more information.
 newtype SymInteger = SymInteger {underlyingIntegerTerm :: Term Integer}
   deriving (Lift, NFData, Generic)

--- a/src/Grisette/Internal/SymPrim/SymTabularFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymTabularFun.hs
@@ -18,7 +18,10 @@
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-module Grisette.Internal.SymPrim.SymTabularFun (type (=~>) (..)) where
+module Grisette.Internal.SymPrim.SymTabularFun
+  ( type (=~>) (SymTabularFun),
+  )
+where
 
 import Control.DeepSeq (NFData (rnf))
 import Data.Hashable (Hashable (hashWithSalt))

--- a/src/Grisette/SymPrim.hs
+++ b/src/Grisette/SymPrim.hs
@@ -40,9 +40,9 @@ module Grisette.SymPrim
     --   input-output relations).
     -- * @'SymBool' t'-~>' 'SymBool'@ (@'Bool' t'-->' 'Bool'@, symbolic
     --   functions, uninterpreted or represented as a formula over some
-    --   bound variables.
+    --   bound variables).
     --
-    -- This module provides an operations to extract all primitive values from a
+    -- This module provides an operation to extract all primitive values from a
     -- symbolic value, with 'AllSyms'. The module also provides the
     -- representation for symbols ('TypedSymbol'), symbol sets ('SymbolSet'),
     -- and models ('Model'). They are useful when working with

--- a/test/Grisette/Backend/TermRewritingTests.hs
+++ b/test/Grisette/Backend/TermRewritingTests.hs
@@ -108,8 +108,8 @@ bitwuzlaConfig = do
         .&& symNot (symFpIsPositiveInfinite (con $ -4.7e-38 :: SymFP32))
         .&& ( symIte
                 "bool"
-                (con $ fpPositiveInfinite :: SymFP32)
-                (con $ fpNegativeInfinite)
+                (con fpPositiveInfinite :: SymFP32)
+                (con fpNegativeInfinite)
                 .== "m"
             )
   case v of


### PR DESCRIPTION
Introduce `IEEEFPRoundingMode`, fix printing of FP terms, and refine symbolic primitive documentation.