### PR TITLE
Add default ITEOp implementation when a type implements SimpleMergeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   ([#280](https://github.com/lsrcz/grisette/pull/280))
 - Added `PPrint` instances for `SomeTerm` and `Term`.
   ([#281](https://github.com/lsrcz/grisette/pull/281))
+- Types with `SimpleMergeable` instances now have default `ITEOp` instances.
+  ([#290](https://github.com/lsrcz/grisette/pull/290))
 
 ### Changed
 

--- a/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
@@ -68,7 +68,8 @@ import Grisette.Internal.Internal.Decl.Core.Data.Class.Mergeable
 import Grisette.Internal.Internal.Decl.Core.Data.Class.TryMerge
   ( TryMerge (tryMergeWithStrategy),
   )
-import Grisette.Internal.SymPrim.SymBool (SymBool)
+import Grisette.Internal.SymPrim.Prim.Internal.Term (SupportedPrim (pevalITETerm))
+import Grisette.Internal.SymPrim.SymBool (SymBool (SymBool))
 import Grisette.Internal.Utils.Derive (Arity0, Arity1)
 
 -- $setup
@@ -301,5 +302,9 @@ mrgIf = mrgIfWithStrategy rootStrategy
 {-# INLINE mrgIf #-}
 
 instance SimpleMergeable SymBool where
-  mrgIte = symIte
+  mrgIte (SymBool c) (SymBool t) (SymBool f) = SymBool $ pevalITETerm c t f
   {-# INLINE mrgIte #-}
+
+instance {-# OVERLAPPABLE #-} (SimpleMergeable a) => ITEOp a where
+  symIte = mrgIte
+  {-# INLINE symIte #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Control/Monad/Union.hs
@@ -414,7 +414,7 @@ instance (Num a, Mergeable a) => Num (Union a) where
   abs = tryMerge . unionUnaryOp abs
   signum = tryMerge . unionUnaryOp signum
 
-instance (ITEOp a, Mergeable a) => ITEOp (Union a) where
+instance (Mergeable a) => ITEOp (Union a) where
   symIte = mrgIf
 
 instance (LogicalOp a, Mergeable a) => LogicalOp (Union a) where


### PR DESCRIPTION
This pull request makes any type that implements `SimpleMergeable` automatically get `ITEOp` instance. This could help us use `symMax` etc. when a type only has `SimpleMergeable` but no `ITEOp` implemented.