### PR TITLE
Simplify the instances for uninterpreted functions and fix the missing instances for concrete functions

### DIFF
--- a/src/Grisette/Internal/Backend/Solving.hs
+++ b/src/Grisette/Internal/Backend/Solving.hs
@@ -80,6 +80,7 @@ import Control.Monad.STM (STM)
 import Control.Monad.State (MonadState (get, put), StateT, evalStateT, modify)
 import Control.Monad.Writer (tell)
 import Data.Dynamic (fromDyn, toDyn)
+import qualified Data.HashSet as HS
 import Data.List.NonEmpty (NonEmpty)
 import Data.Proxy (Proxy (Proxy))
 import qualified Data.SBV as SBV
@@ -579,7 +580,7 @@ lowerSinglePrimImpl config t@(ForallTerm _ (ts :: TypedConstantSymbol t1) v) =
       m <- get
       let (newm, sb@(TypedSymbol sbs)) = attachNextQuantifiedSymbolInfo m ts
       put newm
-      let substedTerm = substTerm ts (symTerm sbs) v
+      let substedTerm = substTerm ts (symTerm sbs) HS.empty v
       r <-
         local (addQuantifiedSymbol sb) $
           lowerSinglePrimCached'
@@ -596,7 +597,7 @@ lowerSinglePrimImpl config t@(ExistsTerm _ (ts :: TypedConstantSymbol t1) v) =
       m <- get
       let (newm, sb@(TypedSymbol sbs)) = attachNextQuantifiedSymbolInfo m ts
       put newm
-      let substedTerm = substTerm ts (symTerm sbs) v
+      let substedTerm = substTerm ts (symTerm sbs) HS.empty v
       r <-
         local (addQuantifiedSymbol sb) $
           lowerSinglePrimCached'

--- a/src/Grisette/Internal/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Internal/Core/Control/Monad/Union.hs
@@ -137,6 +137,7 @@ import Grisette.Internal.SymPrim.GeneralFun
   )
 import Grisette.Internal.SymPrim.Prim.Term
   ( LinkedRep,
+    SupportedNonFuncPrim,
     SupportedPrim,
   )
 import Grisette.Internal.SymPrim.SymBV
@@ -483,13 +484,21 @@ instance (KnownNat n, 1 <= n) => ToSym (Union (WordN n)) (SymWordN n) where
   toSym = simpleMerge . fmap con
 
 instance
-  (SupportedPrim ((=->) ca cb), LinkedRep ca sa, LinkedRep cb sb) =>
+  ( SupportedPrim ((=->) ca cb),
+    SupportedNonFuncPrim ca,
+    LinkedRep ca sa,
+    LinkedRep cb sb
+  ) =>
   ToSym (Union ((=->) ca cb)) ((=~>) sa sb)
   where
   toSym = simpleMerge . fmap con
 
 instance
-  (SupportedPrim ((-->) ca cb), LinkedRep ca sa, LinkedRep cb sb) =>
+  ( SupportedPrim ((-->) ca cb),
+    SupportedNonFuncPrim ca,
+    LinkedRep ca sa,
+    LinkedRep cb sb
+  ) =>
   ToSym (Union ((-->) ca cb)) ((-~>) sa sb)
   where
   toSym = simpleMerge . fmap con

--- a/src/Grisette/Internal/Core/Data/Class/EvalSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/EvalSym.hs
@@ -98,9 +98,7 @@ import Grisette.Internal.SymPrim.FP (FP, FPRoundingMode, NotRepresentableFPError
 import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Model (Model, evalTerm)
 import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep,
-    SupportedPrim,
-    SymRep (SymType),
+  ( SymRep (SymType),
     someTypedSymbol,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
@@ -373,8 +371,7 @@ instance (KnownNat n, 1 <= n) => EvalSym (symtype n) where \
     symtype $ evalTerm fillDefault model HS.empty t
 
 #define EVALUATE_SYM_FUN(cop, op, cons) \
-instance (SupportedPrim (cop ca cb), LinkedRep ca sa, LinkedRep cb sb) => \
-  EvalSym (op sa sb) where \
+instance EvalSym (op sa sb) where \
   evalSym fillDefault model (cons t) = \
     cons $ evalTerm fillDefault model HS.empty t
 

--- a/src/Grisette/Internal/Core/Data/Class/ExtractSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ExtractSym.hs
@@ -95,8 +95,6 @@ import Grisette.Internal.SymPrim.Prim.Model
   )
 import Grisette.Internal.SymPrim.Prim.Term
   ( IsSymbolKind (decideSymbolKind),
-    LinkedRep,
-    SupportedPrim,
     SymRep (SymType),
     SymbolKind,
     someTypedSymbol,
@@ -364,9 +362,8 @@ instance (KnownNat n, 1 <= n) => ExtractSym (symtype n) where \
       Left HRefl -> SymbolSet <$> extractTerm HS.empty t; \
       Right HRefl -> SymbolSet <$> extractTerm HS.empty t
 
-#define EXTRACT_SYMBOLICS_FUN(cop, op, cons) \
-instance (SupportedPrim (cop ca cb), LinkedRep ca sa, LinkedRep cb sb) => \
-  ExtractSym (op sa sb) where \
+#define EXTRACT_SYMBOLICS_FUN(op, cons) \
+instance ExtractSym (op sa sb) where \
   extractSymMaybe :: \
     forall knd. (IsSymbolKind knd) => op sa sb -> Maybe (SymbolSet knd); \
   extractSymMaybe (cons t) = \
@@ -381,8 +378,8 @@ EXTRACT_SYMBOLICS_SIMPLE(SymFPRoundingMode)
 EXTRACT_SYMBOLICS_SIMPLE(SymAlgReal)
 EXTRACT_SYMBOLICS_BV(SymIntN)
 EXTRACT_SYMBOLICS_BV(SymWordN)
-EXTRACT_SYMBOLICS_FUN((=->), (=~>), SymTabularFun)
-EXTRACT_SYMBOLICS_FUN((-->), (-~>), SymGeneralFun)
+EXTRACT_SYMBOLICS_FUN((=~>), SymTabularFun)
+EXTRACT_SYMBOLICS_FUN((-~>), SymGeneralFun)
 #endif
 
 instance (ValidFP eb fb) => ExtractSym (SymFP eb fb) where

--- a/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -19,12 +20,16 @@ module Grisette.Internal.Core.Data.Class.ITEOp
 where
 
 import Control.Monad.Identity (Identity (Identity))
+import qualified Data.HashSet as HS
 import GHC.TypeNats (KnownNat, type (<=))
 import Grisette.Internal.SymPrim.FP (ValidFP)
-import Grisette.Internal.SymPrim.GeneralFun (type (-->))
+import Grisette.Internal.SymPrim.GeneralFun (freshArgSymbol, substTerm, type (-->) (GeneralFun))
+import Grisette.Internal.SymPrim.Prim.SomeTerm (SomeTerm (SomeTerm))
 import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep,
-    SupportedPrim (pevalITETerm),
+  ( SupportedPrim (pevalITETerm),
+    TypedConstantSymbol,
+    TypedSymbol (unTypedSymbol),
+    symTerm,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
 import Grisette.Internal.SymPrim.SymBV
@@ -39,7 +44,6 @@ import Grisette.Internal.SymPrim.SymFP
 import Grisette.Internal.SymPrim.SymGeneralFun (type (-~>) (SymGeneralFun))
 import Grisette.Internal.SymPrim.SymInteger (SymInteger (SymInteger))
 import Grisette.Internal.SymPrim.SymTabularFun (type (=~>) (SymTabularFun))
-import Grisette.Internal.SymPrim.TabularFun (type (=->))
 
 -- $setup
 -- >>> import Grisette.Core
@@ -69,7 +73,7 @@ instance (KnownNat n, 1 <= n) => ITEOp (type n) where \
   {-# INLINE symIte #-}
 
 #define ITEOP_FUN(cop, op, cons) \
-instance (SupportedPrim (cop ca cb), LinkedRep ca sa, LinkedRep cb sb) => ITEOp (op sa sb) where \
+instance ITEOp (op sa sb) where \
   symIte (SymBool c) (cons t) (cons f) = cons $ pevalITETerm c t f; \
   {-# INLINE symIte #-}
 
@@ -83,6 +87,21 @@ ITEOP_BV(SymWordN)
 ITEOP_FUN((=->), (=~>), SymTabularFun)
 ITEOP_FUN((-->), (-~>), SymGeneralFun)
 #endif
+
+instance ITEOp (a --> b) where
+  symIte
+    (SymBool c)
+    (GeneralFun (ta :: TypedConstantSymbol a) a)
+    (GeneralFun tb b) =
+      GeneralFun argSymbol $
+        pevalITETerm
+          c
+          (substTerm ta (symTerm $ unTypedSymbol argSymbol) HS.empty a)
+          (substTerm tb (symTerm $ unTypedSymbol argSymbol) HS.empty b)
+      where
+        argSymbol :: TypedConstantSymbol a
+        argSymbol = freshArgSymbol [SomeTerm a, SomeTerm b]
+  {-# INLINE symIte #-}
 
 instance (ValidFP eb sb) => ITEOp (SymFP eb sb) where
   symIte (SymBool c) (SymFP t) (SymFP f) = SymFP $ pevalITETerm c t f

--- a/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Internal/Core/Data/Class/Mergeable.hs
@@ -141,10 +141,6 @@ import Grisette.Internal.SymPrim.FP
     withValidFPProofs,
   )
 import Grisette.Internal.SymPrim.GeneralFun (type (-->))
-import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep,
-    SupportedPrim,
-  )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
 import Grisette.Internal.SymPrim.SymBV (SymIntN, SymWordN)
 import Grisette.Internal.SymPrim.SymBool (SymBool)
@@ -604,6 +600,12 @@ instance (ValidFP eb sb) => Mergeable (FP eb sb) where
             (\fp -> (bitCastOrCanonical fp :: WordN (eb + sb)))
           $ const sub
 
+instance Mergeable (a =-> b) where
+  rootStrategy = NoStrategy
+
+instance Mergeable (a --> b) where
+  rootStrategy = SimpleStrategy symIte
+
 #define MERGEABLE_SIMPLE(symtype) \
 instance Mergeable symtype where \
   rootStrategy = SimpleStrategy symIte
@@ -612,9 +614,8 @@ instance Mergeable symtype where \
 instance (KnownNat n, 1 <= n) => Mergeable (symtype n) where \
   rootStrategy = SimpleStrategy symIte
 
-#define MERGEABLE_FUN(cop, op) \
-instance (SupportedPrim (cop ca cb), LinkedRep ca sa, LinkedRep cb sb) => \
-  Mergeable (op sa sb) where \
+#define MERGEABLE_FUN(cop, op, consop) \
+instance Mergeable (op sa sb) where \
   rootStrategy = SimpleStrategy symIte
 
 #if 1
@@ -624,8 +625,8 @@ MERGEABLE_SIMPLE(SymFPRoundingMode)
 MERGEABLE_SIMPLE(SymAlgReal)
 MERGEABLE_BV(SymIntN)
 MERGEABLE_BV(SymWordN)
-MERGEABLE_FUN((=->), (=~>))
-MERGEABLE_FUN((-->), (-~>))
+MERGEABLE_FUN((=->), (=~>), SymTabularFun)
+MERGEABLE_FUN((-->), (-~>), SymGeneralFun)
 #endif
 
 instance (ValidFP eb sb) => Mergeable (SymFP eb sb) where

--- a/src/Grisette/Internal/Core/Data/Class/PPrint.hs
+++ b/src/Grisette/Internal/Core/Data/Class/PPrint.hs
@@ -137,9 +137,7 @@ import Grisette.Internal.SymPrim.Prim.Model
   )
 import Grisette.Internal.SymPrim.Prim.ModelValue (ModelValue)
 import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep,
-    SomeTypedSymbol (SomeTypedSymbol),
-    SupportedPrim,
+  ( SomeTypedSymbol (SomeTypedSymbol),
     TypedSymbol (unTypedSymbol),
     prettyPrintTerm,
   )
@@ -589,8 +587,7 @@ instance (KnownNat n, 1 <= n) => PPrint (symtype n) where \
   pformat (symtype t) = prettyPrintTerm t
 
 #define FORMAT_SYM_FUN(op, cons) \
-instance (SupportedPrim ca, SupportedPrim cb, LinkedRep ca sa, LinkedRep cb sb)\
-  => PPrint (sa op sb) where \
+instance PPrint (sa op sb) where \
   pformat (cons t) = prettyPrintTerm t
 
 #if 1

--- a/src/Grisette/Internal/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SimpleMergeable.hs
@@ -95,10 +95,6 @@ import Grisette.Internal.Core.Data.Class.TryMerge
   )
 import Grisette.Internal.SymPrim.FP (ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->))
-import Grisette.Internal.SymPrim.Prim.Term
-  ( LinkedRep,
-    SupportedPrim,
-  )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
 import Grisette.Internal.SymPrim.SymBV
   ( SymIntN,
@@ -109,7 +105,6 @@ import Grisette.Internal.SymPrim.SymFP (SymFP, SymFPRoundingMode)
 import Grisette.Internal.SymPrim.SymGeneralFun (type (-~>))
 import Grisette.Internal.SymPrim.SymInteger (SymInteger)
 import Grisette.Internal.SymPrim.SymTabularFun (type (=~>))
-import Grisette.Internal.SymPrim.TabularFun (type (=->))
 import Grisette.Internal.TH.DeriveBuiltin (deriveBuiltins)
 import Grisette.Internal.TH.DeriveInstanceProvider
   ( Strategy (ViaDefault, ViaDefault1),
@@ -820,8 +815,7 @@ instance (KnownNat n, 1 <= n) => SimpleMergeable (symtype n) where \
   {-# INLINE mrgIte #-}
 
 #define SIMPLE_MERGEABLE_FUN(cop, op) \
-instance (SupportedPrim (cop ca cb), LinkedRep ca sa, LinkedRep cb sb) => \
-  SimpleMergeable (op sa sb) where \
+instance SimpleMergeable (op sa sb) where \
   mrgIte = symIte; \
   {-# INLINE mrgIte #-}
 
@@ -835,6 +829,10 @@ SIMPLE_MERGEABLE_BV(SymWordN)
 SIMPLE_MERGEABLE_FUN((=->), (=~>))
 SIMPLE_MERGEABLE_FUN((-->), (-~>))
 #endif
+
+instance SimpleMergeable (a --> b) where
+  mrgIte = symIte
+  {-# INLINE mrgIte #-}
 
 instance (ValidFP eb sb) => SimpleMergeable (SymFP eb sb) where
   mrgIte = symIte

--- a/src/Grisette/Internal/Core/Data/Class/ToSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ToSym.hs
@@ -108,6 +108,7 @@ import Grisette.Internal.SymPrim.GeneralFun (type (-->))
 import Grisette.Internal.SymPrim.IntBitwidth (intBitwidthQ)
 import Grisette.Internal.SymPrim.Prim.Term
   ( LinkedRep,
+    SupportedNonFuncPrim,
     SupportedPrim,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
@@ -359,7 +360,7 @@ instance (KnownNat n, 1 <= n) => ToSym (contype n) (symtype n) where \
   toSym = con
 
 #define TO_SYM_FROMCON_FUN(conop, symop) \
-instance (SupportedPrim (conop ca cb), LinkedRep ca sa, LinkedRep cb sb) => \
+instance (SupportedPrim (conop ca cb), SupportedNonFuncPrim ca, LinkedRep ca sa, LinkedRep cb sb) => \
   ToSym (conop ca cb) (symop sa sb) where \
   toSym = con
 

--- a/src/Grisette/Internal/SymPrim/FunInstanceGen.hs
+++ b/src/Grisette/Internal/SymPrim/FunInstanceGen.hs
@@ -44,7 +44,6 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
       ),
     TypedSymbol (TypedSymbol),
     decideSymbolKind,
-    pevalITEBasicTerm,
     translateTypeError,
     withNonFuncPrim,
   )
@@ -87,6 +86,7 @@ instanceWithOverlapDescD o ctxts ty descs = do
 supportedPrimFun ::
   ExpQ ->
   ExpQ ->
+  ExpQ ->
   ([TypeQ] -> ExpQ) ->
   String ->
   String ->
@@ -95,6 +95,7 @@ supportedPrimFun ::
   DecsQ
 supportedPrimFun
   dv
+  ite
   parse
   consbv
   funNameInError
@@ -113,7 +114,7 @@ supportedPrimFun
       (constraints tyVars)
       [t|SupportedPrim $(funType tyVars)|]
       ( [ [d|$(varP 'defaultValue) = $dv|],
-          [d|$(varP 'pevalITETerm) = pevalITEBasicTerm|],
+          [d|$(varP 'pevalITETerm) = $ite|],
           [d|
             $(varP 'pevalEqTerm) =
               $( translateError
@@ -230,9 +231,10 @@ supportedPrimFun
 -- | Generate instances of 'SupportedPrim' for functions with up to a given
 -- number of arguments.
 supportedPrimFunUpTo ::
-  ExpQ -> ExpQ -> ([TypeQ] -> ExpQ) -> String -> String -> Name -> Int -> DecsQ
+  ExpQ -> ExpQ -> ExpQ -> ([TypeQ] -> ExpQ) -> String -> String -> Name -> Int -> DecsQ
 supportedPrimFunUpTo
   dv
+  ite
   parse
   consbv
   funNameInError
@@ -243,6 +245,7 @@ supportedPrimFunUpTo
       <$> sequence
         [ supportedPrimFun
             dv
+            ite
             parse
             consbv
             funNameInError

--- a/src/Grisette/Internal/SymPrim/TabularFun.hs
+++ b/src/Grisette/Internal/SymPrim/TabularFun.hs
@@ -57,7 +57,7 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
     applyTerm,
     conTerm,
     partitionCVArg,
-    pevalEqTerm,
+    pevalEqTerm, pevalITEBasicTerm,
   )
 import Language.Haskell.TH.Syntax (Lift)
 
@@ -162,6 +162,7 @@ parseTabularFunSMTModelResult level (l, s) =
 
 supportedPrimFunUpTo
   [|TabularFun [] defaultValue|]
+  [|pevalITEBasicTerm|]
   [|parseTabularFunSMTModelResult|]
   ( \tyVars ->
       [|


### PR DESCRIPTION
This pull request simplifies the instances for uninterpreted functions by moving the constraints to the types themselves as GADTs.

This pull request also fixes the missing instances for concrete functions, especially the `ITEOp`/`SimpleMergeable`/`Mergeable` instances for general functions.