### PR TITLE
Fix derivation for empty data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,18 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   that accepts type constructors with exactly or at most @n@ arguments. Added
   more list of classes.
   ([#269](https://github.com/lsrcz/grisette/pull/269))
+- Added derivation for `Mergeable` using `NoStrategy`.
+  ([#270](https://github.com/lsrcz/grisette/pull/270))
+- Added derivation for cereal and binary serializations.
+  ([#271](https://github.com/lsrcz/grisette/pull/271))
 
 ### Changed
 - Derivation of `PPrint` no longer relies on `OverloadedStrings` extension.
   ([#268](https://github.com/lsrcz/grisette/pull/268))
+
+### Fixed
+- Fixed the derivation for empty data types.
+  ([#272](https://github.com/lsrcz/grisette/pull/272))
 
 ## [0.11.0.0] - 2024-12-29
 

--- a/src/Grisette/Internal/TH/GADT/BinaryOpCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/BinaryOpCommon.hs
@@ -55,6 +55,7 @@ import Language.Haskell.TH
     Type (AppT, ConT, VarT),
     clause,
     conP,
+    funD,
     nameBase,
     newName,
     normalB,
@@ -287,6 +288,10 @@ genBinaryOpFun ::
   [ConstructorInfo] ->
   [ConstructorInfo] ->
   Q Dec
+genBinaryOpFun config n _ _ [] [] =
+  funD
+    (fieldFunNames config !! n)
+    [clause [] (normalB [|error "impossible"|]) []]
 genBinaryOpFun
   config
   n
@@ -371,7 +376,11 @@ genBinaryOpClass deriveConfig (BinaryOpClassConfig {..}) n typName = do
   return
     [ InstanceD
         Nothing
-        (extraPreds ++ catMaybes ctxs)
+        ( extraPreds
+            ++ if null (constructors lhsResult)
+              then []
+              else catMaybes ctxs
+        )
         instanceType
         instanceFuns
     ]

--- a/src/Grisette/Internal/TH/GADT/Common.hs
+++ b/src/Grisette/Internal/TH/GADT/Common.hs
@@ -459,10 +459,7 @@ extraConstraint
         then extraExtraMergeableConstraint constructors keptArgs
         else return []
     return $
-      extraMergeablePreds
-        ++ concat
-          ( extraArgEvalModePreds
-              ++ evalModePreds
-              ++ bitSizePreds
-              ++ fpBitSizePreds
-          )
+      concat (extraArgEvalModePreds ++ evalModePreds)
+        ++ if null constructors
+          then []
+          else extraMergeablePreds ++ concat (bitSizePreds ++ fpBitSizePreds)

--- a/src/Grisette/Internal/TH/GADT/ConvertOpCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/ConvertOpCommon.hs
@@ -444,6 +444,6 @@ genConvertOpClass deriveConfig (ConvertOpClassConfig {..}) n typName = do
               )
               instanceUnionType
               [instanceUnionFun]
-          | n == 0
+            | n == 0
           ]
         )

--- a/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/SerializeCommon.hs
@@ -105,6 +105,15 @@ getSerializedType numConstructors =
     | otherwise -> ''Integer
 
 instance UnaryOpFunConfig UnaryOpDeserializeConfig where
+  genUnaryOpFun _ UnaryOpDeserializeConfig funNames n _ _ _ _ [] = do
+    let instanceFunName = funNames !! n
+    funD
+      instanceFunName
+      [ clause
+          []
+          (normalB [|error "deserializing a type without constructors"|])
+          []
+      ]
   genUnaryOpFun
     _
     UnaryOpDeserializeConfig

--- a/src/Grisette/Internal/TH/GADT/UnaryOpCommon.hs
+++ b/src/Grisette/Internal/TH/GADT/UnaryOpCommon.hs
@@ -59,10 +59,13 @@ import Language.Haskell.TH
     Q,
     Type (AppT, ConT, VarT),
     appE,
+    clause,
     conP,
     conT,
+    funD,
     nameBase,
     newName,
+    normalB,
     varE,
     varP,
   )
@@ -308,6 +311,8 @@ class UnaryOpFunConfig config where
     Q Dec
 
 instance UnaryOpFunConfig UnaryOpFieldConfig where
+  genUnaryOpFun _ _ funNames n _ _ _ _ [] =
+    funD (funNames !! n) [clause [] (normalB [|error "impossible"|]) []]
   genUnaryOpFun _ config funNames n _ _ argTypes _ constructors = do
     clauses <-
       zipWithM
@@ -382,7 +387,11 @@ genUnaryOpClass deriveConfig (UnaryOpClassConfig {..}) n typName = do
   return
     [ InstanceD
         Nothing
-        (extraPreds ++ catMaybes ctxs)
+        ( extraPreds
+            ++ if null constructors
+              then []
+              else catMaybes ctxs
+        )
         instanceType
         instanceFuns
     ]

--- a/test/Grisette/Core/TH/DerivationData.hs
+++ b/test/Grisette/Core/TH/DerivationData.hs
@@ -120,6 +120,14 @@ import Grisette.Unified
 import Test.QuickCheck (Arbitrary, oneof, sized)
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
 
+data Empty a b c
+
+deriveGADT [''Empty] allClasses012
+
+data EmptyWithMode mode a b c
+
+deriveGADT [''EmptyWithMode] allClasses012
+
 data T mode n a
   = T (GetBool mode) [GetWordN mode n] [a] (GetData mode (T mode n a))
   | TNil


### PR DESCRIPTION
This pull request fixes derivation for empty data types. For such instances, usually no contexts are needed.