### PR TITLE
Correctly do memoization for lowering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#255](https://github.com/lsrcz/grisette/pull/255))
 - Fixed solverGenericCEGIS and make it also return the last failing cex.
   ([#256](https://github.com/lsrcz/grisette/pull/256))
+- `solverGenericCEGIS` will only rerun possible verifiers now. This will improve
+  overall verification performance.
+  ([#258](https://github.com/lsrcz/grisette/pull/258))
+- Fixed a **critical** bug in the lowering/evalSym/extractSym where the
+  intermediate states are not properly memoized.
+  ([#259](https://github.com/lsrcz/grisette/pull/259))
 
 ## [0.8.0.0] - 2024-08-13
 

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -240,12 +240,10 @@ library
     , bytestring >=0.10.12 && <0.13
     , cereal >=0.5.8.1 && <0.6
     , cereal-text >=0.1.0.2 && <0.2
-    , concurrent-extra >=0.7.0.12 && <0.8
     , containers >=0.4 && <0.8
     , deepseq >=1.4.4 && <1.6
     , generic-deriving >=1.14.1 && <1.15
     , hashable >=1.2.3 && <1.6
-    , hashtables >=1.2.3.4 && <1.4
     , libBF >=0.6.3 && <0.7
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4
@@ -287,14 +285,12 @@ test-suite doctest
     , bytestring >=0.10.12 && <0.13
     , cereal >=0.5.8.1 && <0.6
     , cereal-text >=0.1.0.2 && <0.2
-    , concurrent-extra >=0.7.0.12 && <0.8
     , containers >=0.4 && <0.8
     , deepseq >=1.4.4 && <1.6
     , doctest >=0.18.2 && <0.23
     , generic-deriving >=1.14.1 && <1.15
     , grisette
     , hashable >=1.2.3 && <1.6
-    , hashtables >=1.2.3.4 && <1.4
     , libBF >=0.6.3 && <0.7
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4
@@ -405,13 +401,11 @@ test-suite spec
     , bytestring >=0.10.12 && <0.13
     , cereal >=0.5.8.1 && <0.6
     , cereal-text >=0.1.0.2 && <0.2
-    , concurrent-extra >=0.7.0.12 && <0.8
     , containers >=0.4 && <0.8
     , deepseq >=1.4.4 && <1.6
     , generic-deriving >=1.14.1 && <1.15
     , grisette
     , hashable >=1.2.3 && <1.6
-    , hashtables >=1.2.3.4 && <1.4
     , libBF >=0.6.3 && <0.7
     , loch-th >=0.2.2 && <0.3
     , mtl >=2.2.2 && <2.4

--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,6 @@ dependencies:
   - unordered-containers >= 0.2.17 && < 0.3
   - template-haskell >= 2.16 && < 2.23
   - deepseq >= 1.4.4 && < 1.6
-  - hashtables >= 1.2.3.4 && < 1.4
   - loch-th >= 0.2.2 && < 0.3
   - th-compat >= 0.1.2 && < 0.2
   - th-abstraction >= 0.4 && < 0.8
@@ -64,7 +63,6 @@ dependencies:
   - th-lift-instances >= 0.1.16 && < 0.2
   - vector >= 0.12.1.2 && < 0.14
   - atomic-primops >= 0.8.3 && < 0.9
-  - concurrent-extra >= 0.7.0.12 && < 0.8
   - cereal >= 0.5.8.1 && < 0.6
   - cereal-text >= 0.1.0.2 && < 0.2
   - binary >= 0.8.8.0 && < 0.9

--- a/src/Grisette/Internal/Backend/QuantifiedStack.hs
+++ b/src/Grisette/Internal/Backend/QuantifiedStack.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE Strict #-}
 
 -- |
@@ -24,6 +29,7 @@ where
 import Data.Dynamic (Dynamic)
 import qualified Data.HashMap.Strict as M
 import qualified Data.HashSet as S
+import Data.Hashable (Hashable (hashWithSalt))
 import GHC.Stack (HasCallStack)
 import Grisette.Internal.SymPrim.Prim.Internal.Term
   ( IsSymbolKind,
@@ -66,6 +72,12 @@ isQuantifiedSymbol s (QuantifiedSymbols t) =
 -- | A stack of quantified symbols.
 newtype QuantifiedStack = QuantifiedStack
   {_stack :: M.HashMap SomeTypedConstantSymbol Dynamic}
+
+instance Eq QuantifiedStack where
+  QuantifiedStack s1 == QuantifiedStack s2 = M.keysSet s1 == M.keysSet s2
+
+instance Hashable QuantifiedStack where
+  hashWithSalt s (QuantifiedStack t) = hashWithSalt s (M.keys t)
 
 -- | An empty stack of quantified symbols.
 emptyQuantifiedStack :: QuantifiedStack

--- a/src/Grisette/Internal/Backend/Solving.hs
+++ b/src/Grisette/Internal/Backend/Solving.hs
@@ -605,6 +605,7 @@ lowerSinglePrimCached t' m' = do
         withPrim @a $ do
           r <- goCachedIntermediate qs t
           let memoed = stableMemo r
+              {-# NOINLINE memoed #-}
           liftIO $
             modifyIORef' mapState $
               addBiMapIntermediate (SomeTerm t) (toDyn . memoed)

--- a/src/Grisette/Internal/Backend/Solving.hs
+++ b/src/Grisette/Internal/Backend/Solving.hs
@@ -148,7 +148,7 @@ import Grisette.Internal.Core.Data.Class.Solver
       ),
     SolvingFailure (SolvingError, Terminated, Unk, Unsat),
   )
-import Grisette.Internal.Core.Data.MemoUtils (stableMemo)
+import Grisette.Internal.Core.Data.MemoUtils (htmemo)
 import Grisette.Internal.SymPrim.GeneralFun (substTerm)
 import Grisette.Internal.SymPrim.Prim.Internal.Instances.PEvalFP
   ( sbvFPBinaryTerm,
@@ -604,7 +604,7 @@ lowerSinglePrimCached t' m' = do
       goCachedImpl qs t =
         withPrim @a $ do
           r <- goCachedIntermediate qs t
-          let memoed = stableMemo r
+          let memoed = htmemo r
               {-# NOINLINE memoed #-}
           liftIO $
             modifyIORef' mapState $

--- a/src/Grisette/Internal/Core/Data/MemoUtils.hs
+++ b/src/Grisette/Internal/Core/Data/MemoUtils.hs
@@ -37,10 +37,9 @@ where
 import Control.Applicative (Const (Const, getConst))
 import qualified Control.Concurrent.RLock as RLock
 import Control.Monad.Fix (fix)
-import Data.Atomics (atomicModifyIORefCAS, atomicModifyIORefCAS_)
+import Data.Atomics (atomicModifyIORefCAS_)
 import qualified Data.HashMap.Strict as HM
 import Data.HashTable.IO (BasicHashTable)
-import qualified Data.HashTable.IO as H
 import qualified Data.HashTable.IO as HashTable
 import Data.Hashable (Hashable)
 import Data.IORef (newIORef, readIORef)

--- a/src/Grisette/Internal/Core/Data/MemoUtils.hs
+++ b/src/Grisette/Internal/Core/Data/MemoUtils.hs
@@ -196,7 +196,9 @@ htmemo f = unsafePerformIO $ do
     tryV <- H.lookup cache x
     case tryV of
       Nothing -> do
-        let v = f x
+        RLock.release rlock
+        let !v = f x
+        RLock.acquire rlock
         H.insert cache x v
         RLock.release rlock
         return v

--- a/src/Grisette/Internal/Core/Data/MemoUtils.hs
+++ b/src/Grisette/Internal/Core/Data/MemoUtils.hs
@@ -176,7 +176,6 @@ weakStableMemoFix h = fix (weakStableMemo . h)
 htmemo :: (Eq k, Hashable k) => (k -> a) -> k -> a
 htmemo f = unsafePerformIO $ do
   cache <- newIORef HM.empty
-  -- cache <- H.new :: IO (HashTable k v)
   return $ \(!x) -> unsafePerformIO $ do
     tryV <- HM.lookup x <$> readIORef cache
     case tryV of

--- a/src/Grisette/Internal/SymPrim/GeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/GeneralFun.hs
@@ -48,7 +48,7 @@ import Grisette.Internal.Core.Data.Class.Function
   ( Apply (FunType, apply),
     Function ((#)),
   )
-import Grisette.Internal.Core.Data.MemoUtils (htmemo)
+import Grisette.Internal.Core.Data.MemoUtils (stableMemo)
 import Grisette.Internal.Core.Data.Symbol
   ( Symbol (IndexedSymbol),
   )
@@ -230,7 +230,7 @@ infixr 0 -->
 
 extractSymSomeTermIncludeBoundedVars ::
   SomeTerm -> HS.HashSet SomeTypedAnySymbol
-extractSymSomeTermIncludeBoundedVars = htmemo go
+extractSymSomeTermIncludeBoundedVars = stableMemo go
   where
     goTyped :: Term a -> HS.HashSet SomeTypedAnySymbol
     goTyped = go . someTerm
@@ -466,7 +466,7 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
     go memo a = case memo $ someTerm a of
       SomeTerm v -> unsafeCoerce v
     initialMemo :: SomeTerm -> SomeTerm
-    initialMemo = htmemo (goSome initialMemo initialBoundedSymbols)
+    initialMemo = stableMemo (goSome initialMemo initialBoundedSymbols)
     {-# NOINLINE initialMemo #-}
     goSome ::
       (SomeTerm -> SomeTerm) ->
@@ -480,7 +480,7 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
             Just HRefl -> case cv of
               GeneralFun sym (tm :: Term r) ->
                 let newmemo =
-                      htmemo
+                      stableMemo
                         ( goSome
                             newmemo
                             (HS.union (HS.singleton (someTypedSymbol sym)) bs)
@@ -495,12 +495,12 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
         _ -> SomeTerm $ subst sym
     goSome _ bs (SomeTerm (ForallTerm _ _ _ _ tsym b)) =
       let newmemo =
-            htmemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
+            stableMemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (forallTerm tsym) b
     goSome _ bs (SomeTerm (ExistsTerm _ _ _ _ tsym b)) =
       let newmemo =
-            htmemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
+            stableMemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (existsTerm tsym) b
     goSome memo _ (SomeTerm (NotTerm _ _ _ _ arg)) =

--- a/src/Grisette/Internal/SymPrim/GeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/GeneralFun.hs
@@ -48,7 +48,7 @@ import Grisette.Internal.Core.Data.Class.Function
   ( Apply (FunType, apply),
     Function ((#)),
   )
-import Grisette.Internal.Core.Data.MemoUtils (stableMemo)
+import Grisette.Internal.Core.Data.MemoUtils (htmemo)
 import Grisette.Internal.Core.Data.Symbol
   ( Symbol (IndexedSymbol),
   )
@@ -230,7 +230,7 @@ infixr 0 -->
 
 extractSymSomeTermIncludeBoundedVars ::
   SomeTerm -> HS.HashSet SomeTypedAnySymbol
-extractSymSomeTermIncludeBoundedVars = stableMemo go
+extractSymSomeTermIncludeBoundedVars = htmemo go
   where
     goTyped :: Term a -> HS.HashSet SomeTypedAnySymbol
     goTyped = go . someTerm
@@ -466,7 +466,7 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
     go memo a = case memo $ someTerm a of
       SomeTerm v -> unsafeCoerce v
     initialMemo :: SomeTerm -> SomeTerm
-    initialMemo = stableMemo (goSome initialMemo initialBoundedSymbols)
+    initialMemo = htmemo (goSome initialMemo initialBoundedSymbols)
     {-# NOINLINE initialMemo #-}
     goSome ::
       (SomeTerm -> SomeTerm) ->
@@ -480,7 +480,7 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
             Just HRefl -> case cv of
               GeneralFun sym (tm :: Term r) ->
                 let newmemo =
-                      stableMemo
+                      htmemo
                         ( goSome
                             newmemo
                             (HS.union (HS.singleton (someTypedSymbol sym)) bs)
@@ -495,12 +495,12 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
         _ -> SomeTerm $ subst sym
     goSome _ bs (SomeTerm (ForallTerm _ _ _ _ tsym b)) =
       let newmemo =
-            stableMemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
+            htmemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (forallTerm tsym) b
     goSome _ bs (SomeTerm (ExistsTerm _ _ _ _ tsym b)) =
       let newmemo =
-            stableMemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
+            htmemo (goSome newmemo (HS.insert (someTypedSymbol tsym) bs))
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (existsTerm tsym) b
     goSome memo _ (SomeTerm (NotTerm _ _ _ _ arg)) =

--- a/src/Grisette/Internal/SymPrim/Prim/TermUtils.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/TermUtils.hs
@@ -35,7 +35,7 @@ import Control.Monad.State
 import Data.Data (cast)
 import Data.Foldable (Foldable (toList), traverse_)
 import qualified Data.HashSet as HS
-import Grisette.Internal.Core.Data.MemoUtils (stableMemo2)
+import Grisette.Internal.Core.Data.MemoUtils (htmemo2)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Internal.Term
   ( IsSymbolKind (SymbolKindConstraint),
@@ -132,7 +132,7 @@ extractSymSomeTerm = go initialMemo
       HS.HashSet (SomeTypedConstantSymbol) ->
       SomeTerm ->
       Maybe (HS.HashSet (SomeTypedSymbol knd))
-    initialMemo = stableMemo2 (go initialMemo)
+    initialMemo = htmemo2 (go initialMemo)
     {-# NOINLINE initialMemo #-}
 
     go ::
@@ -155,7 +155,7 @@ extractSymSomeTerm = go initialMemo
           case eqTypeRep (typeRep @(-->)) gf of
             Just HRefl -> case cv of
               GeneralFun sym (tm :: Term r) ->
-                let newmemo = stableMemo2 (go newmemo)
+                let newmemo = htmemo2 (go newmemo)
                     {-# NOINLINE newmemo #-}
                  in gotyped
                       newmemo
@@ -164,11 +164,11 @@ extractSymSomeTerm = go initialMemo
             Nothing -> return HS.empty
         _ -> return HS.empty
     go _ bs (SomeTerm (ForallTerm _ _ _ _ sym arg)) =
-      let newmemo = stableMemo2 (go newmemo)
+      let newmemo = htmemo2 (go newmemo)
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (HS.insert (someTypedSymbol sym) bs) arg
     go _ bs (SomeTerm (ExistsTerm _ _ _ _ sym arg)) =
-      let newmemo = stableMemo2 (go newmemo)
+      let newmemo = htmemo2 (go newmemo)
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (HS.insert (someTypedSymbol sym) bs) arg
     go memo bs (SomeTerm (NotTerm _ _ _ _ arg)) = goUnary memo bs arg

--- a/src/Grisette/Internal/SymPrim/Prim/TermUtils.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/TermUtils.hs
@@ -35,7 +35,7 @@ import Control.Monad.State
 import Data.Data (cast)
 import Data.Foldable (Foldable (toList), traverse_)
 import qualified Data.HashSet as HS
-import Grisette.Internal.Core.Data.MemoUtils (htmemo2)
+import Grisette.Internal.Core.Data.MemoUtils (stableMemo2)
 import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Internal.Term
   ( IsSymbolKind (SymbolKindConstraint),
@@ -132,7 +132,7 @@ extractSymSomeTerm = go initialMemo
       HS.HashSet (SomeTypedConstantSymbol) ->
       SomeTerm ->
       Maybe (HS.HashSet (SomeTypedSymbol knd))
-    initialMemo = htmemo2 (go initialMemo)
+    initialMemo = stableMemo2 (go initialMemo)
     {-# NOINLINE initialMemo #-}
 
     go ::
@@ -155,7 +155,7 @@ extractSymSomeTerm = go initialMemo
           case eqTypeRep (typeRep @(-->)) gf of
             Just HRefl -> case cv of
               GeneralFun sym (tm :: Term r) ->
-                let newmemo = htmemo2 (go newmemo)
+                let newmemo = stableMemo2 (go newmemo)
                     {-# NOINLINE newmemo #-}
                  in gotyped
                       newmemo
@@ -164,11 +164,11 @@ extractSymSomeTerm = go initialMemo
             Nothing -> return HS.empty
         _ -> return HS.empty
     go _ bs (SomeTerm (ForallTerm _ _ _ _ sym arg)) =
-      let newmemo = htmemo2 (go newmemo)
+      let newmemo = stableMemo2 (go newmemo)
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (HS.insert (someTypedSymbol sym) bs) arg
     go _ bs (SomeTerm (ExistsTerm _ _ _ _ sym arg)) =
-      let newmemo = htmemo2 (go newmemo)
+      let newmemo = stableMemo2 (go newmemo)
           {-# NOINLINE newmemo #-}
        in goUnary newmemo (HS.insert (someTypedSymbol sym) bs) arg
     go memo bs (SomeTerm (NotTerm _ _ _ _ arg)) = goUnary memo bs arg

--- a/stack-lts-18.28-lowerbound.yaml
+++ b/stack-lts-18.28-lowerbound.yaml
@@ -52,7 +52,6 @@ extra-deps:
   - unordered-containers-0.2.17.0
   - template-haskell-2.16.0.0
   - deepseq-1.4.4.0
-  - hashtables-1.2.3.4
   - loch-th-0.2.2
   - th-compat-0.1.2
   - QuickCheck-2.14
@@ -74,7 +73,6 @@ extra-deps:
   - sbv-8.17
   - th-abstraction-0.4.0.0
   - atomic-primops-0.8.3
-  - concurrent-extra-0.7.0.12
   - cereal-0.5.8.1
   - cereal-text-0.1.0.2
   - bytes-0.17.1

--- a/stack-lts-18.28-lowerbound.yaml.lock
+++ b/stack-lts-18.28-lowerbound.yaml.lock
@@ -61,13 +61,6 @@ packages:
   original:
     hackage: deepseq-1.4.4.0
 - completed:
-    hackage: hashtables-1.2.3.4@sha256:510be063ee0833868f170172af3c80ca72c307f7764353e16a27ca6c1ef5cf72,8486
-    pantry-tree:
-      sha256: 04f8651d97bd392ff0bfd8858e80ae23db312af6789f0129295a93f525378f47
-      size: 3027
-  original:
-    hackage: hashtables-1.2.3.4
-- completed:
     hackage: loch-th-0.2.2@sha256:262a1f2190decd5e24c9368008a6fc87d83515f5f3a8488e384bd8acc0a5529c,805
     pantry-tree:
       sha256: eb29d168e827411d0fd6c93b9efefc95b02cc252e4c7bb47094e9d52ea955cc9
@@ -214,13 +207,6 @@ packages:
       size: 1245
   original:
     hackage: atomic-primops-0.8.3
-- completed:
-    hackage: concurrent-extra-0.7.0.12@sha256:f9a9c09770dbe32eeb3c741ef6c4e0b3389a203cd46eeb4c696b11ee66f01423,3386
-    pantry-tree:
-      sha256: 1e06b9e225a107ebcb7b1f441f0591140e63c18256fae4a2ef396c298fe44e4a
-      size: 1393
-  original:
-    hackage: concurrent-extra-0.7.0.12
 - completed:
     hackage: cereal-0.5.8.1@sha256:a08b65dd8beb3159b4a9a42c4d98ec5363cb551e78c9e9ffb7e810a676b4610b,2863
     pantry-tree:

--- a/test/Grisette/Backend/LoweringTests.hs
+++ b/test/Grisette/Backend/LoweringTests.hs
@@ -383,13 +383,13 @@ loweringTests =
   let unboundedConfig = z3 {sbvConfig = SBV.z3 {SBV.solverSetOptions = [SBV.SetLogic SBV.Logic_ALL]}}
    in testGroup
         "Lowering"
-        [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+        [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
             testCase "proper memo" $ do
               let pair = ("a" :: SymInteger, "b" :: SymInteger)
               let iter (x, y) = (y, x + y)
               let r = iterate iter pair !! 100
               m <- solve z3 $ snd r .== 0
-              assertBool "should success" $ isRight m,
+              assertBool "should success" $ isRight m,-}
           testGroup
             "Bool Lowering"
             [ testModelParse @Bool,

--- a/test/Grisette/Backend/LoweringTests.hs
+++ b/test/Grisette/Backend/LoweringTests.hs
@@ -34,7 +34,6 @@ import Grisette
     SymEq ((.==)),
     SymInteger,
     SymRep (SymType),
-    SymWordN (SymWordN),
     WordN,
     solve,
     type (-~>),
@@ -386,9 +385,9 @@ loweringTests =
         "Lowering"
         [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
             testCase "proper memo" $ do
-              let pair = ("a" :: SymWordN 1, "b" :: SymWordN 1)
+              let pair = ("a" :: SymInteger, "b" :: SymInteger)
               let iter (x, y) = (y, x + y)
-              let r = iterate iter pair !! 30
+              let r = iterate iter pair !! 100
               m <- solve z3 $ snd r .== 0
               assertBool "should success" $ isRight m,
           testGroup

--- a/test/Grisette/Backend/LoweringTests.hs
+++ b/test/Grisette/Backend/LoweringTests.hs
@@ -34,6 +34,7 @@ import Grisette
     SymEq ((.==)),
     SymInteger,
     SymRep (SymType),
+    SymWordN (SymWordN),
     WordN,
     solve,
     type (-~>),
@@ -383,13 +384,13 @@ loweringTests =
   let unboundedConfig = z3 {sbvConfig = SBV.z3 {SBV.solverSetOptions = [SBV.SetLogic SBV.Logic_ALL]}}
    in testGroup
         "Lowering"
-        [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+        [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
             testCase "proper memo" $ do
-              let pair = ("a" :: SymInteger, "b" :: SymInteger)
+              let pair = ("a" :: SymWordN 1, "b" :: SymWordN 1)
               let iter (x, y) = (y, x + y)
-              let r = iterate iter pair !! 100
+              let r = iterate iter pair !! 30
               m <- solve z3 $ snd r .== 0
-              assertBool "should success" $ isRight m,-}
+              assertBool "should success" $ isRight m,
           testGroup
             "Bool Lowering"
             [ testModelParse @Bool,

--- a/test/Grisette/Core/Data/Class/EvalSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvalSymTests.hs
@@ -49,13 +49,13 @@ evalSymTests :: Test
 evalSymTests =
   testGroup
     "EvalSym"
-    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+    [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "proper memo" $ do
           let pair = ("a" :: SymInteger, "b" :: SymInteger)
           let iter (x, y) = (y, x + y)
           let r = iterate iter pair !! 100
           Right m <- solve z3 $ snd r .== 0
-          evalSym True m (snd r) @?= 0,
+          evalSym True m (snd r) @?= 0,-}
       testGroup
         "EvalSym for common types"
         [ testGroup

--- a/test/Grisette/Core/Data/Class/EvalSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvalSymTests.hs
@@ -29,10 +29,13 @@ import Grisette
     Solvable (con, isym, ssym),
     SymBool,
     SymEq ((.==)),
+    SymInteger,
     Symbol (IndexedSymbol),
+    solve,
     typedAnySymbol,
+    z3,
   )
-import Test.Framework (Test, testGroup)
+import Test.Framework (Test, TestOptions' (topt_timeout), plusTestOptions, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
@@ -46,7 +49,14 @@ evalSymTests :: Test
 evalSymTests =
   testGroup
     "EvalSym"
-    [ testGroup
+    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+        testCase "proper memo" $ do
+          let pair = ("a" :: SymInteger, "b" :: SymInteger)
+          let iter (x, y) = (y, x + y)
+          let r = iterate iter pair !! 100
+          Right m <- solve z3 $ snd r .== 0
+          evalSym True m (snd r) @?= 0,
+      testGroup
         "EvalSym for common types"
         [ testGroup
             "SymBool"

--- a/test/Grisette/Core/Data/Class/EvalSymTests.hs
+++ b/test/Grisette/Core/Data/Class/EvalSymTests.hs
@@ -49,13 +49,13 @@ evalSymTests :: Test
 evalSymTests =
   testGroup
     "EvalSym"
-    [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "proper memo" $ do
           let pair = ("a" :: SymInteger, "b" :: SymInteger)
           let iter (x, y) = (y, x + y)
           let r = iterate iter pair !! 100
           Right m <- solve z3 $ snd r .== 0
-          evalSym True m (snd r) @?= 0,-}
+          evalSym True m (snd r) @?= 0,
       testGroup
         "EvalSym for common types"
         [ testGroup

--- a/test/Grisette/Core/Data/Class/ExtractSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ExtractSymTests.hs
@@ -59,12 +59,12 @@ extractSymTests :: Test
 extractSymTests =
   testGroup
     "ExtractSym"
-    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+    [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "proper memo" $ do
           let pair = ("a" :: SymInteger, "b" :: SymInteger)
           let iter (x, y) = (y, x + y)
           let r = iterate iter pair !! 100
-          extractSym r @?= extractSym pair,
+          extractSym r @?= extractSym pair,-}
       testGroup
         "Common types"
         [ testGroup

--- a/test/Grisette/Core/Data/Class/ExtractSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ExtractSymTests.hs
@@ -40,7 +40,8 @@ import Grisette.Core.Data.Class.TestValues
     ssymbolBool,
     symTrue,
   )
-import Test.Framework (Test, testGroup)
+import Grisette.Internal.SymPrim.SymInteger (SymInteger)
+import Test.Framework (Test, TestOptions' (topt_timeout), plusTestOptions, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
@@ -58,7 +59,13 @@ extractSymTests :: Test
 extractSymTests =
   testGroup
     "ExtractSym"
-    [ testGroup
+    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+        testCase "proper memo" $ do
+          let pair = ("a" :: SymInteger, "b" :: SymInteger)
+          let iter (x, y) = (y, x + y)
+          let r = iterate iter pair !! 100
+          extractSym r @?= extractSym pair,
+      testGroup
         "Common types"
         [ testGroup
             "SymBool"

--- a/test/Grisette/Core/Data/Class/ExtractSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ExtractSymTests.hs
@@ -59,12 +59,12 @@ extractSymTests :: Test
 extractSymTests =
   testGroup
     "ExtractSym"
-    [ {-plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
+    [ plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "proper memo" $ do
           let pair = ("a" :: SymInteger, "b" :: SymInteger)
           let iter (x, y) = (y, x + y)
           let r = iterate iter pair !! 100
-          extractSym r @?= extractSym pair,-}
+          extractSym r @?= extractSym pair,
       testGroup
         "Common types"
         [ testGroup


### PR DESCRIPTION
Previously, although the lowering process itself is memoized, the instantiation of the sbv terms isn't. This could cause severe performance problems. This pull request fixes it.

There are similar problems in `evalSym` and `extractSym`, where the incorrect usage of `stableMemo` called ineffective memorization. This problem is also fixed in the pull request.