### PR TITLE
Fix bugs with safe operations

### DIFF
--- a/src/Grisette/Internal/SymPrim/FP.hs
+++ b/src/Grisette/Internal/SymPrim/FP.hs
@@ -440,7 +440,6 @@ BIT_CAST_OR_VIA_INTERMEDIATE(FP16, Int16, WordN16)
 -- | An error thrown when bitcasting or converting t'FP' NaN to other types.
 data NotRepresentableFPError
   = NaNError
-  | InfError
   | FPUnderflowError
   | FPOverflowError
   deriving (Show, Eq, Ord, Generic)
@@ -448,8 +447,6 @@ data NotRepresentableFPError
 instance Exception NotRepresentableFPError where
   displayException NaNError =
     "Converting NaN value cannot be done precisely with SMT-LIB2"
-  displayException InfError =
-    "Converting Inf values to non-FP types cannot be done"
   displayException FPUnderflowError =
     "Converting FP values that cannot be represented by non-FP types due to "
       <> "underflowing"

--- a/src/Grisette/Unified/Internal/UnifiedBV.hs
+++ b/src/Grisette/Unified/Internal/UnifiedBV.hs
@@ -39,6 +39,7 @@ import Data.Kind (Constraint, Type)
 import GHC.TypeNats (KnownNat, Nat, type (<=))
 import Grisette.Internal.Core.Data.Class.BitCast (BitCast)
 import Grisette.Internal.Core.Data.Class.BitVector (BV, SizedBV)
+import Grisette.Internal.Core.Data.Class.SafeDiv (DivOr)
 import Grisette.Internal.Core.Data.Class.SignConversion (SignConversion)
 import Grisette.Internal.Core.Data.Class.SymRotate (SymRotate)
 import Grisette.Internal.Core.Data.Class.SymShift (SymShift)
@@ -111,6 +112,8 @@ type SomeBVPair mode word int =
   ( BVConstraint mode word int,
     BV word,
     BV int,
+    DivOr word,
+    DivOr int,
     ConSymConversion SomeWordN SomeSymWordN word,
     ConSymConversion SomeIntN SomeSymIntN int
   ) ::
@@ -129,6 +132,8 @@ class
     int ~ intn n,
     BitCast word int,
     BitCast int word,
+    DivOr word,
+    DivOr int,
     UnifiedFromIntegral mode (GetInteger mode) word,
     UnifiedFromIntegral mode (GetInteger mode) int,
     UnifiedFromIntegral mode word (GetInteger mode),


### PR DESCRIPTION
This pull request removed `InfError` from not representable floating point numbers, and fixed `DivOr` for `GetIntN` and `GetWordN`.