### PR TITLE
Add *1 instances (SymEq1, etc.) for Union, add all (incoherent) conversions from/to (Identity a)/a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#219](https://github.com/lsrcz/grisette/pull/219))
 - Added `Show` instance for `SomeSym`.
   ([#219](https://github.com/lsrcz/grisette/pull/219))
+- Added incoherent conversions (`ToSym`, `ToCon`) from/to `Identity a` and `a`.
+  ([#221](https://github.com/lsrcz/grisette/pull/221))
 
 ### Fixed
 - Fixed the printing of FP terms.
@@ -33,9 +35,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - [Breaking] Relaxed constraints for type classes, according to
-  https://github.com/haskell/core-libraries-committee/issues/10.
+  https://github.com/haskell/core-libraries-committee/issues/10. One problem
+  this causes is that the instances for `Union` will no longer be able to always
+  merge the results. This is unfortunate, but should not be critical.
   ([#213](https://github.com/lsrcz/grisette/pull/213),
-   [#214](https://github.com/lsrcz/grisette/pull/214))
+   [#214](https://github.com/lsrcz/grisette/pull/214),
+   [#221](https://github.com/lsrcz/grisette/pull/221))
 - [Breaking] Rewritten the generic derivation mechanism.
   ([#213](https://github.com/lsrcz/grisette/pull/213),
    [#214](https://github.com/lsrcz/grisette/pull/214),

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -788,6 +788,7 @@ module Grisette.Core
     unionUnaryOp,
     unionBinOp,
     liftUnion,
+    unionMergingStrategy,
     liftToMonadUnion,
     unionSize,
 
@@ -1322,12 +1323,6 @@ module Grisette.Core
     genericMrgIte,
     genericLiftMrgIte,
 
-    -- *** 'EvalSym'
-    EvalSymArgs (..),
-    GEvalSym (..),
-    genericEvalSym,
-    genericLiftEvalSym,
-
     -- *** 'ToCon'
     ToConArgs (..),
     GToCon (..),
@@ -1340,11 +1335,23 @@ module Grisette.Core
     genericToSym,
     genericLiftToSym,
 
-    -- *** ExtractSym
+    -- *** 'EvalSym'
+    EvalSymArgs (..),
+    GEvalSym (..),
+    genericEvalSym,
+    genericLiftEvalSym,
+
+    -- *** 'ExtractSym'
     ExtractSymArgs (..),
     GExtractSym (..),
     genericExtractSym,
     genericLiftExtractSym,
+
+    -- *** 'SubstSym'
+    SubstSymArgs (..),
+    GSubstSym (..),
+    genericSubstSym,
+    genericLiftSubstSym,
 
     -- *** 'Format'
     genericFormatPrec,
@@ -1354,12 +1361,6 @@ module Grisette.Core
     FormatArgs (..),
     GFormat (..),
     FormatType (..),
-
-    -- *** 'SubstSym'
-    SubstSymArgs (..),
-    GSubstSym (..),
-    genericSubstSym,
-    genericLiftSubstSym,
   )
 where
 
@@ -1382,6 +1383,7 @@ import Grisette.Internal.Core.Control.Monad.Union
     liftToMonadUnion,
     liftUnion,
     unionBinOp,
+    unionMergingStrategy,
     unionSize,
     unionUnaryOp,
   )

--- a/src/Grisette/Internal/Core/Data/Class/SymOrd.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SymOrd.hs
@@ -85,7 +85,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
-import Grisette.Internal.Core.Control.Monad.Union (Union, liftToMonadUnion)
+import Grisette.Internal.Core.Control.Monad.Union (Union)
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp, symIte)
 import Grisette.Internal.Core.Data.Class.LogicalOp
   ( LogicalOp (symNot, (.&&), (.||)),
@@ -503,27 +503,33 @@ SORD_BV(SymWordN)
 #endif
 
 -- Union
-instance (SymOrd a, Mergeable a) => SymOrd (Union a) where
+instance (SymOrd a) => SymOrd (Union a) where
   x .<= y = simpleMerge $ do
-    x1 <- tryMerge x
-    y1 <- tryMerge y
+    x1 <- x
+    y1 <- y
     mrgSingle $ x1 .<= y1
   x .< y = simpleMerge $ do
-    x1 <- tryMerge x
-    y1 <- tryMerge y
+    x1 <- x
+    y1 <- y
     mrgSingle $ x1 .< y1
   x .>= y = simpleMerge $ do
-    x1 <- tryMerge x
-    y1 <- tryMerge y
+    x1 <- x
+    y1 <- y
     mrgSingle $ x1 .>= y1
   x .> y = simpleMerge $ do
-    x1 <- tryMerge x
-    y1 <- tryMerge y
+    x1 <- x
+    y1 <- y
     mrgSingle $ x1 .> y1
-  x `symCompare` y = liftToMonadUnion $ do
-    x1 <- tryMerge x
-    y1 <- tryMerge y
+  x `symCompare` y = tryMerge $ do
+    x1 <- x
+    y1 <- y
     x1 `symCompare` y1
+
+instance SymOrd1 Union where
+  liftSymCompare f x y = tryMerge $ do
+    x1 <- x
+    y1 <- y
+    f x1 y1
 
 -- Instances
 deriveBuiltins

--- a/src/Grisette/Internal/Core/Data/Class/ToCon.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ToCon.hs
@@ -141,6 +141,9 @@ class ToCon a b where
   -- Nothing
   toCon :: a -> Maybe b
 
+instance {-# INCOHERENT #-} ToCon v v where
+  toCon = Just
+
 -- | Lifting of 'ToCon' to unary type constructors.
 class (forall a b. (ToCon a b) => ToCon (f1 a) (f2 b)) => ToCon1 f1 f2 where
   -- | Lift a conversion to concrete function to unary type constructors.
@@ -510,11 +513,11 @@ instance
 instance {-# INCOHERENT #-} (ToCon a b) => ToCon (Identity a) (Identity b) where
   toCon = toCon1
 
-instance ToCon (Identity v) v where
-  toCon = Just . runIdentity
+instance {-# INCOHERENT #-} (ToCon a b) => ToCon (Identity a) b where
+  toCon = toCon . runIdentity
 
-instance ToCon v (Identity v) where
-  toCon = Just . Identity
+instance {-# INCOHERENT #-} (ToCon a b) => ToCon a (Identity b) where
+  toCon = fmap Identity . toCon
 
 instance ToCon1 Identity Identity where
   liftToCon f (Identity a) = Identity <$> f a

--- a/src/Grisette/Internal/TH/Util.hs
+++ b/src/Grisette/Internal/TH/Util.hs
@@ -238,5 +238,5 @@ putHaddock name = addModFinalizer . putDoc (DeclDoc name)
 -- | Put a haddock comment on a declaration.
 -- (No-op because compiling with GHC < 9.2)
 putHaddock :: Name -> String -> Q ()
-putHaddock name _ = return ()
+putHaddock _ _ = return ()
 #endif

--- a/src/Grisette/Unified/Internal/BaseConstraint.hs
+++ b/src/Grisette/Unified/Internal/BaseConstraint.hs
@@ -51,7 +51,5 @@ type ConSymConversion conType symType t =
   ( ToCon t conType,
     ToSym conType t,
     ToCon symType t,
-    ToSym t symType,
-    ToCon t t,
-    ToSym t t
+    ToSym t symType
   )

--- a/test/Grisette/Core/Data/Class/ToConTests.hs
+++ b/test/Grisette/Core/Data/Class/ToConTests.hs
@@ -38,8 +38,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
 import Test.QuickCheck (ioProperty)
 
-toConForConcreteOkProp ::
-  (HasCallStack, ToCon v v, Show v, Eq v) => v -> Assertion
+toConForConcreteOkProp :: (HasCallStack, Show v, Eq v) => v -> Assertion
 toConForConcreteOkProp v = toCon v @?= Just v
 
 toConTests :: Test

--- a/test/Grisette/Core/Data/Class/ToSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ToSymTests.hs
@@ -35,8 +35,7 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
 import Test.QuickCheck (ioProperty)
 
-toSymForConcreteOkProp ::
-  (HasCallStack, ToSym v v, Show v, Eq v) => v -> Assertion
+toSymForConcreteOkProp :: (HasCallStack, Show v, Eq v) => v -> Assertion
 toSymForConcreteOkProp v = toSym v @?= v
 
 toSymTests :: Test


### PR DESCRIPTION
This pull request adds *1 instances like `SymEq1` for `Union`.

This change will cause the instances to no longer merge the values in the unions. For `EvalSym`, `SubstSym`, they will merge the result if the input union is merged. For `ToSym`/`ToCon`, they are not merged.

This is unfortunate, but should not be critical.

This pull request also adds `ToCon` and `ToSym` instances for all possible conversions between `Identity a` and `a`. This also means that the relations are now guaranteed to work on `ToCon a a` and `ToSym a a`.