### PR TITLE
Add Metadata pattern and AsMetadata type class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   ([#271](https://github.com/lsrcz/grisette/pull/271))
 - Added unconstrained positions for derivation.
   ([#273](https://github.com/lsrcz/grisette/pull/273))
+- Added `AsMetadata` type class and `Metadata` pattern for embedding and
+  extracting values from metadata represented as an S-expression.
+  ([#277](https://github.com/lsrcz/grisette/pull/277))
 
 ### Changed
 - Derivation of `PPrint` no longer relies on `OverloadedStrings` extension.

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -306,6 +306,8 @@ module Grisette.Core
     Identifier (..),
     Symbol (..),
     identifier,
+    AsMetadata (..),
+    pattern Metadata,
     withMetadata,
     mapMetadata,
     withLocation,
@@ -1829,7 +1831,8 @@ import Grisette.Internal.Core.Data.SExpr
     showsSExprWithParens,
   )
 import Grisette.Internal.Core.Data.Symbol
-  ( Identifier (..),
+  ( AsMetadata (..),
+    Identifier (..),
     Symbol (..),
     identifier,
     indexed,
@@ -1840,6 +1843,7 @@ import Grisette.Internal.Core.Data.Symbol
     uniqueIdentifier,
     withLocation,
     withMetadata,
+    pattern Metadata,
   )
 import Instances.TH.Lift ()
 


### PR DESCRIPTION
Directly manipulating S-expressions can be hard. This pull request adds a type class `AsMetadata` to help it.