### PR TITLE
Add derivation for cereal and binary

### DIFF
--- a/grisette.cabal
+++ b/grisette.cabal
@@ -162,6 +162,8 @@ library
       Grisette.Internal.TH.GADT.Common
       Grisette.Internal.TH.GADT.ConvertOpCommon
       Grisette.Internal.TH.GADT.DeriveAllSyms
+      Grisette.Internal.TH.GADT.DeriveBinary
+      Grisette.Internal.TH.GADT.DeriveCereal
       Grisette.Internal.TH.GADT.DeriveEq
       Grisette.Internal.TH.GADT.DeriveEvalSym
       Grisette.Internal.TH.GADT.DeriveExtractSym
@@ -182,6 +184,7 @@ library
       Grisette.Internal.TH.GADT.DeriveUnifiedSimpleMergeable
       Grisette.Internal.TH.GADT.DeriveUnifiedSymEq
       Grisette.Internal.TH.GADT.DeriveUnifiedSymOrd
+      Grisette.Internal.TH.GADT.SerializeCommon
       Grisette.Internal.TH.GADT.ShowPPrintCommon
       Grisette.Internal.TH.GADT.UnaryOpCommon
       Grisette.Internal.TH.GADT.UnifiedOpCommon

--- a/src/Grisette/Internal/TH/GADT/Common.hs
+++ b/src/Grisette/Internal/TH/GADT/Common.hs
@@ -280,7 +280,8 @@ data DeriveConfig = DeriveConfig
     fpBitSizePositions :: [(Int, Int)],
     needExtraMergeableUnderEvalMode :: Bool,
     needExtraMergeableWithConcretizedEvalMode :: Bool,
-    useNoStrategy :: Bool
+    useNoStrategy :: Bool,
+    useSerialForCerealAndBinary :: Bool
   }
 
 -- | Get all the evaluation modes to specialize in the t'DeriveConfig'.
@@ -295,10 +296,24 @@ evalModeSpecializeList DeriveConfig {..} =
     evalModeConfig
 
 instance Semigroup DeriveConfig where
-  (<>) = (<>)
+  l <> r =
+    DeriveConfig
+      { evalModeConfig = evalModeConfig l <> evalModeConfig r,
+        bitSizePositions = bitSizePositions l <> bitSizePositions r,
+        fpBitSizePositions = fpBitSizePositions l <> fpBitSizePositions r,
+        needExtraMergeableUnderEvalMode =
+          needExtraMergeableUnderEvalMode l
+            || needExtraMergeableUnderEvalMode r,
+        needExtraMergeableWithConcretizedEvalMode =
+          needExtraMergeableWithConcretizedEvalMode l
+            || needExtraMergeableWithConcretizedEvalMode r,
+        useNoStrategy = useNoStrategy l || useNoStrategy r,
+        useSerialForCerealAndBinary =
+          useSerialForCerealAndBinary l && useSerialForCerealAndBinary r
+      }
 
 instance Monoid DeriveConfig where
-  mempty = DeriveConfig [] [] [] False False False
+  mempty = DeriveConfig [] [] [] False False False True
   mappend = (<>)
 
 -- | Generate extra constraints for evaluation modes.

--- a/src/Grisette/Internal/TH/GADT/DeriveAllSyms.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveAllSyms.hs
@@ -29,9 +29,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig

--- a/src/Grisette/Internal/TH/GADT/DeriveAllSyms.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveAllSyms.hs
@@ -31,7 +31,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig
@@ -58,7 +58,7 @@ allSymsConfig =
               { extraPatNames = [],
                 extraLiftedPatNames = const [],
                 fieldResFun = defaultFieldResFun,
-                fieldCombineFun = \_ _ _ _ exp ->
+                fieldCombineFun = \_ _ _ _ _ exp ->
                   return (AppE (VarE 'mconcat) $ ListE exp, False <$ exp),
                 fieldFunExp =
                   defaultFieldFunExp
@@ -72,7 +72,8 @@ allSymsConfig =
       unaryOpInstanceNames = [''AllSyms, ''AllSyms1, ''AllSyms2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'AllSyms' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveBinary.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveBinary.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 -- |
 -- Module      :   Grisette.Internal.TH.GADT.DeriveBinary

--- a/src/Grisette/Internal/TH/GADT/DeriveBinary.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveBinary.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+-- |
+-- Module      :   Grisette.Internal.TH.GADT.DeriveBinary
+-- Copyright   :   (c) Sirui Lu 2024
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Internal.TH.GADT.DeriveBinary (deriveGADTBinary) where
+
+import Data.Binary (Binary (get, put))
+import Grisette.Internal.TH.GADT.Common
+  ( DeriveConfig (useSerialForCerealAndBinary),
+  )
+import Grisette.Internal.TH.GADT.SerializeCommon
+  ( serializeConfig,
+    serializeWithSerialConfig,
+  )
+import Grisette.Internal.TH.GADT.UnaryOpCommon
+  ( UnaryOpClassConfig,
+    genUnaryOpClass,
+  )
+import Language.Haskell.TH (Dec, Name, Q)
+
+binaryConfig :: UnaryOpClassConfig
+binaryConfig = serializeConfig [''Binary] ['put] ['get]
+
+binaryWithSerialConfig :: UnaryOpClassConfig
+binaryWithSerialConfig =
+  serializeWithSerialConfig [''Binary] ['put] ['get]
+
+-- | Derive 'Binary' instance for a GADT.
+deriveGADTBinary :: DeriveConfig -> Name -> Q [Dec]
+deriveGADTBinary deriveConfig =
+  genUnaryOpClass
+    deriveConfig
+    ( if useSerialForCerealAndBinary deriveConfig
+        then binaryWithSerialConfig
+        else binaryConfig
+    )
+    0

--- a/src/Grisette/Internal/TH/GADT/DeriveCereal.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveCereal.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 -- |
 -- Module      :   Grisette.Internal.TH.GADT.DeriveCereal

--- a/src/Grisette/Internal/TH/GADT/DeriveCereal.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveCereal.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+-- |
+-- Module      :   Grisette.Internal.TH.GADT.DeriveCereal
+-- Copyright   :   (c) Sirui Lu 2024
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Internal.TH.GADT.DeriveCereal (deriveGADTCereal) where
+
+import Data.Serialize (Serialize (get, put))
+import Grisette.Internal.TH.GADT.Common
+  ( DeriveConfig (useSerialForCerealAndBinary),
+  )
+import Grisette.Internal.TH.GADT.SerializeCommon
+  ( serializeConfig,
+    serializeWithSerialConfig,
+  )
+import Grisette.Internal.TH.GADT.UnaryOpCommon
+  ( UnaryOpClassConfig,
+    genUnaryOpClass,
+  )
+import Language.Haskell.TH (Dec, Name, Q)
+
+cerealConfig :: UnaryOpClassConfig
+cerealConfig = serializeConfig [''Serialize] ['put] ['get]
+
+cerealWithSerialConfig :: UnaryOpClassConfig
+cerealWithSerialConfig =
+  serializeWithSerialConfig [''Serialize] ['put] ['get]
+
+-- | Derive 'Serialize' instance for a GADT.
+deriveGADTCereal :: DeriveConfig -> Name -> Q [Dec]
+deriveGADTCereal deriveConfig =
+  genUnaryOpClass
+    deriveConfig
+    ( if useSerialForCerealAndBinary deriveConfig
+        then cerealWithSerialConfig
+        else cerealConfig
+    )
+    0

--- a/src/Grisette/Internal/TH/GADT/DeriveEvalSym.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveEvalSym.hs
@@ -33,6 +33,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
         unaryOpInstanceTypeFromConfig
@@ -67,7 +68,7 @@ evalSymConfig =
               { extraPatNames = ["fillDefault", "model"],
                 extraLiftedPatNames = const [],
                 fieldResFun = defaultFieldResFun,
-                fieldCombineFun = \_ _ con extraPat exp -> do
+                fieldCombineFun = \_ _ _ con extraPat exp -> do
                   return (foldl AppE (ConE con) exp, False <$ extraPat),
                 fieldFunExp =
                   defaultFieldFunExp ['evalSym, 'liftEvalSym, 'liftEvalSym2]
@@ -78,7 +79,8 @@ evalSymConfig =
         [''EvalSym, ''EvalSym1, ''EvalSym2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'EvalSym' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveExtractSym.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveExtractSym.hs
@@ -29,6 +29,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
         unaryOpInstanceTypeFromConfig
@@ -63,7 +64,7 @@ extractSymConfig =
               { extraPatNames = [],
                 extraLiftedPatNames = const [],
                 fieldResFun = defaultFieldResFun,
-                fieldCombineFun = \_ _ _ _ exp ->
+                fieldCombineFun = \_ _ _ _ _ exp ->
                   if null exp
                     then (,[]) <$> [|return mempty|]
                     else return (AppE (VarE 'mconcat) $ ListE exp, False <$ exp),
@@ -83,7 +84,8 @@ extractSymConfig =
         [''ExtractSym, ''ExtractSym1, ''ExtractSym2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'ExtractSym' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveGADT.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveGADT.hs
@@ -237,6 +237,10 @@ import Grisette.Internal.TH.GADT.DeriveUnifiedSymOrd
   )
 import Grisette.Internal.Unified.EvalModeTag (EvalModeTag (C, S))
 import Language.Haskell.TH (Dec, Name, Q)
+import Data.Binary (Binary)
+import Data.Serialize (Serialize)
+import Grisette.Internal.TH.GADT.DeriveBinary (deriveGADTBinary)
+import Grisette.Internal.TH.GADT.DeriveCereal (deriveGADTCereal)
 
 deriveProcedureMap :: M.Map Name (DeriveConfig -> Name -> Q [Dec])
 deriveProcedureMap =
@@ -297,7 +301,9 @@ deriveProcedureMap =
       (''SimpleMergeable2, deriveGADTSimpleMergeable2),
       (''UnifiedSimpleMergeable, deriveGADTUnifiedSimpleMergeable),
       (''UnifiedSimpleMergeable1, deriveGADTUnifiedSimpleMergeable1),
-      (''UnifiedSimpleMergeable2, deriveGADTUnifiedSimpleMergeable2)
+      (''UnifiedSimpleMergeable2, deriveGADTUnifiedSimpleMergeable2),
+      (''Binary, deriveGADTBinary),
+      (''Serialize, deriveGADTCereal)
     ]
 
 deriveSingleGADT :: DeriveConfig -> Name -> Name -> Q [Dec]
@@ -444,18 +450,23 @@ deriveGADTWith' deriveConfig typName classNameList = do
 -- * 'SimpleMergeable'
 -- * 'SimpleMergeable1'
 -- * 'SimpleMergeable2'
+-- * 'Binary'
+-- * 'Serialize'
 --
 -- Note that the following type classes cannot be derived for GADTs with
 -- existential type variables.
 --
--- * 'Eq1'
--- * 'Eq2'
--- * 'SymEq1'
--- * 'SymEq2'
--- * 'Ord1'
--- * 'Ord2'
--- * 'SymOrd1'
--- * 'SymOrd2'
+-- * 'ToCon'
+-- * 'ToCon1'
+-- * 'ToCon2'
+-- * 'ToSym'
+-- * 'ToSym1'
+-- * 'ToSym2'
+-- * 'Serial'
+-- * 'Serial1'
+-- * 'Serial2'
+-- * 'Binary'
+-- * 'Serialize'
 deriveGADTWith :: DeriveConfig -> [Name] -> [Name] -> Q [Dec]
 deriveGADTWith deriveConfig typeNameList classNameList = do
   let typeNames = S.toList $ S.fromList typeNameList
@@ -600,10 +611,12 @@ basicClasses0 =
 -- This includes:
 --
 -- * 'Serial'
+-- * 'Serialize'
+-- * 'Binary'
 -- * 'ToCon'
 -- * 'ToSym'
 noExistentialClasses0 :: [Name]
-noExistentialClasses0 = [''Serial, ''ToCon, ''ToSym]
+noExistentialClasses0 = [''Serial, ''ToCon, ''ToSym, ''Serialize, ''Binary]
 
 -- | Concrete ordered classes that can be derived for GADTs that
 --

--- a/src/Grisette/Internal/TH/GADT/DeriveGADT.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveGADT.hs
@@ -54,11 +54,13 @@ where
 
 import Control.Arrow (Arrow (second))
 import Control.DeepSeq (NFData, NFData1, NFData2)
+import Data.Binary (Binary)
 import Data.Bytes.Serial (Serial, Serial1, Serial2)
 import Data.Functor.Classes (Eq1, Eq2, Ord1, Ord2, Show1, Show2)
 import Data.Hashable (Hashable)
 import Data.Hashable.Lifted (Hashable1, Hashable2)
 import qualified Data.Map as M
+import Data.Serialize (Serialize)
 import qualified Data.Set as S
 import Grisette.Internal.Internal.Decl.Core.Data.Class.EvalSym
   ( EvalSym,
@@ -144,6 +146,8 @@ import Grisette.Internal.TH.GADT.DeriveAllSyms
     deriveGADTAllSyms1,
     deriveGADTAllSyms2,
   )
+import Grisette.Internal.TH.GADT.DeriveBinary (deriveGADTBinary)
+import Grisette.Internal.TH.GADT.DeriveCereal (deriveGADTCereal)
 import Grisette.Internal.TH.GADT.DeriveEq
   ( deriveGADTEq,
     deriveGADTEq1,
@@ -237,10 +241,6 @@ import Grisette.Internal.TH.GADT.DeriveUnifiedSymOrd
   )
 import Grisette.Internal.Unified.EvalModeTag (EvalModeTag (C, S))
 import Language.Haskell.TH (Dec, Name, Q)
-import Data.Binary (Binary)
-import Data.Serialize (Serialize)
-import Grisette.Internal.TH.GADT.DeriveBinary (deriveGADTBinary)
-import Grisette.Internal.TH.GADT.DeriveCereal (deriveGADTCereal)
 
 deriveProcedureMap :: M.Map Name (DeriveConfig -> Name -> Q [Dec])
 deriveProcedureMap =

--- a/src/Grisette/Internal/TH/GADT/DeriveHashable.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveHashable.hs
@@ -26,6 +26,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
         unaryOpInstanceTypeFromConfig
@@ -54,7 +55,7 @@ hashableConfig =
               { extraPatNames = ["salt"],
                 extraLiftedPatNames = const [],
                 fieldCombineFun =
-                  \_ _ _ [salt] exp -> do
+                  \_ _ _ _ [salt] exp -> do
                     r <-
                       foldl
                         (\salt exp -> [|$(return exp) $salt|])
@@ -74,7 +75,8 @@ hashableConfig =
         [''Hashable, ''Hashable1, ''Hashable2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'Hashable' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveMergeable.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveMergeable.hs
@@ -62,9 +62,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFunConfig (genUnaryOpFun),

--- a/src/Grisette/Internal/TH/GADT/DeriveMergeable.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveMergeable.hs
@@ -64,7 +64,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFunConfig (genUnaryOpFun),
@@ -535,7 +535,8 @@ mergeableNoExistentialConfig =
         [''Mergeable, ''Mergeable1, ''Mergeable2, ''Mergeable3],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = False
+      unaryOpAllowExistential = False,
+      unaryOpContextNames = Nothing
     }
 
 newtype MergeableNoExistentialConfig = MergeableNoExistentialConfig

--- a/src/Grisette/Internal/TH/GADT/DeriveNFData.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveNFData.hs
@@ -24,7 +24,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig
@@ -51,7 +51,7 @@ nfdataConfig =
             UnaryOpFieldConfig
               { extraPatNames = [],
                 extraLiftedPatNames = const [],
-                fieldCombineFun = \_ _ _ _ exps -> do
+                fieldCombineFun = \_ _ _ _ _ exps -> do
                   r <-
                     foldl
                       (\acc exp -> [|$acc `seq` $(return exp)|])
@@ -66,7 +66,8 @@ nfdataConfig =
       unaryOpInstanceNames = [''NFData, ''NFData1, ''NFData2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'NFData' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveNFData.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveNFData.hs
@@ -22,9 +22,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig

--- a/src/Grisette/Internal/TH/GADT/DerivePPrint.hs
+++ b/src/Grisette/Internal/TH/GADT/DerivePPrint.hs
@@ -44,7 +44,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig
@@ -83,7 +83,7 @@ pprintConfig =
             UnaryOpFieldConfig
               { extraPatNames = ["prec"],
                 extraLiftedPatNames = \i -> (["pl" | i /= 0]),
-                fieldCombineFun = \_ variant conName [prec] exps -> do
+                fieldCombineFun = \_ _ variant conName [prec] exps -> do
                   let initExps =
                         ( \e ->
                             [|
@@ -193,7 +193,8 @@ pprintConfig =
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceNames = [''PPrint, ''PPrint1, ''PPrint2],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'PPrint' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DerivePPrint.hs
+++ b/src/Grisette/Internal/TH/GADT/DerivePPrint.hs
@@ -42,9 +42,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig

--- a/src/Grisette/Internal/TH/GADT/DeriveSerial.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveSerial.hs
@@ -17,178 +17,25 @@ module Grisette.Internal.TH.GADT.DeriveSerial
   )
 where
 
-import Control.Monad (zipWithM)
 import Data.Bytes.Serial
   ( Serial (deserialize, serialize),
     Serial1 (deserializeWith, serializeWith),
     Serial2 (deserializeWith2, serializeWith2),
   )
-import qualified Data.Map as M
-import Data.Maybe (mapMaybe)
-import qualified Data.Set as S
 import Grisette.Internal.TH.GADT.Common (DeriveConfig)
+import Grisette.Internal.TH.GADT.SerializeCommon (serializeConfig)
 import Grisette.Internal.TH.GADT.UnaryOpCommon
-  ( FieldFunExp,
-    UnaryOpClassConfig
-      ( UnaryOpClassConfig,
-        unaryOpAllowExistential,
-        unaryOpConfigs,
-        unaryOpExtraVars,
-        unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
-      ),
-    UnaryOpConfig (UnaryOpConfig),
-    UnaryOpFieldConfig
-      ( UnaryOpFieldConfig,
-        extraLiftedPatNames,
-        extraPatNames,
-        fieldCombineFun,
-        fieldFunExp,
-        fieldResFun
-      ),
-    UnaryOpFunConfig (genUnaryOpFun),
-    defaultFieldFunExp,
-    defaultUnaryOpInstanceTypeFromConfig,
+  ( UnaryOpClassConfig,
     genUnaryOpClass,
   )
-import Grisette.Internal.TH.Util (integerE)
-import Language.Haskell.TH
-  ( Body (NormalB),
-    Clause (Clause),
-    Dec (FunD),
-    Lit (IntegerL),
-    Match (Match),
-    Name,
-    Pat (LitP, VarP, WildP),
-    Q,
-    Type (VarT),
-    bindS,
-    caseE,
-    conE,
-    conT,
-    doE,
-    match,
-    mkName,
-    newName,
-    noBindS,
-    normalB,
-    sigP,
-    varE,
-    varP,
-    wildP,
-  )
-import Language.Haskell.TH.Datatype
-  ( ConstructorInfo (constructorFields, constructorName),
-    TypeSubstitution (freeVariables),
-    resolveTypeSynonyms,
-  )
-
-newtype UnaryOpDeserializeConfig = UnaryOpDeserializeConfig
-  {fieldDeserializeFun :: FieldFunExp}
-
-instance UnaryOpFunConfig UnaryOpDeserializeConfig where
-  genUnaryOpFun
-    _
-    UnaryOpDeserializeConfig {..}
-    funNames
-    n
-    _
-    _
-    argTypes
-    _
-    constructors = do
-      allFields <-
-        mapM resolveTypeSynonyms $
-          concatMap constructorFields constructors
-      let usedArgs = S.fromList $ freeVariables allFields
-      args <-
-        traverse
-          ( \(ty, _) -> do
-              case ty of
-                VarT nm ->
-                  if S.member nm usedArgs
-                    then do
-                      pname <- newName "p"
-                      return (nm, Just pname)
-                    else return ('undefined, Nothing)
-                _ -> return ('undefined, Nothing)
-          )
-          argTypes
-      let argToFunPat =
-            M.fromList $ mapMaybe (\(nm, mpat) -> fmap (nm,) mpat) args
-      let funPats = fmap (maybe WildP VarP . snd) args
-      let genAuxFunMatch conIdx conInfo = do
-            fields <- mapM resolveTypeSynonyms $ constructorFields conInfo
-            defaultFieldFunExps <-
-              traverse
-                (fieldDeserializeFun argToFunPat M.empty)
-                fields
-            let conName = constructorName conInfo
-            exp <-
-              foldl
-                (\exp fieldFun -> [|$exp <*> $(return fieldFun)|])
-                [|return $(conE conName)|]
-                defaultFieldFunExps
-            return $ Match (LitP (IntegerL conIdx)) (NormalB exp) []
-      auxMatches <- zipWithM genAuxFunMatch [0 ..] constructors
-      auxFallbackMatch <- match wildP (normalB [|undefined|]) []
-      let instanceFunName = funNames !! n
-      -- let auxFunName = mkName "go"
-      let selName = mkName "sel"
-      exp <-
-        doE
-          [ bindS
-              (sigP (varP selName) (conT ''Int))
-              [|deserialize|],
-            noBindS $
-              caseE (varE selName) $
-                return <$> auxMatches ++ [auxFallbackMatch]
-          ]
-      return $
-        FunD
-          instanceFunName
-          [ Clause
-              funPats
-              (NormalB exp)
-              []
-          ]
+import Language.Haskell.TH (Dec, Name, Q)
 
 serialConfig :: UnaryOpClassConfig
 serialConfig =
-  UnaryOpClassConfig
-    { unaryOpConfigs =
-        [ UnaryOpConfig
-            UnaryOpFieldConfig
-              { extraPatNames = [],
-                extraLiftedPatNames = const [],
-                fieldCombineFun = \conIdx _ _ [] exp -> do
-                  r <-
-                    foldl
-                      (\r exp -> [|$r >> $(return exp)|])
-                      ([|serialize ($(integerE conIdx) :: Int)|])
-                      exp
-                  return (r, [True]),
-                fieldResFun = \_ _ _ _ fieldPat fieldFun -> do
-                  r <- [|$(return fieldFun) $(return fieldPat)|]
-                  return (r, [True]),
-                fieldFunExp =
-                  defaultFieldFunExp
-                    ['serialize, 'serializeWith, 'serializeWith2]
-              }
-            ['serialize, 'serializeWith, 'serializeWith2],
-          UnaryOpConfig
-            UnaryOpDeserializeConfig
-              { fieldDeserializeFun =
-                  defaultFieldFunExp
-                    ['deserialize, 'deserializeWith, 'deserializeWith2]
-              }
-            ['deserialize, 'deserializeWith, 'deserializeWith2]
-        ],
-      unaryOpInstanceNames = [''Serial, ''Serial1, ''Serial2],
-      unaryOpExtraVars = const $ return [],
-      unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = False
-    }
+  serializeConfig
+    [''Serial, ''Serial1, ''Serial2]
+    ['serialize, 'serializeWith, 'serializeWith2]
+    ['deserialize, 'deserializeWith, 'deserializeWith2]
 
 -- | Derive 'Serial' instance for a GADT.
 deriveGADTSerial :: DeriveConfig -> Name -> Q [Dec]

--- a/src/Grisette/Internal/TH/GADT/DeriveSerial.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveSerial.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+{-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 -- |
 -- Module      :   Grisette.Internal.TH.GADT.DeriveSerial

--- a/src/Grisette/Internal/TH/GADT/DeriveShow.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveShow.hs
@@ -30,9 +30,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig

--- a/src/Grisette/Internal/TH/GADT/DeriveShow.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveShow.hs
@@ -32,7 +32,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig
@@ -73,7 +73,7 @@ showConfig =
               { extraPatNames = ["prec"],
                 extraLiftedPatNames = \i -> (["sl" | i /= 0]),
                 fieldCombineFun =
-                  \_ variant conName [prec] exps -> do
+                  \_ _ variant conName [prec] exps -> do
                     case (variant, exps) of
                       (NormalConstructor, []) -> do
                         r <- [|showString $(stringE $ nameBase conName)|]
@@ -179,7 +179,8 @@ showConfig =
       unaryOpInstanceNames = [''Show, ''Show1, ''Show2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'Show' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveSubstSym.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveSubstSym.hs
@@ -31,7 +31,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig
@@ -59,7 +59,7 @@ substSymConfig =
               { extraPatNames = ["symbol", "newVal"],
                 extraLiftedPatNames = const [],
                 fieldResFun = defaultFieldResFun,
-                fieldCombineFun = \_ _ con extraPat exp ->
+                fieldCombineFun = \_ _ _ con extraPat exp ->
                   return (foldl AppE (ConE con) exp, False <$ extraPat),
                 fieldFunExp =
                   defaultFieldFunExp
@@ -71,7 +71,8 @@ substSymConfig =
         [''SubstSym, ''SubstSym1, ''SubstSym2],
       unaryOpExtraVars = const $ return [],
       unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'SubstSym' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveSubstSym.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveSubstSym.hs
@@ -29,9 +29,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     UnaryOpFieldConfig

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSimpleMergeable.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSimpleMergeable.hs
@@ -29,9 +29,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSimpleMergeable.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSimpleMergeable.hs
@@ -31,7 +31,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,
@@ -93,7 +93,8 @@ unifiedSimpleMergeableConfig =
                 else return $ keptNewVars !! i
             _ -> fail "UnifiedSimpleMergeable does not support multiple evaluation modes"
           appT (conT con) (return $ fst modeVar),
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'UnifiedSimpleMergeable' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymEq.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymEq.hs
@@ -29,9 +29,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymEq.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymEq.hs
@@ -31,7 +31,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,
@@ -83,7 +83,8 @@ unifiedSymEqConfig =
                 else return $ keptNewVars !! i
             _ -> fail "UnifiedSymEq does not support multiple evaluation modes"
           appT (conT con) (return $ fst modeVar),
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'UnifiedSymEq' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymOrd.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymOrd.hs
@@ -29,9 +29,10 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
       ( UnaryOpClassConfig,
         unaryOpAllowExistential,
         unaryOpConfigs,
+        unaryOpContextNames,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig, unaryOpContextNames
+        unaryOpInstanceTypeFromConfig
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,

--- a/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymOrd.hs
+++ b/src/Grisette/Internal/TH/GADT/DeriveUnifiedSymOrd.hs
@@ -31,7 +31,7 @@ import Grisette.Internal.TH.GADT.UnaryOpCommon
         unaryOpConfigs,
         unaryOpExtraVars,
         unaryOpInstanceNames,
-        unaryOpInstanceTypeFromConfig
+        unaryOpInstanceTypeFromConfig, unaryOpContextNames
       ),
     UnaryOpConfig (UnaryOpConfig),
     genUnaryOpClass,
@@ -83,7 +83,8 @@ unifiedSymOrdConfig =
                 else return $ keptNewVars !! i
             _ -> fail "UnifiedSymOrd does not support multiple evaluation modes"
           appT (conT con) (return $ fst modeVar),
-      unaryOpAllowExistential = True
+      unaryOpAllowExistential = True,
+      unaryOpContextNames = Nothing
     }
 
 -- | Derive 'UnifiedSymOrd' instance for a GADT.

--- a/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
@@ -3,9 +3,16 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 
+-- |
+-- Module      :   Grisette.Internal.TH.GADT.SerializeCommon
+-- Copyright   :   (c) Sirui Lu 2024
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
 module Grisette.Internal.TH.GADT.SerializeCommon
-  ( UnaryOpDeserializeConfig (..),
-    serializeConfig,
+  ( serializeConfig,
     serializeWithSerialConfig,
   )
 where
@@ -84,6 +91,8 @@ instance UnaryOpFunConfig UnaryOpDeserializeWithSerialConfig where
   genUnaryOpFun _ UnaryOpDeserializeWithSerialConfig funNames n _ _ _ _ _ =
     funD (funNames !! n) [clause [] (normalB [|deserialize|]) []]
 
+-- | Configuration for deserialization function, generate the function from
+-- scratch.
 data UnaryOpDeserializeConfig = UnaryOpDeserializeConfig
 
 getSerializedType :: Int -> Name
@@ -169,6 +178,8 @@ instance UnaryOpFunConfig UnaryOpDeserializeConfig where
               []
           ]
 
+-- | Configuration for serialization function, generate the function from
+-- scratch.
 serializeConfig :: [Name] -> [Name] -> [Name] -> UnaryOpClassConfig
 serializeConfig instanceNames serializeFunNames deserializeFunNames =
   UnaryOpClassConfig
@@ -206,6 +217,7 @@ serializeConfig instanceNames serializeFunNames deserializeFunNames =
       unaryOpContextNames = Nothing
     }
 
+-- | Configuration for serialization function, reuse the 'Serial' instance.
 serializeWithSerialConfig :: [Name] -> [Name] -> [Name] -> UnaryOpClassConfig
 serializeWithSerialConfig instanceNames serializeFunNames deserializeFunNames =
   UnaryOpClassConfig

--- a/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
@@ -1,0 +1,223 @@
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Grisette.Internal.TH.GADT.SerializeCommon
+  ( UnaryOpDeserializeConfig (..),
+    serializeConfig,
+    serializeWithSerialConfig,
+  )
+where
+
+import Control.Monad (zipWithM)
+import Data.Bytes.Serial (Serial (deserialize, serialize), Serial1, Serial2)
+import qualified Data.Map as M
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as S
+import GHC.Word (Word16, Word32, Word64, Word8)
+import Grisette.Internal.TH.GADT.UnaryOpCommon
+  ( UnaryOpClassConfig
+      ( UnaryOpClassConfig,
+        unaryOpAllowExistential,
+        unaryOpConfigs,
+        unaryOpContextNames,
+        unaryOpExtraVars,
+        unaryOpInstanceNames,
+        unaryOpInstanceTypeFromConfig
+      ),
+    UnaryOpConfig (UnaryOpConfig),
+    UnaryOpFieldConfig
+      ( UnaryOpFieldConfig,
+        extraLiftedPatNames,
+        extraPatNames,
+        fieldCombineFun,
+        fieldFunExp,
+        fieldResFun
+      ),
+    UnaryOpFunConfig (genUnaryOpFun),
+    defaultFieldFunExp,
+    defaultUnaryOpInstanceTypeFromConfig,
+  )
+import Grisette.Internal.TH.Util (integerE)
+import Language.Haskell.TH
+  ( Body (NormalB),
+    Clause (Clause),
+    Dec (FunD),
+    Lit (IntegerL),
+    Match (Match),
+    Name,
+    Pat (LitP, VarP, WildP),
+    Type (VarT),
+    bindS,
+    caseE,
+    clause,
+    conE,
+    conT,
+    doE,
+    funD,
+    match,
+    mkName,
+    newName,
+    noBindS,
+    normalB,
+    sigP,
+    varE,
+    varP,
+    wildP,
+  )
+import Language.Haskell.TH.Datatype
+  ( ConstructorInfo (constructorFields, constructorName),
+    TypeSubstitution (freeVariables),
+    resolveTypeSynonyms,
+  )
+
+data UnaryOpSerializeWithSerialConfig = UnaryOpSerializeWithSerialConfig
+
+instance UnaryOpFunConfig UnaryOpSerializeWithSerialConfig where
+  genUnaryOpFun _ UnaryOpSerializeWithSerialConfig {..} funNames n _ _ _ _ _ =
+    funD (funNames !! n) [clause [] (normalB [|serialize|]) []]
+
+data UnaryOpDeserializeWithSerialConfig = UnaryOpDeserializeWithSerialConfig
+
+instance UnaryOpFunConfig UnaryOpDeserializeWithSerialConfig where
+  genUnaryOpFun _ UnaryOpDeserializeWithSerialConfig {..} funNames n _ _ _ _ _ =
+    funD (funNames !! n) [clause [] (normalB [|deserialize|]) []]
+
+data UnaryOpDeserializeConfig = UnaryOpDeserializeConfig
+
+getSerializedType :: Int -> Name
+getSerializedType numConstructors =
+  if
+    | numConstructors <= fromIntegral (maxBound @Word8) + 1 -> ''Word8
+    | numConstructors <= fromIntegral (maxBound @Word16) + 1 -> ''Word16
+    | numConstructors <= fromIntegral (maxBound @Word32) + 1 -> ''Word32
+    | numConstructors <= fromIntegral (maxBound @Word64) + 1 -> ''Word64
+    | otherwise -> ''Integer
+
+instance UnaryOpFunConfig UnaryOpDeserializeConfig where
+  genUnaryOpFun
+    _
+    UnaryOpDeserializeConfig {..}
+    funNames
+    n
+    _
+    _
+    argTypes
+    _
+    constructors = do
+      allFields <-
+        mapM resolveTypeSynonyms $
+          concatMap constructorFields constructors
+      let usedArgs = S.fromList $ freeVariables allFields
+      args <-
+        traverse
+          ( \(ty, _) -> do
+              case ty of
+                VarT nm ->
+                  if S.member nm usedArgs
+                    then do
+                      pname <- newName "p"
+                      return (nm, Just pname)
+                    else return ('undefined, Nothing)
+                _ -> return ('undefined, Nothing)
+          )
+          argTypes
+      let argToFunPat =
+            M.fromList $ mapMaybe (\(nm, mpat) -> fmap (nm,) mpat) args
+      let funPats = fmap (maybe WildP VarP . snd) args
+      let genAuxFunMatch conIdx conInfo = do
+            fields <- mapM resolveTypeSynonyms $ constructorFields conInfo
+            defaultFieldFunExps <-
+              traverse
+                ( defaultFieldFunExp
+                    funNames
+                    argToFunPat
+                    M.empty
+                )
+                fields
+            let conName = constructorName conInfo
+            exp <-
+              foldl
+                (\exp fieldFun -> [|$exp <*> $(return fieldFun)|])
+                [|return $(conE conName)|]
+                defaultFieldFunExps
+            return $ Match (LitP (IntegerL conIdx)) (NormalB exp) []
+      auxMatches <- zipWithM genAuxFunMatch [0 ..] constructors
+      auxFallbackMatch <- match wildP (normalB [|undefined|]) []
+      let instanceFunName = funNames !! n
+      -- let auxFunName = mkName "go"
+      let selName = mkName "sel"
+      exp <-
+        doE
+          [ bindS
+              ( sigP
+                  (varP selName)
+                  (conT (getSerializedType $ length constructors))
+              )
+              (varE (head funNames)),
+            noBindS $
+              caseE (varE selName) $
+                return <$> auxMatches ++ [auxFallbackMatch]
+          ]
+      return $
+        FunD
+          instanceFunName
+          [ Clause
+              funPats
+              (NormalB exp)
+              []
+          ]
+
+serializeConfig :: [Name] -> [Name] -> [Name] -> UnaryOpClassConfig
+serializeConfig instanceNames serializeFunNames deserializeFunNames =
+  UnaryOpClassConfig
+    { unaryOpConfigs =
+        [ UnaryOpConfig
+            UnaryOpFieldConfig
+              { extraPatNames = [],
+                extraLiftedPatNames = const [],
+                fieldCombineFun = \totalConNumber conIdx _ _ [] exp -> do
+                  let ty = getSerializedType totalConNumber
+                  r <-
+                    foldl
+                      (\r exp -> [|$r >> $(return exp)|])
+                      ( [|
+                          $(varE $ head serializeFunNames)
+                            ($(integerE conIdx) :: $(conT ty))
+                          |]
+                      )
+                      exp
+                  return (r, [True]),
+                fieldResFun = \_ _ _ _ fieldPat fieldFun -> do
+                  r <- [|$(return fieldFun) $(return fieldPat)|]
+                  return (r, [True]),
+                fieldFunExp = defaultFieldFunExp serializeFunNames
+              }
+            serializeFunNames,
+          UnaryOpConfig
+            UnaryOpDeserializeConfig
+            deserializeFunNames
+        ],
+      unaryOpInstanceNames = instanceNames,
+      unaryOpExtraVars = const $ return [],
+      unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
+      unaryOpAllowExistential = False,
+      unaryOpContextNames = Nothing
+    }
+
+serializeWithSerialConfig :: [Name] -> [Name] -> [Name] -> UnaryOpClassConfig
+serializeWithSerialConfig instanceNames serializeFunNames deserializeFunNames =
+  UnaryOpClassConfig
+    { unaryOpConfigs =
+        [ UnaryOpConfig UnaryOpSerializeWithSerialConfig serializeFunNames,
+          UnaryOpConfig UnaryOpDeserializeWithSerialConfig deserializeFunNames
+        ],
+      unaryOpInstanceNames = instanceNames,
+      unaryOpExtraVars = const $ return [],
+      unaryOpInstanceTypeFromConfig = defaultUnaryOpInstanceTypeFromConfig,
+      unaryOpAllowExistential = False,
+      unaryOpContextNames =
+        Just $ take (length instanceNames) [''Serial, ''Serial1, ''Serial2]
+    }

--- a/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -76,13 +75,13 @@ import Language.Haskell.TH.Datatype
 data UnaryOpSerializeWithSerialConfig = UnaryOpSerializeWithSerialConfig
 
 instance UnaryOpFunConfig UnaryOpSerializeWithSerialConfig where
-  genUnaryOpFun _ UnaryOpSerializeWithSerialConfig {..} funNames n _ _ _ _ _ =
+  genUnaryOpFun _ UnaryOpSerializeWithSerialConfig funNames n _ _ _ _ _ =
     funD (funNames !! n) [clause [] (normalB [|serialize|]) []]
 
 data UnaryOpDeserializeWithSerialConfig = UnaryOpDeserializeWithSerialConfig
 
 instance UnaryOpFunConfig UnaryOpDeserializeWithSerialConfig where
-  genUnaryOpFun _ UnaryOpDeserializeWithSerialConfig {..} funNames n _ _ _ _ _ =
+  genUnaryOpFun _ UnaryOpDeserializeWithSerialConfig funNames n _ _ _ _ _ =
     funD (funNames !! n) [clause [] (normalB [|deserialize|]) []]
 
 data UnaryOpDeserializeConfig = UnaryOpDeserializeConfig
@@ -99,7 +98,7 @@ getSerializedType numConstructors =
 instance UnaryOpFunConfig UnaryOpDeserializeConfig where
   genUnaryOpFun
     _
-    UnaryOpDeserializeConfig {..}
+    UnaryOpDeserializeConfig
     funNames
     n
     _

--- a/test/Grisette/Core/TH/DerivationTest.hs
+++ b/test/Grisette/Core/TH/DerivationTest.hs
@@ -13,6 +13,9 @@
 
 module Grisette.Core.TH.DerivationTest (derivationTest) where
 
+import Data.Bytes.Get (runGetS)
+import Data.Bytes.Put (runPutS)
+import Data.Bytes.Serial (Serial (deserialize, serialize))
 import Data.Functor.Classes (showsPrec1, showsPrec2)
 import qualified Data.Text as T
 import GHC.TypeLits (KnownNat, type (<=))
@@ -37,8 +40,9 @@ import Grisette
 import Grisette.Core.TH.DerivationData
   ( Extra (Extra),
     GGG,
+    Serializable,
     gggToVVV,
-    replaceVVVShown, Serializable,
+    replaceVVVShown,
   )
 import Grisette.Core.TH.PartialEvalMode (PartialEvalMode)
 import Grisette.Unified
@@ -54,9 +58,6 @@ import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit ((@?=))
 import Test.QuickCheck.Property ((.&.), (===))
-import Data.Bytes.Serial (Serial(deserialize, serialize))
-import Data.Bytes.Put (runPutS)
-import Data.Bytes.Get (runGetS)
 
 #if MIN_VERSION_base(4,16,0)
 ftst ::

--- a/test/Grisette/Core/TH/DerivationTest.hs
+++ b/test/Grisette/Core/TH/DerivationTest.hs
@@ -38,7 +38,7 @@ import Grisette.Core.TH.DerivationData
   ( Extra (Extra),
     GGG,
     gggToVVV,
-    replaceVVVShown,
+    replaceVVVShown, Serializable,
   )
 import Grisette.Core.TH.PartialEvalMode (PartialEvalMode)
 import Grisette.Unified
@@ -54,6 +54,9 @@ import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit ((@?=))
 import Test.QuickCheck.Property ((.&.), (===))
+import Data.Bytes.Serial (Serial(deserialize, serialize))
+import Data.Bytes.Put (runPutS)
+import Data.Bytes.Get (runGetS)
 
 #if MIN_VERSION_base(4,16,0)
 ftst ::
@@ -155,6 +158,11 @@ derivationTest =
           symCompare1 g1 g2 === (g1 `symCompare` g2),
       testProperty "GADT SymOrd2 and SymOrd are consistent" $
         \(g1 :: GGG (GGG Int String) [Int]) g2 ->
-          symCompare2 g1 g2 === (g1 `symCompare` g2)
+          symCompare2 g1 g2 === (g1 `symCompare` g2),
+      testProperty "Serialize" $ do
+        \(s :: Serializable Int) ->
+          let bs = runPutS (serialize s)
+              s' = runGetS deserialize bs
+           in Right s === s'
     ]
       ++ derivationExtraTest


### PR DESCRIPTION
This pull request adds derivation for cereal and binary. It can be configured to derive from scratch or reuse the `Serial` instance.