### PR TITLE
Add Integral instances for SymInteger, SymIntN and SymWordN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to
 
 - Added missing instances for `ArithException`.
   ([#292](https://github.com/lsrcz/grisette/pull/292))
+- \[Breaking\] Added `Integral` instances for `SymInteger`, `SymIntN`, and
+  `SymWordN`. Also make `(/)`, `recip` and `logBase` no longer throw errors for
+  `SymAlgReal`. These functions are "unsafe" and should be used with caution as
+  they expose undefined behavior for some inputs.
+  ([#293](https://github.com/lsrcz/grisette/pull/293))
 
 ## [0.12.0.0] -- 2025-04-12
 

--- a/src/Grisette/Internal/Core/Data/Class/SafeLogBase.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SafeLogBase.hs
@@ -25,12 +25,7 @@ import Grisette.Internal.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Internal.Core.Data.Class.SimpleMergeable (mrgIf)
 import Grisette.Internal.Core.Data.Class.SymEq (SymEq ((.==)))
 import Grisette.Internal.Core.Data.Class.TryMerge (TryMerge)
-import Grisette.Internal.SymPrim.Prim.Internal.Term
-  ( FloatingUnaryOp (FloatingLog),
-    PEvalFloatingTerm (pevalFloatingUnaryTerm),
-    PEvalFractionalTerm (pevalFdivTerm),
-  )
-import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
+import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -64,23 +59,13 @@ class (MonadError e m, TryMerge m, Mergeable a) => SafeLogBase e a m where
   {-# INLINE safeLogBase #-}
 
 instance LogBaseOr SymAlgReal where
-  logBaseOr d base@(SymAlgReal baset) (SymAlgReal at) =
-    symIte (base .== 1) d $
-      SymAlgReal $
-        pevalFdivTerm
-          (pevalFloatingUnaryTerm FloatingLog at)
-          (pevalFloatingUnaryTerm FloatingLog baset)
+  logBaseOr d base a = symIte (base .== 1) d $ logBase base a
   {-# INLINE logBaseOr #-}
 
 instance
   (MonadError ArithException m, MonadUnion m) =>
   SafeLogBase ArithException SymAlgReal m
   where
-  safeLogBase base@(SymAlgReal baset) (SymAlgReal at) =
-    mrgIf (base .== 1) (throwError RatioZeroDenominator) $
-      pure $
-        SymAlgReal $
-          pevalFdivTerm
-            (pevalFloatingUnaryTerm FloatingLog at)
-            (pevalFloatingUnaryTerm FloatingLog baset)
+  safeLogBase base a =
+    mrgIf (base .== 1) (throwError RatioZeroDenominator) $ pure $ logBase base a
   {-# INLINE safeLogBase #-}

--- a/src/Grisette/Internal/SymPrim/GeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/GeneralFun.hs
@@ -291,6 +291,13 @@ buildGeneralFun arg v =
   where
     argSymbol = freshArgSymbol [SomeTerm v]
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq (a --> b) where
   GeneralFun sym1 tm1 == GeneralFun sym2 tm2 = sym1 == sym2 && tm1 == tm2
 

--- a/src/Grisette/Internal/SymPrim/SymAlgReal.hs
+++ b/src/Grisette/Internal/SymPrim/SymAlgReal.hs
@@ -92,6 +92,13 @@ instance Apply SymAlgReal where
   type FunType SymAlgReal = SymAlgReal
   apply = id
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq SymAlgReal where
   SymAlgReal a == SymAlgReal b = a == b
 

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -309,8 +309,8 @@ instance (KnownNat n, 1 <= n) => Enum (symtype n) where \
     error $ "enumFromThenTo: enumFromThenTo isn't supported for " ++ symtypestring
 
 #if 1
-ENUM_BV (SymIntN, IntN, "SymIntN")
-ENUM_BV (SymWordN, WordN, "SymWordN")
+ENUM_BV(SymIntN, IntN, "SymIntN")
+ENUM_BV(SymWordN, WordN, "SymWordN")
 #endif
 
 #define ORD_BV(symtype, symtypestring) \

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -453,7 +453,21 @@ instance (KnownNat n, 1 <= n) => Eq (symtype n) where \
   (symtype l) == (symtype r) = l == r
 
 #if 1
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 EQ_BV(SymIntN)
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 EQ_BV(SymWordN)
 #endif
 

--- a/src/Grisette/Internal/SymPrim/SymBool.hs
+++ b/src/Grisette/Internal/SymPrim/SymBool.hs
@@ -75,6 +75,13 @@ instance Apply SymBool where
   type FunType SymBool = SymBool
   apply = id
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq SymBool where
   SymBool l == SymBool r = l == r
 

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -209,6 +209,13 @@ instance (ValidFP eb sb) => Apply (SymFP eb sb) where
   type FunType (SymFP eb sb) = SymFP eb sb
   apply = id
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance (ValidFP eb sb) => Eq (SymFP eb sb) where
   SymFP a == SymFP b = a == b
 

--- a/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
@@ -195,6 +195,13 @@ instance
 instance Show (sa -~> sb) where
   show (SymGeneralFun t) = pformatTerm t
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq (sa -~> sb) where
   SymGeneralFun l == SymGeneralFun r = l == r
 

--- a/src/Grisette/Internal/SymPrim/SymInteger.hs
+++ b/src/Grisette/Internal/SymPrim/SymInteger.hs
@@ -145,6 +145,13 @@ instance Integral SymInteger where
   quotRem (SymInteger l) (SymInteger r) =
     (SymInteger $ pevalQuotIntegralTerm l r, SymInteger $ pevalRemIntegralTerm l r)
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq SymInteger where
   SymInteger l == SymInteger r = l == r
 

--- a/src/Grisette/Internal/SymPrim/SymTabularFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymTabularFun.hs
@@ -149,6 +149,13 @@ instance
 instance Show (sa =~> sb) where
   show (SymTabularFun t) = pformatTerm t
 
+-- | Checks if two formulas are the same. Not building the actual symbolic
+-- equality formula.
+--
+-- The reason why we choose this behavior is to allow symbolic variables to be
+-- used as keys in hash maps, which can be useful for memoization.
+--
+-- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
 instance Eq (sa =~> sb) where
   SymTabularFun l == SymTabularFun r = l == r
 


### PR DESCRIPTION
Added `Integral` instances for `SymInteger`, `SymIntN`, and `SymWordN`. Also make `(/)`, `recip` and `logBase` no longer throw errors for `SymAlgReal`. These functions are "unsafe" and should be used with caution as they expose undefined behavior for some inputs.