### PR TITLE
Allow number literals in SomeBV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#239](https://github.com/lsrcz/grisette/pull/239),
    [#240](https://github.com/lsrcz/grisette/pull/240),
    [#243](https://github.com/lsrcz/grisette/pull/243))
+- Allow the use of number literals for `SomeBV`.
+  ([#245](https://github.com/lsrcz/grisette/pull/245))
 
 ### Fixed
 - Fixed model parsing for floating points.

--- a/src/Grisette/Internal/Core/Data/Class/EvalSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/EvalSym.hs
@@ -93,7 +93,7 @@ import Grisette.Internal.Core.Data.Class.ToCon
     toCon2,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Model (Model, evalTerm)
@@ -417,7 +417,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/ExtractSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ExtractSym.hs
@@ -86,7 +86,7 @@ import Grisette.Internal.Core.Control.Exception
     VerificationConditions,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Model
@@ -417,7 +417,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
@@ -130,8 +130,7 @@ import Grisette.Internal.Core.Data.Class.BitCast (bitCastOrCanonical)
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.SymPrim.AlgReal (AlgReal, AlgRealPoly, RealPoint)
 import Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch,
-    IntN,
+  ( IntN,
     WordN,
   )
 import Grisette.Internal.SymPrim.FP
@@ -822,7 +821,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/PPrint.hs
+++ b/src/Grisette/Internal/Core/Data/Class/PPrint.hs
@@ -128,7 +128,7 @@ import Grisette.Internal.Core.Control.Exception
   )
 import Grisette.Internal.Core.Data.Symbol (Identifier, Symbol)
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.Prim.Internal.Term ()
 import Grisette.Internal.SymPrim.Prim.Model
@@ -630,7 +630,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Monoid.Dual,
     ''Monoid.Sum,

--- a/src/Grisette/Internal/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SimpleMergeable.hs
@@ -93,7 +93,6 @@ import Grisette.Internal.Core.Data.Class.Mergeable
 import Grisette.Internal.Core.Data.Class.TryMerge
   ( TryMerge (tryMergeWithStrategy),
   )
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch)
 import Grisette.Internal.SymPrim.FP (ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->))
 import Grisette.Internal.SymPrim.Prim.Term
@@ -365,7 +364,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,),
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
-    ''BitwidthMismatch,
     ''Identity,
     ''Monoid.Dual,
     ''Monoid.Sum,

--- a/src/Grisette/Internal/Core/Data/Class/SubstSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SubstSym.hs
@@ -80,7 +80,7 @@ import Grisette.Internal.Core.Control.Exception
     VerificationConditions,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (substTerm, type (-->))
 import Grisette.Internal.SymPrim.Prim.Term
@@ -382,7 +382,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/SymEq.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SymEq.hs
@@ -81,7 +81,7 @@ import Grisette.Internal.Core.Control.Exception
 import Grisette.Internal.Core.Data.Class.LogicalOp (LogicalOp (symNot, (.&&)))
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.Prim.Term (pevalEqTerm)
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
@@ -346,7 +346,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/SymOrd.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SymOrd.hs
@@ -110,7 +110,7 @@ import Grisette.Internal.Core.Data.Class.TryMerge
     tryMerge,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError, ValidFP)
 import Grisette.Internal.SymPrim.Prim.Term
   ( PEvalOrdTerm
@@ -558,7 +558,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Identity,
     ''Monoid.Dual,

--- a/src/Grisette/Internal/Core/Data/Class/ToCon.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ToCon.hs
@@ -87,8 +87,7 @@ import Grisette.Internal.Core.Data.Class.Solvable
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
 import Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch,
-    IntN (IntN),
+  ( IntN (IntN),
     WordN (WordN),
   )
 import Grisette.Internal.SymPrim.FP (FP, FP32, FP64, FPRoundingMode, NotRepresentableFPError, ValidFP)
@@ -406,7 +405,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Monoid.Dual,
     ''Monoid.Sum,

--- a/src/Grisette/Internal/Core/Data/Class/ToSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ToSym.hs
@@ -95,8 +95,7 @@ import Grisette.Internal.Core.Data.Class.Mergeable
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
 import Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch,
-    IntN,
+  ( IntN,
     WordN,
   )
 import Grisette.Internal.SymPrim.FP
@@ -426,7 +425,6 @@ deriveBuiltins
     ''(,,,,,,,,,,,,,,),
     ''AssertionError,
     ''VerificationConditions,
-    ''BitwidthMismatch,
     ''NotRepresentableFPError,
     ''Monoid.Dual,
     ''Monoid.Sum,

--- a/src/Grisette/Internal/SymPrim/BV.hs
+++ b/src/Grisette/Internal/SymPrim/BV.hs
@@ -26,8 +26,7 @@
 -- Stability   :   Experimental
 -- Portability :   GHC only
 module Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch (..),
-    IntN (..),
+  ( IntN (..),
     IntN8,
     IntN16,
     IntN32,
@@ -44,7 +43,6 @@ import Control.Applicative (Alternative ((<|>)))
 import Control.DeepSeq (NFData)
 import Control.Exception
   ( ArithException (Overflow),
-    Exception (displayException),
     throw,
   )
 import Data.Bits
@@ -135,14 +133,6 @@ import qualified Text.Read.Lex as L
 -- >>> import Grisette.SymPrim
 -- >>> import Grisette.Backend
 -- >>> import Data.Proxy
-
--- | An exception that would be thrown when operations are performed on
--- incompatible bit widths.
-data BitwidthMismatch = BitwidthMismatch
-  deriving (Show, Eq, Ord, Generic)
-
-instance Exception BitwidthMismatch where
-  displayException BitwidthMismatch = "Bit width does not match"
 
 -- |
 -- Unsigned bit vector type. Indexed with the bit width. Signedness affect the

--- a/src/Grisette/SymPrim.hs
+++ b/src/Grisette/SymPrim.hs
@@ -71,7 +71,7 @@ module Grisette.SymPrim
 
     -- ** Runtime-sized bit-vector types
     SomeBV (..),
-    BitwidthMismatch (..),
+    SomeBVException (..),
     pattern SomeIntN,
     type SomeIntN,
     pattern SomeWordN,
@@ -87,7 +87,7 @@ module Grisette.SymPrim
     -- *** Some low-level helpers for writing instances for t'SomeBV'
 
     -- | The functions here will check the bitwidths of the input bit-vectors
-    -- and raise t'BitwidthMismatch' if they do not match.
+    -- and raise v'BitwidthMismatch' if they do not match.
     unsafeSomeBV,
     unarySomeBV,
     unarySomeBVR1,
@@ -226,8 +226,7 @@ import Grisette.Internal.SymPrim.AllSyms
     symsSize,
   )
 import Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch (..),
-    IntN,
+  ( IntN,
     IntN16,
     IntN32,
     IntN64,
@@ -281,6 +280,7 @@ import Grisette.Internal.SymPrim.Quantifier
   )
 import Grisette.Internal.SymPrim.SomeBV
   ( SomeBV (..),
+    SomeBVException (..),
     arbitraryBV,
     binSomeBV,
     binSomeBVR1,

--- a/src/Grisette/Unified/Internal/Class/UnifiedSafeDiv.hs
+++ b/src/Grisette/Unified/Internal/Class/UnifiedSafeDiv.hs
@@ -41,8 +41,8 @@ import Grisette.Internal.Core.Data.Class.SafeDiv
 import qualified Grisette.Internal.Core.Data.Class.SafeDiv
 import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.SomeBV
-  ( SomeIntN, 
-    SomeBVException,
+  ( SomeBVException,
+    SomeIntN,
     SomeSymIntN,
     SomeSymWordN,
     SomeWordN,

--- a/src/Grisette/Unified/Internal/Class/UnifiedSafeDiv.hs
+++ b/src/Grisette/Unified/Internal/Class/UnifiedSafeDiv.hs
@@ -39,9 +39,10 @@ import Grisette.Internal.Core.Data.Class.SafeDiv
     SafeDiv,
   )
 import qualified Grisette.Internal.Core.Data.Class.SafeDiv
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.SomeBV
-  ( SomeIntN,
+  ( SomeIntN, 
+    SomeBVException,
     SomeSymIntN,
     SomeSymWordN,
     SomeWordN,
@@ -214,12 +215,12 @@ instance
   withBaseSafeDiv r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeDiv
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeIntN
     m
   where
@@ -227,24 +228,24 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeDiv
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymIntN
     m
   where
   withBaseSafeDiv r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeDiv
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeWordN
     m
   where
@@ -252,12 +253,12 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeDiv
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymWordN
     m
   where

--- a/src/Grisette/Unified/Internal/Class/UnifiedSafeLinearArith.hs
+++ b/src/Grisette/Unified/Internal/Class/UnifiedSafeLinearArith.hs
@@ -37,9 +37,10 @@ import Grisette.Internal.Core.Data.Class.SafeLinearArith
     SafeLinearArith,
   )
 import qualified Grisette.Internal.Core.Data.Class.SafeLinearArith
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.SomeBV
-  ( SomeIntN,
+  ( SomeBVException,
+    SomeIntN,
     SomeSymIntN,
     SomeSymWordN,
     SomeWordN,
@@ -166,12 +167,12 @@ instance
   withBaseSafeLinearArith r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeLinearArith
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeIntN
     m
   where
@@ -179,24 +180,24 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeLinearArith
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymIntN
     m
   where
   withBaseSafeLinearArith r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeLinearArith
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeWordN
     m
   where
@@ -204,12 +205,12 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeLinearArith
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymWordN
     m
   where

--- a/src/Grisette/Unified/Internal/Class/UnifiedSafeSymRotate.hs
+++ b/src/Grisette/Unified/Internal/Class/UnifiedSafeSymRotate.hs
@@ -33,9 +33,10 @@ import Control.Monad.Error.Class (MonadError)
 import GHC.TypeLits (KnownNat, type (<=))
 import Grisette.Internal.Core.Data.Class.SafeSymRotate (SafeSymRotate)
 import qualified Grisette.Internal.Core.Data.Class.SafeSymRotate
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.SomeBV
-  ( SomeIntN,
+  ( SomeBVException,
+    SomeIntN,
     SomeSymIntN,
     SomeSymWordN,
     SomeWordN,
@@ -129,12 +130,12 @@ instance
   withBaseSafeSymRotate r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeSymRotate
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeIntN
     m
   where
@@ -142,24 +143,24 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeSymRotate
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymIntN
     m
   where
   withBaseSafeSymRotate r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeSymRotate
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeWordN
     m
   where
@@ -167,12 +168,12 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeSymRotate
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymWordN
     m
   where

--- a/src/Grisette/Unified/Internal/Class/UnifiedSafeSymShift.hs
+++ b/src/Grisette/Unified/Internal/Class/UnifiedSafeSymShift.hs
@@ -35,9 +35,10 @@ import Control.Monad.Error.Class (MonadError)
 import GHC.TypeLits (KnownNat, type (<=))
 import Grisette.Internal.Core.Data.Class.SafeSymShift (SafeSymShift)
 import qualified Grisette.Internal.Core.Data.Class.SafeSymShift
-import Grisette.Internal.SymPrim.BV (BitwidthMismatch, IntN, WordN)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.SomeBV
-  ( SomeIntN,
+  ( SomeBVException,
+    SomeIntN,
     SomeSymIntN,
     SomeSymWordN,
     SomeWordN,
@@ -173,12 +174,12 @@ instance
   withBaseSafeSymShift r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeSymShift
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeIntN
     m
   where
@@ -186,24 +187,24 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeSymShift
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymIntN
     m
   where
   withBaseSafeSymShift r = withBaseBranching @'Sym @m r
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching mode m
   ) =>
   UnifiedSafeSymShift
     mode
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeWordN
     m
   where
@@ -211,12 +212,12 @@ instance
     withMode @mode (withBaseBranching @mode @m r) (withBaseBranching @mode @m r)
 
 instance
-  ( MonadError (Either BitwidthMismatch ArithException) m,
+  ( MonadError (Either SomeBVException ArithException) m,
     UnifiedBranching 'Sym m
   ) =>
   UnifiedSafeSymShift
     'Sym
-    (Either BitwidthMismatch ArithException)
+    (Either SomeBVException ArithException)
     SomeSymWordN
     m
   where

--- a/src/Grisette/Unified/Internal/UnifiedBV.hs
+++ b/src/Grisette/Unified/Internal/UnifiedBV.hs
@@ -44,12 +44,12 @@ import Grisette.Internal.Core.Data.Class.SignConversion (SignConversion)
 import Grisette.Internal.Core.Data.Class.SymRotate (SymRotate)
 import Grisette.Internal.Core.Data.Class.SymShift (SymShift)
 import Grisette.Internal.SymPrim.BV
-  ( BitwidthMismatch,
-    IntN,
+  ( IntN,
     WordN,
   )
 import Grisette.Internal.SymPrim.SomeBV
   ( SomeBV,
+    SomeBVException,
     SomeIntN,
     SomeSymIntN,
     SomeSymWordN,
@@ -259,27 +259,27 @@ instance
 
 class
   ( SomeBVPair mode word int,
-    UnifiedSafeDiv mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeLinearArith mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeSymRotate mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeSymShift mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeDiv mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeLinearArith mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeSymRotate mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeSymShift mode (Either BitwidthMismatch ArithException) int m
+    UnifiedSafeDiv mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeLinearArith mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeSymRotate mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeSymShift mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeDiv mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeLinearArith mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeSymRotate mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeSymShift mode (Either SomeBVException ArithException) int m
   ) =>
   SafeUnifiedSomeBVImpl (mode :: EvalModeTag) word int m
 
 instance
   ( SomeBVPair mode word int,
-    UnifiedSafeDiv mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeLinearArith mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeSymRotate mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeSymShift mode (Either BitwidthMismatch ArithException) word m,
-    UnifiedSafeDiv mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeLinearArith mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeSymRotate mode (Either BitwidthMismatch ArithException) int m,
-    UnifiedSafeSymShift mode (Either BitwidthMismatch ArithException) int m
+    UnifiedSafeDiv mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeLinearArith mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeSymRotate mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeSymShift mode (Either SomeBVException ArithException) word m,
+    UnifiedSafeDiv mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeLinearArith mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeSymRotate mode (Either SomeBVException ArithException) int m,
+    UnifiedSafeSymShift mode (Either SomeBVException ArithException) int m
   ) =>
   SafeUnifiedSomeBVImpl (mode :: EvalModeTag) word int m
 
@@ -314,7 +314,7 @@ class
     SafeUnifiedBV mode n m,
     forall m.
     ( UnifiedBranching mode m,
-      MonadError (Either BitwidthMismatch ArithException) m
+      MonadError (Either SomeBVException ArithException) m
     ) =>
     SafeUnifiedSomeBV mode m,
     forall n. (KnownNat n, 1 <= n) => UnifiedBV mode n,
@@ -334,7 +334,7 @@ instance
     SafeUnifiedBV mode n m,
     forall m.
     ( UnifiedBranching mode m,
-      MonadError (Either BitwidthMismatch ArithException) m
+      MonadError (Either SomeBVException ArithException) m
     ) =>
     SafeUnifiedSomeBV mode m,
     forall n. (KnownNat n, 1 <= n) => UnifiedBV mode n,

--- a/test/Grisette/Core/Data/Class/SafeDivTests.hs
+++ b/test/Grisette/Core/Data/Class/SafeDivTests.hs
@@ -18,10 +18,10 @@ import GHC.Int (Int16, Int32, Int64, Int8)
 import GHC.Word (Word16, Word32, Word64, Word8)
 import Grisette
   ( BV (bv),
-    BitwidthMismatch (BitwidthMismatch),
     IntN,
     Mergeable,
     SafeDiv (safeDiv, safeDivMod, safeMod, safeQuot, safeQuotRem, safeRem),
+    SomeBVException (BitwidthMismatch),
     SomeIntN,
     SomeWordN,
     Union,
@@ -325,12 +325,12 @@ safeDivTests =
               opBoundedSafeDivTestBase
                 SomeWordN
                 SomeWordN
-                (\e -> Right e :: Either BitwidthMismatch ArithException)
+                (\e -> Right e :: Either SomeBVException ArithException)
         let doubleOutputSafeDivTest =
               opBoundedSafeDivTestBase
                 SomeWordN
                 (bimap SomeWordN SomeWordN)
-                (\e -> Right e :: Either BitwidthMismatch ArithException)
+                (\e -> Right e :: Either SomeBVException ArithException)
         [ singleOutputDivOrTest "divOr" divOr (div @(WordN 8)),
           singleOutputDivOrTest "modOr" modOr (mod @(WordN 8)),
           doubleOutputDivOrTest "divModOr" divModOr (divMod @(WordN 8)),
@@ -350,7 +350,7 @@ safeDivTests =
             let actual =
                   safeDiv (bv 10 2) (bv 11 3) ::
                     ExceptT
-                      (Either BitwidthMismatch ArithException)
+                      (Either SomeBVException ArithException)
                       Union
                       SomeWordN
             let expected = mrgThrowError $ Left BitwidthMismatch
@@ -369,12 +369,12 @@ safeDivTests =
               opBoundedSafeDivTestBase
                 SomeIntN
                 SomeIntN
-                (\e -> Right e :: Either BitwidthMismatch ArithException)
+                (\e -> Right e :: Either SomeBVException ArithException)
         let doubleOutputSafeDivTest =
               opBoundedSafeDivTestBase
                 SomeIntN
                 (bimap SomeIntN SomeIntN)
-                (\e -> Right e :: Either BitwidthMismatch ArithException)
+                (\e -> Right e :: Either SomeBVException ArithException)
         [ singleOutputDivOrTest "divOr" divOr (div @(IntN 8)),
           singleOutputDivOrTest "modOr" modOr (mod @(IntN 8)),
           doubleOutputDivOrTest "divModOr" divModOr (divMod @(IntN 8)),
@@ -391,7 +391,7 @@ safeDivTests =
             let actual =
                   safeDiv (bv 10 2) (bv 11 3) ::
                     ExceptT
-                      (Either BitwidthMismatch ArithException)
+                      (Either SomeBVException ArithException)
                       Union
                       SomeIntN
             let expected = mrgThrowError $ Left BitwidthMismatch

--- a/test/Grisette/Core/Data/Class/SafeLinearArithTests.hs
+++ b/test/Grisette/Core/Data/Class/SafeLinearArithTests.hs
@@ -17,10 +17,10 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Grisette
   ( BV (bv),
-    BitwidthMismatch (BitwidthMismatch),
     IntN,
     Mergeable,
     SafeLinearArith (safeAdd, safeNeg, safeSub),
+    SomeBVException (BitwidthMismatch),
     SomeIntN,
     SomeWordN,
     TryMerge,
@@ -141,12 +141,12 @@ safeLinearArithTests =
       safeLinearArithTestSimple @(IntN 128),
       safeLinearArithTest @(IntN 2)
         @SomeIntN
-        @(Either BitwidthMismatch ArithException)
+        @(Either SomeBVException ArithException)
         SomeIntN
         Right,
       safeLinearArithTest @(IntN 128)
         @SomeIntN
-        @(Either BitwidthMismatch ArithException)
+        @(Either SomeBVException ArithException)
         SomeIntN
         Right,
       testCase "SomeIntN different bit width" $ do
@@ -154,7 +154,7 @@ safeLinearArithTests =
         let r = bv 3 1 :: SomeIntN
         let actual =
               safeAdd l r ::
-                ExceptT (Either BitwidthMismatch ArithException) Union SomeIntN
+                ExceptT (Either SomeBVException ArithException) Union SomeIntN
         let expected = mrgThrowError $ Left BitwidthMismatch
         actual @?= expected,
       safeLinearArithTestSimple @Word,
@@ -168,12 +168,12 @@ safeLinearArithTests =
       safeLinearArithTestSimple @(WordN 128),
       safeLinearArithTest @(WordN 2)
         @SomeWordN
-        @(Either BitwidthMismatch ArithException)
+        @(Either SomeBVException ArithException)
         SomeWordN
         Right,
       safeLinearArithTest @(WordN 128)
         @SomeWordN
-        @(Either BitwidthMismatch ArithException)
+        @(Either SomeBVException ArithException)
         SomeWordN
         Right,
       testCase "SomeWordN different bit width" $ do
@@ -182,7 +182,7 @@ safeLinearArithTests =
         let actual =
               safeAdd l r ::
                 ExceptT
-                  (Either BitwidthMismatch ArithException)
+                  (Either SomeBVException ArithException)
                   Union
                   SomeWordN
         let expected = mrgThrowError $ Left BitwidthMismatch

--- a/test/Grisette/Unified/EvalModeTest.hs
+++ b/test/Grisette/Unified/EvalModeTest.hs
@@ -42,13 +42,13 @@ import GHC.Generics (Generic)
 import Grisette
   ( BV (bv),
     BitCast (bitCast),
-    BitwidthMismatch,
     Default (Default),
     IEEEFPConstants (fpNaN),
     IEEEFPConvertible (toFP),
     IEEEFPRoundingMode (rne),
     IntN,
     Mergeable,
+    SomeBVException,
     SymBool,
     SymFP,
     SymIntN,
@@ -154,11 +154,11 @@ fbv' l r = do
 
 #if MIN_VERSION_base(4,16,0)
 type SomeBVConstraint mode m =
-  (MonadWithMode mode m, MonadError (Either BitwidthMismatch ArithException) m)
+  (MonadWithMode mode m, MonadError (Either SomeBVException ArithException) m)
 #else
 type SomeBVConstraint mode m =
   ( MonadWithMode mode m,
-    MonadError (Either BitwidthMismatch ArithException) m,
+    MonadError (Either SomeBVException ArithException) m,
     SafeUnifiedSomeBV mode m
   )
 #endif
@@ -192,7 +192,7 @@ fsomebv' ::
   (SomeBVConstraint' mode m) =>
   GetSomeIntN mode ->
   GetSomeIntN mode ->
-  ExceptT (Either BitwidthMismatch ArithException) m (GetSomeIntN mode)
+  ExceptT (Either SomeBVException ArithException) m (GetSomeIntN mode)
 fsomebv' l r = do
   v <- safeDiv @mode l r
   mrgReturn $
@@ -386,7 +386,7 @@ evalModeTest =
                       (v + r)
                       (Grisette.symIte (l Grisette..< r) l r) ::
                     ExceptT
-                      (Either BitwidthMismatch ArithException)
+                      (Either SomeBVException ArithException)
                       Union
                       SomeSymIntN
             fsomebv l r @?= expected

--- a/test/Grisette/Unified/EvalModeTest.hs
+++ b/test/Grisette/Unified/EvalModeTest.hs
@@ -183,7 +183,7 @@ type SomeBVConstraint' mode m =
 #else
 type SomeBVConstraint' mode m =
   ( MonadWithMode mode m,
-    SafeUnifiedSomeBV mode (ExceptT (Either BitwidthMismatch ArithException) m)
+    SafeUnifiedSomeBV mode (ExceptT (Either SomeBVException ArithException) m)
   )
 #endif
 


### PR DESCRIPTION
This pull request allows number literals in `SomeBV`.

Previously, the following code would crash:

```haskell
>>> 1 :: SomeIntN
```

This would require us to write the following code if we want to add 1 to some value:

```haskell
>>> v = bv 4 5
>>> v + bv (finiteBitSize v) 1
0x6
```

This pull request allows us to directly use number literals in such scenarios:

```haskell
>>> v + 1
0x6
```

We don't allow operations on literals, though, because the result may rely on the bit-widths.

```haskell
>>> 1 * 1 :: SomeIntN
*** Exception: ...
```

Some operations allows on literals as the result does not rely on the bit-widths:

```haskell
>>> 1 + 1 :: SomeIntN
2
```
