### PR TITLE
Re-export SupportedPrim

### DIFF
--- a/src/Grisette/SymPrim.hs
+++ b/src/Grisette/SymPrim.hs
@@ -141,6 +141,7 @@ module Grisette.SymPrim
     type (-~>) (..),
 
     -- ** Basic constraints
+    SupportedPrim,
     SymRep (SymType),
     ConRep (ConType),
     LinkedRep,
@@ -219,6 +220,7 @@ import Grisette.Internal.SymPrim.Prim.Model
 import Grisette.Internal.SymPrim.Prim.Term
   ( ConRep (..),
     LinkedRep,
+    SupportedPrim,
     SymRep (..),
     TypedSymbol (..),
   )


### PR DESCRIPTION
We have removed `SupportedPrim` from the export list of `Grisette.SymPrim`. However, we found that it is used in user-level code with uninterpreted functions so we should not remove it.