### PR TITLE
Make ToSym for Union merges again

### DIFF
--- a/src/Grisette/Internal/Core/Control/Monad/CBMCExcept.hs
+++ b/src/Grisette/Internal/Core/Control/Monad/CBMCExcept.hs
@@ -92,8 +92,8 @@ import Grisette.Internal.Core.Data.Class.SimpleMergeable
 import Grisette.Internal.Core.Data.Class.Solver (UnionWithExcept (extractUnionExcept))
 import Grisette.Internal.Core.Data.Class.SymEq (SymEq ((.==)))
 import Grisette.Internal.Core.Data.Class.SymOrd (SymOrd (symCompare, (.<), (.<=), (.>), (.>=)))
-import Grisette.Internal.Core.Data.Class.ToCon (ToCon (toCon))
-import Grisette.Internal.Core.Data.Class.ToSym (ToSym (toSym))
+import Grisette.Internal.Core.Data.Class.ToCon (ToCon (toCon), ToCon1)
+import Grisette.Internal.Core.Data.Class.ToSym (ToSym (toSym), ToSym1)
 import Grisette.Internal.Core.Data.Class.TryMerge
   ( TryMerge (tryMergeWithStrategy),
     tryMerge,
@@ -456,7 +456,7 @@ instance (SymOrd (m (CBMCEither e a))) => SymOrd (CBMCExceptT e m a) where
   symCompare (CBMCExceptT l) (CBMCExceptT r) = symCompare l r
 
 instance
-  (ToCon (m1 (CBMCEither e1 a)) (m2 (CBMCEither e2 b))) =>
+  (ToCon1 m1 m2, ToCon e1 e2, ToCon a b) =>
   ToCon (CBMCExceptT e1 m1 a) (CBMCExceptT e2 m2 b)
   where
   toCon (CBMCExceptT v) = CBMCExceptT <$> toCon v
@@ -468,7 +468,7 @@ instance
   toCon (CBMCExceptT v) = toCon v
 
 instance
-  (ToSym (m1 (CBMCEither e1 a)) (m2 (CBMCEither e2 b))) =>
+  (ToSym e1 e2, ToSym a b, ToSym1 m1 m2) =>
   ToSym (CBMCExceptT e1 m1 a) (CBMCExceptT e2 m2 b)
   where
   toSym (CBMCExceptT v) = CBMCExceptT $ toSym v

--- a/src/Grisette/Internal/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Internal/Core/Control/Monad/Union.hs
@@ -468,7 +468,7 @@ instance (ToSym a b) => ToSym (Union a) (Union b) where
   toSym = toSym1
 
 instance ToSym1 Union Union where
-  liftToSym = fmap
+  liftToSym f = tryMerge . fmap f
 
 instance ToSym (Union Bool) SymBool where
   toSym = simpleMerge . fmap con

--- a/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
@@ -52,6 +53,7 @@ module Grisette.Internal.Core.Data.Class.Mergeable
     buildStrategyList,
     resolveStrategy,
     resolveStrategy',
+    resolveMergeable1,
   )
 where
 
@@ -287,6 +289,15 @@ class
 rootStrategy1 :: (Mergeable a, Mergeable1 u) => MergingStrategy (u a)
 rootStrategy1 = liftRootStrategy rootStrategy
 {-# INLINE rootStrategy1 #-}
+
+-- | Workaround as GHC prior to 9.6 doesn't support quantified constraints
+-- reliably.
+--
+-- Similar to https://github.com/haskell/core-libraries-committee/issues/10,
+-- which is only available with 9.6 or higher.
+resolveMergeable1 ::
+  forall f a r. (Mergeable1 f, Mergeable a) => ((Mergeable (f a)) => r) -> r
+resolveMergeable1 v = v
 
 -- | Lifting of the 'Mergeable' class to binary type constructors.
 class

--- a/test/Grisette/Core/Control/Monad/UnionTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionTests.hs
@@ -252,7 +252,7 @@ unionTests =
         actual @?= expected,
       testCase "ToSym (Union a) (Union b)" $ do
         let actual = toSym (mrgSingle True :: Union Bool) :: Union SymBool
-        let expected = return (con True)
+        let expected = mrgSingle (con True)
         actual @?= expected,
       testCase "ToSym (Union Integer) SymInteger" $ do
         let actual = toSym (mrgIf "a" 1 2 :: Union Integer)

--- a/test/Grisette/Core/Data/Class/ToSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ToSymTests.hs
@@ -27,7 +27,7 @@ import Grisette
     Solvable (con, isym, ssym),
     SymBool,
     SymEq ((.==)),
-    ToSym (toSym),
+    ToSym (toSym), Mergeable
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
@@ -35,7 +35,8 @@ import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
 import Test.QuickCheck (ioProperty)
 
-toSymForConcreteOkProp :: (HasCallStack, Show v, Eq v) => v -> Assertion
+toSymForConcreteOkProp ::
+  (HasCallStack, Show v, Eq v, Mergeable v) => v -> Assertion
 toSymForConcreteOkProp v = toSym v @?= v
 
 toSymTests :: Test

--- a/test/Grisette/Core/Data/Class/ToSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ToSymTests.hs
@@ -24,10 +24,11 @@ import GHC.Stack (HasCallStack)
 import Grisette
   ( ITEOp (symIte),
     LogicalOp (symNot, (.&&), (.||)),
+    Mergeable,
     Solvable (con, isym, ssym),
     SymBool,
     SymEq ((.==)),
-    ToSym (toSym), Mergeable
+    ToSym (toSym),
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)


### PR DESCRIPTION
This pull request adds the `Mergeable` superclass to `ToSym`. Also adds `Mergeable` constraint to `liftToSym`. This enables us to merge the resulting `Union` when we do `toSym` from `Union` to `Union`.