### PR TITLE
Make grisette compatible with sbv-11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725103162,
-        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "lastModified": 1730785428,
+        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -249,7 +249,7 @@ library
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <11
+    , sbv >=8.17 && <12
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.23
     , text >=1.2.4.1 && <2.2
@@ -296,7 +296,7 @@ test-suite doctest
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <11
+    , sbv >=8.17 && <12
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.23
     , text >=1.2.4.1 && <2.2
@@ -411,7 +411,7 @@ test-suite spec
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2.0 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <11
+    , sbv >=8.17 && <12
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.23
     , test-framework >=0.8.2 && <0.9

--- a/package.yaml
+++ b/package.yaml
@@ -52,7 +52,7 @@ dependencies:
   - th-compat >= 0.1.2 && < 0.2
   - th-abstraction >= 0.4 && < 0.8
   - array >= 0.5.4 && < 0.6
-  - sbv >= 8.17 && < 11
+  - sbv >= 8.17 && < 12
   - parallel >= 3.2.2.0 && < 3.3
   - text >= 1.2.4.1 && < 2.2
   - QuickCheck >= 2.14 && < 2.16

--- a/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/SupportedPrim.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/SupportedPrim.hs
@@ -66,10 +66,12 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
         pevalITETerm,
         pformatCon,
         sameCon,
+        sbvDistinct,
+        sbvEq,
         sbvIte,
         symSBVName,
         symSBVTerm,
-        withPrim, sbvDistinct, sbvEq
+        withPrim
       ),
     SupportedPrimConstraint
       ( PrimConstraint

--- a/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/SupportedPrim.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Internal/Instances/SupportedPrim.hs
@@ -69,7 +69,7 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
         sbvIte,
         symSBVName,
         symSBVTerm,
-        withPrim
+        withPrim, sbvDistinct, sbvEq
       ),
     SupportedPrimConstraint
       ( PrimConstraint
@@ -167,6 +167,8 @@ instance (KnownNat w, 1 <= w) => SBVRep (IntN w) where
   type SBVType (IntN w) = SBV.SBV (SBV.IntN w)
 
 instance (KnownNat w, 1 <= w) => SupportedPrim (IntN w) where
+  sbvDistinct = withPrim @(IntN w) $ SBV.distinct . toList
+  sbvEq = withPrim @(IntN w) (SBV..==)
   pformatCon = show
   defaultValue = 0
   pevalITETerm = pevalITEBasicTerm
@@ -219,6 +221,8 @@ instance (KnownNat w, 1 <= w) => SBVRep (WordN w) where
   type SBVType (WordN w) = SBV.SBV (SBV.WordN w)
 
 instance (KnownNat w, 1 <= w) => SupportedPrim (WordN w) where
+  sbvDistinct = withPrim @(WordN w) $ SBV.distinct . toList
+  sbvEq = withPrim @(WordN w) (SBV..==)
   pformatCon = show
   defaultValue = 0
   pevalITETerm = pevalITEBasicTerm

--- a/src/Grisette/Internal/SymPrim/Prim/Internal/Term.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Internal/Term.hs
@@ -213,6 +213,10 @@ import Data.Text.Prettyprint.Doc
 #define SMTDefinable Uninterpreted
 #endif
 
+#if MIN_VERSION_sbv(11,0,0)
+import qualified Data.SBV as SBVTC
+#endif
+
 import Control.DeepSeq (NFData (rnf))
 import Control.Monad (msum)
 import Control.Monad.IO.Class (MonadIO)

--- a/src/Grisette/Internal/SymPrim/TabularFun.hs
+++ b/src/Grisette/Internal/SymPrim/TabularFun.hs
@@ -155,7 +155,7 @@ lowerTFunCon ::
   ( SBV.SBV (NonFuncSBVBaseType a) ->
     SBVType b
   )
-lowerTFunCon (TabularFun l d) = go l d
+lowerTFunCon (TabularFun l d) = withNonFuncPrim @a $ go l d
   where
     go [] d _ = conSBVTerm d
     go ((x, r) : xs) d v =

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,6 +42,8 @@ packages:
 #
 # Override default flag values for local packages and extra-deps
 # flags: {}
+extra-deps:
+  - sbv-11.0
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: sbv-11.0@sha256:7c8d8b54028aa33caa118b27775d669436a22812d08057c2adb1224af9890b93,25534
+    pantry-tree:
+      sha256: c58ca5ee8968337fd202ba85ac37f4b59d763863e357eee7d4d2f1c3323fc5cf
+      size: 77025
+  original:
+    hackage: sbv-11.0
 snapshots:
 - completed:
     sha256: 3e2ebb6e538654269973faf683d0068b123a6ee9462a48ac2c3f3281a7bf3f8b

--- a/test/Grisette/SymPrim/FPTests.hs
+++ b/test/Grisette/SymPrim/FPTests.hs
@@ -552,6 +552,7 @@ fpTests =
                         ( ConvertibleBound bv,
                           Num (bv n),
                           SBV.HasKind (sbvbv n),
+                          SBV.SymVal (sbvbv n),
                           Num (SBV.SBV (sbvbv n)),
                           Typeable bv
                         ) =>


### PR DESCRIPTION
This pull request bumps the upper bound for sbv to <12 and fixed some compatibility issues.