### PR TITLE
Allow literal bvs to be used under conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `SomeBV` now allows being used under conditionals even if no bit-width is
+  specified. ([#261](https://github.com/lsrcz/grisette/pull/261))
+
 ## [0.9.0.0] - 2024-11-07
 
 ### Added

--- a/test/Grisette/SymPrim/SomeBVTests.hs
+++ b/test/Grisette/SymPrim/SomeBVTests.hs
@@ -114,6 +114,30 @@ testFuncMatchLit name f a b r = testCase name $ do
   let SomeBVLit expected = r
   actual @?= expected
 
+testSymFuncMatch ::
+  String ->
+  (SomeSymIntN -> SomeSymIntN -> SomeSymIntN) ->
+  SomeSymIntN ->
+  SomeSymIntN ->
+  SomeSymIntN ->
+  Test
+testSymFuncMatch name f a b r = testCase name $ do
+  let actual = f a b
+  let expected = r
+  actual @?= expected
+
+testSymFuncMatchLit ::
+  String ->
+  (SomeSymIntN -> SomeSymIntN -> SomeSymIntN) ->
+  SomeSymIntN ->
+  SomeSymIntN ->
+  SomeSymIntN ->
+  Test
+testSymFuncMatchLit name f a b r = testCase name $ do
+  let SomeBVLit actual = f a b
+  let SomeBVLit expected = r
+  actual @?= expected
+
 testFuncMisMatch ::
   (NFData r, Show r, Eq r) =>
   (SomeIntN -> SomeIntN -> r) ->
@@ -277,6 +301,26 @@ someBVTests =
                 5
                 2
                 7,
+              testSymFuncMatch "SomeBV/SomeBV"
+                (binSomeBV (\l r -> SomeBV $ l + r) undefined )
+                (ssymBV 4 "a")
+                (ssymBV 4 "b")
+                ((ssymBV 4 "a") + (ssymBV 4 "b")),
+              testSymFuncMatch "SomeBV/SomeBVCondLit"
+                (binSomeBV (\l r -> SomeBV $ l + r) undefined )
+                (ssymBV 4 "a")
+                (symIte "b" 5 6)
+                ((ssymBV 4 "a") + symIte "b" (bv 4 5) (bv 4 6)),
+              testSymFuncMatchLit "SomeBVCondLit/SomeBVCondLit"
+                (binSomeBV undefined (\l r -> SomeBVLit $ l + r))
+                (symIte "a" 5 6)
+                (symIte "b" 5 6)
+                (symIte "a" (symIte "b" 10 11) (symIte "b" 11 12)),
+              testSymFuncMatchLit "SomeBVLit/SomeBVCondLit"
+                (binSomeBV undefined (\l r -> SomeBVLit $ l + r))
+                5
+                (symIte "b" 5 6)
+                (symIte "b" 10 11),
               testFuncMisMatch @SomeIntN
                 (binSomeBV (\l r -> SomeIntN $ l + r) undefined)
                 (bv 4 5)

--- a/test/Grisette/SymPrim/SomeBVTests.hs
+++ b/test/Grisette/SymPrim/SomeBVTests.hs
@@ -301,22 +301,26 @@ someBVTests =
                 5
                 2
                 7,
-              testSymFuncMatch "SomeBV/SomeBV"
-                (binSomeBV (\l r -> SomeBV $ l + r) undefined )
+              testSymFuncMatch
+                "SomeBV/SomeBV"
+                (binSomeBV (\l r -> SomeBV $ l + r) undefined)
                 (ssymBV 4 "a")
                 (ssymBV 4 "b")
                 ((ssymBV 4 "a") + (ssymBV 4 "b")),
-              testSymFuncMatch "SomeBV/SomeBVCondLit"
-                (binSomeBV (\l r -> SomeBV $ l + r) undefined )
+              testSymFuncMatch
+                "SomeBV/SomeBVCondLit"
+                (binSomeBV (\l r -> SomeBV $ l + r) undefined)
                 (ssymBV 4 "a")
                 (symIte "b" 5 6)
                 ((ssymBV 4 "a") + symIte "b" (bv 4 5) (bv 4 6)),
-              testSymFuncMatchLit "SomeBVCondLit/SomeBVCondLit"
+              testSymFuncMatchLit
+                "SomeBVCondLit/SomeBVCondLit"
                 (binSomeBV undefined (\l r -> SomeBVLit $ l + r))
                 (symIte "a" 5 6)
                 (symIte "b" 5 6)
                 (symIte "a" (symIte "b" 10 11) (symIte "b" 11 12)),
-              testSymFuncMatchLit "SomeBVLit/SomeBVCondLit"
+              testSymFuncMatchLit
+                "SomeBVLit/SomeBVCondLit"
                 (binSomeBV undefined (\l r -> SomeBVLit $ l + r))
                 5
                 (symIte "b" 5 6)


### PR DESCRIPTION
This pull request allows the following code to work:

```Haskell
symIte "cond" 1 2 :: SomeSymWordN
```

The result will be in the state where the bit width is undetermined. It will be assigned a bit width when further used with other bit vectors that have a bit width.
