### PR TITLE
Add reporting for maybe no counter-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#251](https://github.com/lsrcz/grisette/pull/251))
 - Added serialization for the core constructs.
   ([#253](https://github.com/lsrcz/grisette/pull/253))
+- Added partial evaluation for distinct.
+  ([#254](https://github.com/lsrcz/grisette/pull/254))
 
 ### Changed
 - [Breaking] Moved the constraints for the general and tabular functions and
@@ -34,10 +36,17 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - [Breaking] Changed the solving/cegis results from maintaining the exception
   themselves to maintaining a textual representation of them.
   ([#253](https://github.com/lsrcz/grisette/pull/253))
+- [Breaking] Changed the 'VerifierResult' type for CEGIS to allow it report that
+  the verifier cannot find a counter example.
+  ([#257](https://github.com/lsrcz/grisette/pull/257))
 
 ### Fixed
 - Fixed memory leak within the term cache.
   ([#252](https://github.com/lsrcz/grisette/pull/252))
+- Fixed printing of bv terms.
+  ([#255](https://github.com/lsrcz/grisette/pull/255))
+- Fixed solverGenericCEGIS and make it also return the last failing cex.
+  ([#256](https://github.com/lsrcz/grisette/pull/256))
 
 ## [0.8.0.0] - 2024-08-13
 

--- a/src/Grisette/Internal/Core/Data/Class/CEGISSolver.hs
+++ b/src/Grisette/Internal/Core/Data/Class/CEGISSolver.hs
@@ -121,11 +121,10 @@ import Language.Haskell.TH.Syntax (Lift)
 -- | The response from a verifier.
 data VerifierResult cex exception
   = CEGISVerifierFoundCex cex
-  | CEGISVerifierNoCex
-      -- | True indicates that the verifier is sure that there is no
-      -- counter-example, while False indicates that the verifier is not sure,
-      -- but it cannot find a counter-example.
-      Bool
+  | -- | True indicates that the verifier is sure that there is no
+    -- counter-example, while False indicates that the verifier is not sure,
+    -- but it cannot find a counter-example.
+    CEGISVerifierNoCex Bool
   | CEGISVerifierException exception
   deriving (Show, Eq, Generic, Lift)
   deriving anyclass (Hashable, NFData)


### PR DESCRIPTION
This pull request enhances the verifier result for the cex procedure allowing it to report that the verifier cannot find a counter-example. Still, it isn't sure that no such counter-example exists.