### PR TITLE
Better interface to smart constructor generation with decapitalized names

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -153,14 +153,15 @@ library
       Grisette.Internal.SymPrim.SymInteger
       Grisette.Internal.SymPrim.SymTabularFun
       Grisette.Internal.SymPrim.TabularFun
+      Grisette.Internal.TH.Ctor.Common
+      Grisette.Internal.TH.Ctor.SmartConstructor
+      Grisette.Internal.TH.Ctor.UnifiedConstructor
       Grisette.Internal.TH.DeriveBuiltin
       Grisette.Internal.TH.DeriveInstanceProvider
       Grisette.Internal.TH.DerivePredefined
       Grisette.Internal.TH.DeriveTypeParamHandler
       Grisette.Internal.TH.DeriveUnifiedInterface
       Grisette.Internal.TH.DeriveWithHandlers
-      Grisette.Internal.TH.MergeConstructor
-      Grisette.Internal.TH.UnifiedConstructor
       Grisette.Internal.TH.Util
       Grisette.Internal.Utils.Derive
       Grisette.Internal.Utils.Parameterized

--- a/src/Grisette/Internal/TH/Ctor/Common.hs
+++ b/src/Grisette/Internal/TH/Ctor/Common.hs
@@ -1,0 +1,61 @@
+-- |
+-- Module      :   Grisette.Internal.TH.Ctor.Common
+-- Copyright   :   (c) Sirui Lu 2024
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Internal.TH.Ctor.Common
+  ( withNameTransformer,
+    prefixTransformer,
+    decapitalizeTransformer,
+  )
+where
+
+import Control.Monad (unless)
+import Data.Char (isAlphaNum, toLower)
+import Data.Foldable (traverse_)
+import Grisette.Internal.TH.Util (occName)
+import Language.Haskell.TH (Dec, Name, Q)
+import Language.Haskell.TH.Datatype
+  ( ConstructorInfo (constructorName),
+    DatatypeInfo (datatypeCons),
+    reifyDatatype,
+  )
+
+checkName :: String -> Q ()
+checkName name =
+  unless (all (\x -> isAlphaNum x || x == '\'' || x == '_') name) $
+    fail
+      ( "Constructor name contain invalid characters, consider providing a "
+          ++ "custom name: "
+          ++ show name
+      )
+
+-- | Generate smart constructor given a type name, using a name transformer
+-- to transform constructor names.
+withNameTransformer ::
+  -- | A function that generates decs given a list of constructor names and a
+  -- type name
+  ([String] -> Name -> Q [Dec]) ->
+  -- | A function that transforms constructor names
+  (String -> String) ->
+  -- | The type to generate the wrappers for
+  Name ->
+  Q [Dec]
+withNameTransformer namedGen nameTransformer typName = do
+  d <- reifyDatatype typName
+  let constructorNames = occName . constructorName <$> datatypeCons d
+  let transformedNames = nameTransformer <$> constructorNames
+  traverse_ checkName transformedNames
+  namedGen transformedNames typName
+
+-- | A name transformer that prefixes a string to the constructor name
+prefixTransformer :: String -> String -> String
+prefixTransformer = (++)
+
+-- | A name transformer that converts the first character to lowercase
+decapitalizeTransformer :: String -> String
+decapitalizeTransformer (x : xs) = toLower x : xs
+decapitalizeTransformer [] = []

--- a/src/Grisette/Internal/TH/Ctor/SmartConstructor.hs
+++ b/src/Grisette/Internal/TH/Ctor/SmartConstructor.hs
@@ -3,24 +3,31 @@
 {-# LANGUAGE Trustworthy #-}
 
 -- |
--- Module      :   Grisette.Internal.TH.MergedConstructor
+-- Module      :   Grisette.Internal.TH.Ctor.SmartConstructor
 -- Copyright   :   (c) Sirui Lu 2021-2024
 -- License     :   BSD-3-Clause (see the LICENSE file)
 --
 -- Maintainer  :   siruilu@cs.washington.edu
 -- Stability   :   Experimental
 -- Portability :   GHC only
-module Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
-    mkMergeConstructor',
+module Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makeSmartCtorWith,
+    makePrefixedSmartCtor,
+    makeNamedSmartCtor,
+    makeSmartCtor,
   )
 where
 
 import Control.Monad (join, replicateM, when, zipWithM)
 import Data.Bifunctor (Bifunctor (second))
 import Grisette.Internal.Core.Data.Class.Mergeable (Mergeable)
-import Grisette.Internal.Core.Data.Class.TryMerge (TryMerge)
-import Grisette.Internal.TH.Util (constructorInfoToType, occName, putHaddock)
+import Grisette.Internal.Core.Data.Class.TryMerge (TryMerge, mrgSingle)
+import Grisette.Internal.TH.Ctor.Common
+  ( decapitalizeTransformer,
+    prefixTransformer,
+    withNameTransformer,
+  )
+import Grisette.Internal.TH.Util (constructorInfoToType, putHaddock)
 import Language.Haskell.TH
   ( Body (NormalB),
     Clause (Clause),
@@ -49,49 +56,75 @@ import Language.Haskell.TH.Datatype.TyVarBndr
   )
 
 -- | Generate constructor wrappers that wraps the result in a container with
+-- `TryMerge` with provided name transformer.
+--
+-- > makeSmartCtorWith (\name -> "mrg" ++ name) ''Maybe
+--
+-- generates
+--
+-- > mrgNothing :: (Mergeable (Maybe a), Applicative m, TryMerge m) => m (Maybe a)
+-- > mrgNothing = mrgSingle Nothing
+makeSmartCtorWith :: (String -> String) -> Name -> Q [Dec]
+makeSmartCtorWith = withNameTransformer makeNamedSmartCtor
+
+-- | Generate constructor wrappers that wraps the result in a container with
+-- `TryMerge`.
+--
+-- > makePrefixedSmartCtor "mrg" ''Maybe
+--
+-- generates
+--
+-- > mrgNothing :: (Mergeable (Maybe a), Applicative m, TryMerge m) => m (Maybe a)
+-- > mrgNothing = mrgSingle Nothing
+-- > mrgJust :: (Mergeable (Maybe a), Applicative m, TryMerge m) => a -> m (Maybe a)
+-- > mrgJust = \x -> mrgSingle (Just x)
+makePrefixedSmartCtor ::
+  -- | Prefix for generated wrappers
+  String ->
+  -- | The type to generate the wrappers for
+  Name ->
+  Q [Dec]
+makePrefixedSmartCtor = makeSmartCtorWith . prefixTransformer
+
+-- | Generate constructor wrappers that wraps the result in a container with
+-- `TryMerge`.
+--
+-- > makeSmartCtor ''Maybe
+--
+-- generates
+--
+-- > nothing :: (Mergeable (Maybe a), Applicative m, TryMerge m) => m (Maybe a)
+-- > nothing = mrgSingle Nothing
+-- > just :: (Mergeable (Maybe a), Applicative m, TryMerge m) => a -> m (Maybe a)
+-- > just = \x -> mrgSingle (Just x)
+makeSmartCtor ::
+  -- | The type to generate the wrappers for
+  Name ->
+  Q [Dec]
+makeSmartCtor = makeSmartCtorWith decapitalizeTransformer
+
+-- | Generate constructor wrappers that wraps the result in a container with
 -- `TryMerge` with provided names.
 --
--- > mkMergeConstructor' ["mrgTuple2"] ''(,)
+-- > makeNamedSmartCtor ["mrgTuple2"] ''(,)
 --
 -- generates
 --
 -- > mrgTuple2 :: (Mergeable (a, b), Applicative m, TryMerge m) => a -> b -> u (a, b)
 -- > mrgTuple2 = \v1 v2 -> mrgSingle (v1, v2)
-mkMergeConstructor' ::
+makeNamedSmartCtor ::
   -- | Names for generated wrappers
   [String] ->
   -- | The type to generate the wrappers for
   Name ->
   Q [Dec]
-mkMergeConstructor' names typName = do
+makeNamedSmartCtor names typName = do
   d <- reifyDatatype typName
   let constructors = datatypeCons d
   when (length names /= length constructors) $
     fail "Number of names does not match the number of constructors"
   ds <- zipWithM (mkSingleWrapper d) names constructors
   return $ join ds
-
--- | Generate constructor wrappers that wraps the result in a container with
--- `TryMerge`.
---
--- > mkMergeConstructor "mrg" ''Maybe
---
--- generates
---
--- > mrgJust :: (Mergeable (Maybe a), Applicative m, TryMerge m) => m (Maybe a)
--- > mrgNothing = mrgSingle Nothing
--- > mrgJust :: (Mergeable (Maybe a), Applicative m, TryMerge m) => a -> m (Maybe a)
--- > mrgJust = \x -> mrgSingle (Just x)
-mkMergeConstructor ::
-  -- | Prefix for generated wrappers
-  String ->
-  -- | The type to generate the wrappers for
-  Name ->
-  Q [Dec]
-mkMergeConstructor prefix typName = do
-  d <- reifyDatatype typName
-  let constructorNames = occName . constructorName <$> datatypeCons d
-  mkMergeConstructor' ((prefix ++) <$> constructorNames) typName
 
 augmentNormalCExpr :: Int -> Exp -> Q Exp
 augmentNormalCExpr n f = do

--- a/src/Grisette/Lib/Data/Bool.hs
+++ b/src/Grisette/Lib/Data/Bool.hs
@@ -13,9 +13,8 @@
 -- Portability :   GHC only
 module Grisette.Lib.Data.Bool (mrgTrue, mrgFalse) where
 
-import Grisette.Internal.Core.Data.Class.TryMerge (mrgSingle)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makePrefixedSmartCtor,
   )
 
-mkMergeConstructor "mrg" ''Bool
+makePrefixedSmartCtor "mrg" ''Bool

--- a/src/Grisette/Lib/Data/Either.hs
+++ b/src/Grisette/Lib/Data/Either.hs
@@ -13,9 +13,8 @@
 -- Portability :   GHC only
 module Grisette.Lib.Data.Either (mrgLeft, mrgRight) where
 
-import Grisette.Internal.Core.Data.Class.TryMerge (mrgSingle)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makePrefixedSmartCtor,
   )
 
-mkMergeConstructor "mrg" ''Either
+makePrefixedSmartCtor "mrg" ''Either

--- a/src/Grisette/Lib/Data/Functor/Sum.hs
+++ b/src/Grisette/Lib/Data/Functor/Sum.hs
@@ -14,9 +14,8 @@
 module Grisette.Lib.Data.Functor.Sum (mrgInR, mrgInL) where
 
 import Data.Functor.Sum (Sum)
-import Grisette.Internal.Core.Data.Class.TryMerge (mrgSingle)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makePrefixedSmartCtor,
   )
 
-mkMergeConstructor "mrg" ''Sum
+makePrefixedSmartCtor "mrg" ''Sum

--- a/src/Grisette/Lib/Data/Maybe.hs
+++ b/src/Grisette/Lib/Data/Maybe.hs
@@ -13,9 +13,8 @@
 -- Portability :   GHC only
 module Grisette.Lib.Data.Maybe (mrgNothing, mrgJust) where
 
-import Grisette.Internal.Core.Data.Class.TryMerge (mrgSingle)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makePrefixedSmartCtor,
   )
 
-mkMergeConstructor "mrg" ''Maybe
+makePrefixedSmartCtor "mrg" ''Maybe

--- a/src/Grisette/Lib/Data/Tuple.hs
+++ b/src/Grisette/Lib/Data/Tuple.hs
@@ -24,16 +24,15 @@ module Grisette.Lib.Data.Tuple
   )
 where
 
-import Grisette.Internal.Core.Data.Class.TryMerge (mrgSingle)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor',
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makeNamedSmartCtor,
   )
 
-mkMergeConstructor' ["mrgUnit"] ''()
-mkMergeConstructor' ["mrgTuple2"] ''(,)
-mkMergeConstructor' ["mrgTuple3"] ''(,,)
-mkMergeConstructor' ["mrgTuple4"] ''(,,,)
-mkMergeConstructor' ["mrgTuple5"] ''(,,,,)
-mkMergeConstructor' ["mrgTuple6"] ''(,,,,,)
-mkMergeConstructor' ["mrgTuple7"] ''(,,,,,,)
-mkMergeConstructor' ["mrgTuple8"] ''(,,,,,,,)
+makeNamedSmartCtor ["mrgUnit"] ''()
+makeNamedSmartCtor ["mrgTuple2"] ''(,)
+makeNamedSmartCtor ["mrgTuple3"] ''(,,)
+makeNamedSmartCtor ["mrgTuple4"] ''(,,,)
+makeNamedSmartCtor ["mrgTuple5"] ''(,,,,)
+makeNamedSmartCtor ["mrgTuple6"] ''(,,,,,)
+makeNamedSmartCtor ["mrgTuple7"] ''(,,,,,,)
+makeNamedSmartCtor ["mrgTuple8"] ''(,,,,,,,)

--- a/src/Grisette/TH.hs
+++ b/src/Grisette/TH.hs
@@ -15,12 +15,16 @@ module Grisette.TH
     deriveAllExcept,
 
     -- * Smart constructors that merges in a monad
-    mkMergeConstructor,
-    mkMergeConstructor',
+    makePrefixedSmartCtor,
+    makeNamedSmartCtor,
+    makeSmartCtor,
+    makeSmartCtorWith,
 
     -- * Smart constructors that are polymorphic in evaluation modes
-    mkUnifiedConstructor,
-    mkUnifiedConstructor',
+    makePrefixedUnifiedCtor,
+    makeNamedUnifiedCtor,
+    makeUnifiedCtor,
+    makeUnifiedCtorWith,
 
     -- * Tools for building more derivation procedures
 
@@ -51,6 +55,18 @@ module Grisette.TH
   )
 where
 
+import Grisette.Internal.TH.Ctor.SmartConstructor
+  ( makeNamedSmartCtor,
+    makePrefixedSmartCtor,
+    makeSmartCtor,
+    makeSmartCtorWith,
+  )
+import Grisette.Internal.TH.Ctor.UnifiedConstructor
+  ( makeNamedUnifiedCtor,
+    makePrefixedUnifiedCtor,
+    makeUnifiedCtor,
+    makeUnifiedCtorWith,
+  )
 import Grisette.Internal.TH.DeriveBuiltin
   ( deriveBuiltinExtra,
   )
@@ -81,11 +97,3 @@ import Grisette.Internal.TH.DeriveUnifiedInterface
     deriveUnifiedInterfaceExtra,
   )
 import Grisette.Internal.TH.DeriveWithHandlers (deriveWithHandlers)
-import Grisette.Internal.TH.MergeConstructor
-  ( mkMergeConstructor,
-    mkMergeConstructor',
-  )
-import Grisette.Internal.TH.UnifiedConstructor
-  ( mkUnifiedConstructor,
-    mkUnifiedConstructor',
-  )

--- a/test/Grisette/Unified/UnifiedConstructorTest.hs
+++ b/test/Grisette/Unified/UnifiedConstructorTest.hs
@@ -29,7 +29,7 @@ import Grisette.Unified.Internal.UnifiedData (GetData, UnifiedData)
 import Control.Monad.Identity (Identity (Identity))
 import Generics.Deriving (Default (Default))
 import Grisette (Solvable (con), SymInteger, ToSym (toSym), Union, mrgReturn)
-import Grisette.TH (deriveAll, mkUnifiedConstructor, mkUnifiedConstructor')
+import Grisette.TH (deriveAll, makeNamedUnifiedCtor, makePrefixedUnifiedCtor)
 import Grisette.Unified.Internal.EvalMode (EvalModeBase)
 import Grisette.Unified.Internal.EvalModeTag (EvalModeTag (Sym))
 import Grisette.Unified.Internal.UnifiedBool (UnifiedBool (GetBool))
@@ -42,7 +42,7 @@ data T mode a
   | T1
 
 deriveAll ''T
-mkUnifiedConstructor "mk" ''T
+makePrefixedUnifiedCtor "mk" ''T
 
 #if MIN_VERSION_base(4,16,0)
 type FConstraint mode = (EvalModeBase mode)
@@ -57,12 +57,12 @@ f = mkT (toSym True) 10 mkT1
 data TNoMode a = TNoMode0 Bool a (TNoMode a) | TNoMode1
 
 deriveAll ''TNoMode
-mkUnifiedConstructor' ["tNoMode0", "tNoMode1"] ''TNoMode
+makeNamedUnifiedCtor ["tNoMode0", "tNoMode1"] ''TNoMode
 
 data TNoArg = TNoArg
 
 deriveAll ''TNoArg
-mkUnifiedConstructor "mk" ''TNoArg
+makePrefixedUnifiedCtor "mk" ''TNoArg
 
 unifiedConstructorTest :: Test
 unifiedConstructorTest =


### PR DESCRIPTION
This pull request adds better interface to smart constructors.

Given the data type

```haskell
data T a = T1 | T2 a
makeSmartCtor ''T
```

will now generate

```haskell
t1 :: (Mergeable (T a), Applicative m, TryMerge m) => m (T a)
t1 = mrgSingle T1
t2 :: (Mergeable (T a), Applicative m, TryMerge m) => a -> m (T a)
t2 = \x -> mrgSingle (T2 x)
```