### PR TITLE
Remove Hashable on symbolic types, error on their Eq instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to
 
 - Removed `Show` constraints for merging indices.
   ([#294](https://github.com/lsrcz/grisette/pull/294))
+- \[Breaking\] Removed `Hashable` instances for `SymBool`, and also, `Eq` now
+  errors when called. Added `AsKey` wrapper to recover the original behavior.
+  ([#299](https://github.com/lsrcz/grisette/pull/299))
 
 ## [0.12.0.0] -- 2025-04-12
 

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ to symbolic and concrete evaluations. GHC 9.0 or earlier, without the
 impredicative types, may fail to resolve some constraints. You may need to
 provide additional constraints in your code to help the compiler.
 
+### `AsKey1` wrapper for `Union`
+
+To use term equality based comparison for `Union`, we may use the `AsKey1`
+wrapper. For the same reason as unified interfaces, it cannot be used with GHC
+9.0 or earlier.
+
 ## Citing Grisette
 
 If you use Grisette in your research, please use the following bibtex entry:

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -70,6 +70,7 @@ library
       Grisette.Internal.Core.Control.Monad.CBMCExcept
       Grisette.Internal.Core.Control.Monad.Class.Union
       Grisette.Internal.Core.Control.Monad.Union
+      Grisette.Internal.Core.Data.Class.AsKey
       Grisette.Internal.Core.Data.Class.BitCast
       Grisette.Internal.Core.Data.Class.BitVector
       Grisette.Internal.Core.Data.Class.CEGISSolver

--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -825,6 +825,16 @@ module Grisette.Core
     -- For more details of the algorithm, please refer to
     -- [Grisette's paper](https://lsrcz.github.io/files/POPL23.pdf).
 
+    -- ** Use symbolic types as concrete key based on structural term equality
+    AsKey (..),
+    AsKey1 (..),
+    KeyEq (..),
+    KeyEq1 (..),
+    KeyHashable (..),
+    KeyHashable1 (..),
+    KeyOrd (..),
+    KeyOrd1 (..),
+
     -- ** Union Monad
     Union,
     unionUnaryOp,
@@ -1449,6 +1459,16 @@ import Grisette.Internal.Core.Control.Monad.Union
     unionMergingStrategy,
     unionSize,
     unionUnaryOp,
+  )
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( AsKey (..),
+    AsKey1 (..),
+    KeyEq (..),
+    KeyEq1 (..),
+    KeyHashable (..),
+    KeyHashable1 (..),
+    KeyOrd (..),
+    KeyOrd1 (..),
   )
 import Grisette.Internal.Core.Data.Class.BitCast
   ( BitCast (..),

--- a/src/Grisette/Internal/Core/Data/Class/AsKey.hs
+++ b/src/Grisette/Internal/Core/Data/Class/AsKey.hs
@@ -152,7 +152,7 @@ instance KeyHashable AlgReal where
 instance (ValidFP a b) => KeyHashable (FP a b) where
   keyHashWithSalt = hashWithSalt
 
-instance (Hashable a) => KeyHashable (Identity a) where
+instance (Eq a, Hashable a) => KeyHashable (Identity a) where
   keyHashWithSalt = hashWithSalt
 
 class KeyEq1 f where

--- a/src/Grisette/Internal/Core/Data/Class/AsKey.hs
+++ b/src/Grisette/Internal/Core/Data/Class/AsKey.hs
@@ -1,0 +1,426 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (..),
+    KeyOrd (..),
+    KeyHashable (..),
+    KeyEq1 (..),
+    KeyOrd1 (..),
+    KeyHashable1 (..),
+    AsKey (..),
+    AsKey1 (..),
+    shouldUseAsKeyError,
+    shouldUseAsKeyHasSymbolicVersionError,
+    shouldUseSymbolicVersionError,
+  )
+where
+
+import Control.DeepSeq (NFData, NFData1)
+import Control.Monad.Identity (Identity)
+import qualified Data.Binary as Binary
+import Data.Bits (Bits, FiniteBits)
+import qualified Data.Bytes.Serial as Serial
+import Data.Functor.Classes
+  ( Eq1 (liftEq),
+    Ord1 (liftCompare),
+    Show1,
+    compare1,
+    eq1,
+  )
+import Data.Hashable (Hashable (hashWithSalt))
+import Data.Hashable.Lifted (Hashable1 (liftHashWithSalt), hashWithSalt1)
+import Data.Proxy (Proxy (Proxy))
+import qualified Data.Serialize as Cereal
+import Data.String (IsString)
+import GHC.Stack (HasCallStack)
+import GHC.TypeLits (KnownNat, type (<=))
+import Grisette.Internal.Core.Data.Class.BitCast
+  ( BitCast (bitCast),
+    BitCastCanonical (bitCastCanonicalValue),
+  )
+import Grisette.Internal.Core.Data.Class.BitVector
+  ( BV (bv, bvConcat, bvExt, bvSelect, bvSext, bvZext),
+  )
+import Grisette.Internal.Core.Data.Class.Concrete (Concrete)
+import Grisette.Internal.Core.Data.Class.Function
+  ( Apply (FunType, apply),
+    Function ((#)),
+  )
+import Grisette.Internal.Core.Data.Class.IEEEFP
+  ( IEEEFPConstants
+      ( fpMaxNormalized,
+        fpMaxSubnormal,
+        fpMinNormalized,
+        fpMinSubnormal,
+        fpNaN,
+        fpNegativeInfinite,
+        fpNegativeZero,
+        fpPositiveInfinite,
+        fpPositiveZero
+      ),
+    IEEEFPConvertible (fromFPOr, toFP),
+    IEEEFPOp
+      ( fpAbs,
+        fpMaximum,
+        fpMaximumNumber,
+        fpMinimum,
+        fpMinimumNumber,
+        fpNeg,
+        fpRem
+      ),
+    IEEEFPRoundingMode (rna, rne, rtn, rtp, rtz),
+    IEEEFPRoundingOp
+      ( fpAdd,
+        fpDiv,
+        fpFMA,
+        fpMul,
+        fpRoundToIntegral,
+        fpSqrt,
+        fpSub
+      ),
+    IEEEFPToAlgReal (fpToAlgReal),
+  )
+import Grisette.Internal.Core.Data.Class.SignConversion
+  ( SignConversion (toSigned, toUnsigned),
+  )
+import Grisette.Internal.SymPrim.AlgReal (AlgReal)
+import Grisette.Internal.SymPrim.BV (IntN, WordN)
+import Grisette.Internal.SymPrim.FP (FP, ValidFP)
+import Grisette.Internal.SymPrim.Prim.Internal.Term (ConRep (ConType))
+import Language.Haskell.TH.Syntax (Lift)
+
+class KeyEq a where
+  keyEq :: a -> a -> Bool
+
+infix 4 `keyEq`
+
+instance (KnownNat n, 1 <= n) => KeyEq (WordN n) where
+  keyEq = (==)
+
+instance (KnownNat n, 1 <= n) => KeyEq (IntN n) where
+  keyEq = (==)
+
+instance KeyEq Integer where
+  keyEq = (==)
+
+instance KeyEq Bool where
+  keyEq = (==)
+
+instance KeyEq AlgReal where
+  keyEq = (==)
+
+instance (ValidFP a b) => KeyEq (FP a b) where
+  keyEq = (==)
+
+instance (Eq a) => KeyEq (Identity a) where
+  keyEq = (==)
+
+class (KeyEq a) => KeyOrd a where
+  keyCompare :: a -> a -> Ordering
+
+infix 4 `keyCompare`
+
+class (KeyEq a) => KeyHashable a where
+  keyHashWithSalt :: Int -> a -> Int
+
+instance (KnownNat n, 1 <= n) => KeyHashable (WordN n) where
+  keyHashWithSalt = hashWithSalt
+
+instance (KnownNat n, 1 <= n) => KeyHashable (IntN n) where
+  keyHashWithSalt = hashWithSalt
+
+instance KeyHashable Integer where
+  keyHashWithSalt = hashWithSalt
+
+instance KeyHashable Bool where
+  keyHashWithSalt = hashWithSalt
+
+instance KeyHashable AlgReal where
+  keyHashWithSalt = hashWithSalt
+
+instance (ValidFP a b) => KeyHashable (FP a b) where
+  keyHashWithSalt = hashWithSalt
+
+instance (Hashable a) => KeyHashable (Identity a) where
+  keyHashWithSalt = hashWithSalt
+
+class KeyEq1 f where
+  liftKeyEq :: (a -> b -> Bool) -> f a -> f b -> Bool
+
+class (KeyEq1 f) => KeyOrd1 f where
+  liftKeyCompare :: (a -> b -> Ordering) -> f a -> f b -> Ordering
+
+class (KeyEq1 f) => KeyHashable1 f where
+  liftKeyHashWithSalt :: (Int -> a -> Int) -> Int -> f a -> Int
+
+infixl 0 `keyHashWithSalt`
+
+newtype AsKey a = AsKey {getAsKey :: a}
+  deriving newtype
+    ( Binary.Binary,
+      Cereal.Serialize,
+      NFData,
+      IsString,
+      Show,
+      Num,
+      Bits,
+      FiniteBits,
+      Enum,
+      Bounded,
+      Fractional,
+      Floating
+    )
+  deriving stock (Functor, Lift)
+
+newtype AsKey1 f a = AsKey1 {getAsKey1 :: f a}
+  deriving newtype
+    ( Binary.Binary,
+      Cereal.Serialize,
+      IsString,
+      Show,
+      Show1,
+      Functor,
+      NFData,
+      NFData1,
+      Applicative,
+      Monad,
+      Num
+    )
+  deriving stock (Lift)
+
+instance (Serial.Serial a) => Serial.Serial (AsKey a) where
+  serialize = Serial.serialize . getAsKey
+  deserialize = AsKey <$> Serial.deserialize
+
+instance (KeyEq a) => Eq (AsKey a) where
+  (AsKey a) == (AsKey b) = keyEq a b
+
+instance (KeyOrd a) => Ord (AsKey a) where
+  compare (AsKey a) (AsKey b) = keyCompare a b
+
+instance (KeyHashable a) => Hashable (AsKey a) where
+  hashWithSalt salt = keyHashWithSalt salt . getAsKey
+
+instance (KeyEq1 f, Eq a) => Eq (AsKey1 f a) where
+  (==) = eq1
+
+instance (KeyEq1 f) => Eq1 (AsKey1 f) where
+  liftEq f (AsKey1 a) (AsKey1 b) = liftKeyEq f a b
+
+instance (KeyOrd1 f, Ord a) => Ord (AsKey1 f a) where
+  compare = compare1
+
+instance (KeyOrd1 f) => Ord1 (AsKey1 f) where
+  liftCompare f (AsKey1 a) (AsKey1 b) = liftKeyCompare f a b
+
+instance (KeyHashable1 f, Hashable a) => Hashable (AsKey1 f a) where
+  hashWithSalt = hashWithSalt1
+
+instance (KeyHashable1 f) => Hashable1 (AsKey1 f) where
+  liftHashWithSalt f salt (AsKey1 a) = liftKeyHashWithSalt f salt a
+
+shouldUseAsKeyError :: (HasCallStack) => String -> String -> a
+shouldUseAsKeyError typ op =
+  error $
+    "As "
+      <> typ
+      <> " is a symbolic type, "
+      <> op
+      <> " is likely not going to work as expected.\n"
+      <> "You should use AsKey if you do want term identity based "
+      <> op
+      <> " on "
+      <> typ
+      <> "."
+
+shouldUseAsKeyHasSymbolicVersionError ::
+  (HasCallStack) => String -> String -> String -> a
+shouldUseAsKeyHasSymbolicVersionError typ op symop =
+  error $
+    "As "
+      <> typ
+      <> " is a symbolic type, "
+      <> op
+      <> " is likely not going to work as expected.\n"
+      <> "You should use AsKey if you do want term identity based "
+      <> op
+      <> " on "
+      <> typ
+      <> ",\n or use "
+      <> symop
+      <> " instead if you want symbolic version of "
+      <> op
+      <> "."
+
+shouldUseSymbolicVersionError ::
+  (HasCallStack) => String -> String -> String -> a
+shouldUseSymbolicVersionError typ op symop =
+  error $
+    "As "
+      <> typ
+      <> " is a symbolic type, "
+      <> op
+      <> " is likely not going to work as expected.\n"
+      <> "You should use "
+      <> symop
+      <> " instead if you want symbolic version of "
+      <> op
+      <> "."
+
+instance (Function a arg res) => Function (AsKey a) arg res where
+  (AsKey a) # b = a # b
+
+instance
+  (Function (f a) arg (f res)) =>
+  Function (AsKey1 f a) arg (AsKey1 f res)
+  where
+  (AsKey1 f) # b = AsKey1 $ f # b
+
+instance (Apply a) => Apply (AsKey a) where
+  type FunType (AsKey a) = FunType a
+  apply (AsKey a) = apply a
+
+instance (ConRep a) => ConRep (AsKey a) where
+  type ConType (AsKey a) = ConType a
+
+instance {-# INCOHERENT #-} (BitCast a b) => BitCast (AsKey a) (AsKey b) where
+  bitCast (AsKey a) = AsKey $ bitCast a
+  {-# INLINE bitCast #-}
+
+instance {-# INCOHERENT #-} (BitCast a b) => BitCast a (AsKey b) where
+  bitCast a = AsKey $ bitCast a
+  {-# INLINE bitCast #-}
+
+instance {-# INCOHERENT #-} (BitCast a b) => BitCast (AsKey a) b where
+  bitCast (AsKey a) = bitCast a
+  {-# INLINE bitCast #-}
+
+instance
+  {-# INCOHERENT #-}
+  (BitCastCanonical a b) =>
+  BitCastCanonical (AsKey a) (AsKey b)
+  where
+  bitCastCanonicalValue _ = AsKey $ bitCastCanonicalValue (Proxy @a)
+
+instance
+  {-# INCOHERENT #-}
+  (BitCastCanonical a b) =>
+  BitCastCanonical (AsKey a) b
+  where
+  bitCastCanonicalValue _ = bitCastCanonicalValue (Proxy @a)
+
+instance
+  {-# INCOHERENT #-}
+  (BitCastCanonical a b) =>
+  BitCastCanonical a (AsKey b)
+  where
+  bitCastCanonicalValue p = AsKey $ bitCastCanonicalValue p
+
+instance (SignConversion a b) => SignConversion (AsKey a) (AsKey b) where
+  toSigned (AsKey a) = AsKey $ toSigned a
+  toUnsigned (AsKey a) = AsKey $ toUnsigned a
+
+instance (IEEEFPConstants a) => IEEEFPConstants (AsKey a) where
+  fpPositiveInfinite = AsKey fpPositiveInfinite
+  fpNegativeInfinite = AsKey fpNegativeInfinite
+  fpNaN = AsKey fpNaN
+  fpNegativeZero = AsKey fpNegativeZero
+  fpPositiveZero = AsKey fpPositiveZero
+  fpMinNormalized = AsKey fpMinNormalized
+  fpMinSubnormal = AsKey fpMinSubnormal
+  fpMaxNormalized = AsKey fpMaxNormalized
+  fpMaxSubnormal = AsKey fpMaxSubnormal
+
+instance (IEEEFPOp a) => IEEEFPOp (AsKey a) where
+  fpAbs (AsKey a) = AsKey $ fpAbs a
+  fpNeg (AsKey a) = AsKey $ fpNeg a
+  fpRem (AsKey a) (AsKey b) = AsKey $ fpRem a b
+  fpMinimum (AsKey a) (AsKey b) = AsKey $ fpMinimum a b
+  fpMaximum (AsKey a) (AsKey b) = AsKey $ fpMaximum a b
+  fpMinimumNumber (AsKey a) (AsKey b) = AsKey $ fpMinimumNumber a b
+  fpMaximumNumber (AsKey a) (AsKey b) = AsKey $ fpMaximumNumber a b
+
+instance (IEEEFPRoundingMode a) => IEEEFPRoundingMode (AsKey a) where
+  rne = AsKey rne
+  rna = AsKey rna
+  rtp = AsKey rtp
+  rtn = AsKey rtn
+  rtz = AsKey rtz
+
+instance
+  (IEEEFPRoundingOp a mode) =>
+  IEEEFPRoundingOp (AsKey a) (AsKey mode)
+  where
+  fpAdd (AsKey mode) (AsKey a) (AsKey b) = AsKey $ fpAdd mode a b
+  fpSub (AsKey mode) (AsKey a) (AsKey b) = AsKey $ fpSub mode a b
+  fpMul (AsKey mode) (AsKey a) (AsKey b) = AsKey $ fpMul mode a b
+  fpDiv (AsKey mode) (AsKey a) (AsKey b) = AsKey $ fpDiv mode a b
+  fpFMA (AsKey mode) (AsKey a) (AsKey b) (AsKey c) = AsKey $ fpFMA mode a b c
+  fpSqrt (AsKey mode) (AsKey a) = AsKey $ fpSqrt mode a
+  fpRoundToIntegral (AsKey mode) (AsKey a) = AsKey $ fpRoundToIntegral mode a
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPConvertible a fp mode) =>
+  IEEEFPConvertible (AsKey a) (AsKey fp) (AsKey mode)
+  where
+  fromFPOr (AsKey d) (AsKey mode) (AsKey fp) = AsKey $ fromFPOr d mode fp
+  toFP (AsKey mode) (AsKey a) = AsKey $ toFP mode a
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPConvertible a fp mode) =>
+  IEEEFPConvertible a (AsKey fp) (AsKey mode)
+  where
+  fromFPOr a (AsKey mode) (AsKey fp) = fromFPOr a mode fp
+  toFP (AsKey mode) a = AsKey $ toFP mode a
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPConvertible a fp mode) =>
+  IEEEFPConvertible (AsKey a) fp mode
+  where
+  fromFPOr (AsKey a) mode fp = AsKey $ fromFPOr a mode fp
+  toFP mode (AsKey a) = toFP mode a
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPToAlgReal a fp mode) =>
+  IEEEFPToAlgReal (AsKey a) (AsKey fp) (AsKey mode)
+  where
+  fpToAlgReal (AsKey d) (AsKey fp) = AsKey $ fpToAlgReal d fp
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPToAlgReal a fp mode) =>
+  IEEEFPToAlgReal a (AsKey fp) (AsKey mode)
+  where
+  fpToAlgReal a (AsKey fp) = fpToAlgReal a fp
+
+instance
+  {-# INCOHERENT #-}
+  (IEEEFPToAlgReal a fp mode) =>
+  IEEEFPToAlgReal (AsKey a) fp mode
+  where
+  fpToAlgReal (AsKey d) fp = AsKey $ fpToAlgReal d fp
+
+instance Concrete (AsKey a)
+
+instance (BV a) => BV (AsKey a) where
+  bvConcat (AsKey a) (AsKey b) = AsKey $ bvConcat a b
+  bvZext n (AsKey a) = AsKey $ bvZext n a
+  bvSext n (AsKey a) = AsKey $ bvSext n a
+  bvExt n (AsKey a) = AsKey $ bvExt n a
+  bvSelect ix w (AsKey a) = AsKey $ bvSelect ix w a
+  bv n a = AsKey $ bv n a

--- a/src/Grisette/Internal/Core/Data/Class/GenSym.hs
+++ b/src/Grisette/Internal/Core/Data/Class/GenSym.hs
@@ -112,6 +112,7 @@ import Grisette.Internal.Core.Control.Monad.Union
     isMerged,
     unionBase,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy, sortIndices),
     Mergeable1 (liftRootStrategy),
@@ -155,6 +156,7 @@ import Grisette.Internal.SymPrim.SymGeneralFun (type (-~>) (SymGeneralFun))
 import Grisette.Internal.SymPrim.SymInteger (SymInteger)
 import Grisette.Internal.SymPrim.SymTabularFun (type (=~>) (SymTabularFun))
 import Grisette.Internal.SymPrim.TabularFun (type (=->))
+import Grisette.Unified.Lib.Data.Functor (mrgFmap)
 
 -- $setup
 -- >>> import Grisette.Core
@@ -1787,3 +1789,39 @@ instance
     where
       go (UnionSingle x) = fresh x
       go (UnionIf _ _ _ t f) = mrgIf <$> simpleFresh () <*> go t <*> go f
+
+instance {-# INCOHERENT #-} (GenSym a b) => GenSym a (AsKey b) where
+  fresh spec = mrgFmap AsKey <$> fresh spec
+
+instance {-# INCOHERENT #-} (GenSym a b) => GenSym (AsKey a) b where
+  fresh (AsKey spec) = fresh spec
+
+instance {-# INCOHERENT #-} (GenSym a b) => GenSym (AsKey a) (AsKey b) where
+  fresh (AsKey spec) = mrgFmap AsKey <$> fresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple a b) => GenSymSimple a (AsKey b) where
+  simpleFresh spec = AsKey <$> simpleFresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple a b) => GenSymSimple (AsKey a) (AsKey b) where
+  simpleFresh (AsKey spec) = AsKey <$> simpleFresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple a b) => GenSymSimple (AsKey a) b where
+  simpleFresh (AsKey spec) = simpleFresh spec
+
+instance {-# INCOHERENT #-} (GenSym a (f b)) => GenSym a (AsKey1 f b) where
+  fresh spec = mrgFmap AsKey1 <$> fresh spec
+
+instance {-# INCOHERENT #-} (GenSym (f a) (f b)) => GenSym (AsKey1 f a) (AsKey1 f b) where
+  fresh (AsKey1 spec) = mrgFmap AsKey1 <$> fresh spec
+
+instance {-# INCOHERENT #-} (GenSym (f a) b) => GenSym (AsKey1 f a) b where
+  fresh (AsKey1 spec) = fresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple a (f b)) => GenSymSimple a (AsKey1 f b) where
+  simpleFresh spec = AsKey1 <$> simpleFresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple (f a) (f b)) => GenSymSimple (AsKey1 f a) (AsKey1 f b) where
+  simpleFresh (AsKey1 spec) = AsKey1 <$> simpleFresh spec
+
+instance {-# INCOHERENT #-} (GenSymSimple (f a) b) => GenSymSimple (AsKey1 f a) b where
+  simpleFresh (AsKey1 spec) = simpleFresh spec

--- a/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
@@ -23,6 +23,7 @@ import Control.Monad.Identity (Identity (Identity))
 import qualified Data.HashSet as HS
 import Data.Proxy (Proxy)
 import GHC.TypeNats (KnownNat, type (<=))
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.SymPrim.FP (ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun
   ( freshArgSymbol,
@@ -117,4 +118,8 @@ instance (ITEOp v) => ITEOp (Identity v) where
 
 instance ITEOp (Proxy a) where
   symIte _ l _ = l
+  {-# INLINE symIte #-}
+
+instance (ITEOp a) => ITEOp (AsKey a) where
+  symIte c (AsKey t) (AsKey f) = AsKey $ symIte c t f
   {-# INLINE symIte #-}

--- a/src/Grisette/Internal/Core/Data/Class/LogicalOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/LogicalOp.hs
@@ -18,6 +18,7 @@ import Control.Applicative (liftA2)
 #endif
 
 import Control.Monad.Identity (Identity)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.SymPrim.Prim.Term
   ( pevalAndTerm,
@@ -136,3 +137,12 @@ instance (LogicalOp a) => LogicalOp (Identity a) where
   symNot = fmap symNot
   symXor = liftA2 symXor
   symImplies = liftA2 symImplies
+
+instance (LogicalOp a) => LogicalOp (AsKey a) where
+  true = AsKey true
+  false = AsKey false
+  (AsKey l) .|| (AsKey r) = AsKey $ l .|| r
+  (AsKey l) .&& (AsKey r) = AsKey $ l .&& r
+  symNot (AsKey v) = AsKey $ symNot v
+  (AsKey l) `symXor` (AsKey r) = AsKey $ l `symXor` r
+  (AsKey l) `symImplies` (AsKey r) = AsKey $ l `symImplies` r

--- a/src/Grisette/Internal/Core/Data/Class/PlainUnion.hs
+++ b/src/Grisette/Internal/Core/Data/Class/PlainUnion.hs
@@ -33,6 +33,7 @@ where
 
 import Data.Bifunctor (Bifunctor (first))
 import Data.Kind (Type)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.Function (Function ((#)))
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.Core.Data.Class.LogicalOp
@@ -245,3 +246,11 @@ unionToCon u =
       if cl then unionToCon l else unionToCon r
     _ -> Nothing
 {-# INLINE unionToCon #-}
+
+instance (PlainUnion u) => PlainUnion (AsKey1 u) where
+  singleView (AsKey1 u) = singleView u
+  ifView (AsKey1 u) = case ifView u of
+    Just (c, l, r) -> Just (c, AsKey1 l, AsKey1 r)
+    Nothing -> Nothing
+  toGuardedList (AsKey1 u) = toGuardedList u
+  overestimateUnionValues (AsKey1 u) = overestimateUnionValues u

--- a/src/Grisette/Internal/Core/Data/Class/PlainUnion.hs
+++ b/src/Grisette/Internal/Core/Data/Class/PlainUnion.hs
@@ -247,6 +247,7 @@ unionToCon u =
     _ -> Nothing
 {-# INLINE unionToCon #-}
 
+#if MIN_VERSION_base(4,16,0)
 instance (PlainUnion u) => PlainUnion (AsKey1 u) where
   singleView (AsKey1 u) = singleView u
   ifView (AsKey1 u) = case ifView u of
@@ -254,3 +255,4 @@ instance (PlainUnion u) => PlainUnion (AsKey1 u) where
     Nothing -> Nothing
   toGuardedList (AsKey1 u) = toGuardedList u
   overestimateUnionValues (AsKey1 u) = overestimateUnionValues u
+#endif

--- a/src/Grisette/Internal/Core/Data/Class/SafeLinearArith.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SafeLinearArith.hs
@@ -30,6 +30,7 @@ import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.TypeNats (KnownNat, type (<=))
 import Grisette.Internal.Core.Control.Monad.Class.Union (MonadUnion)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.Core.Data.Class.LogicalOp
   ( LogicalOp ((.&&), (.||)),
   )
@@ -227,3 +228,14 @@ instance
       (mrgSingle res)
     where
       res = ls - rs
+
+instance (SafeLinearArith e a m) => SafeLinearArith e (AsKey a) m where
+  safeAdd (AsKey a) (AsKey b) = do
+    r <- safeAdd a b
+    mrgSingle $ AsKey r
+  safeNeg (AsKey a) = do
+    r <- safeNeg a
+    mrgSingle $ AsKey r
+  safeSub (AsKey a) (AsKey b) = do
+    r <- safeSub a b
+    mrgSingle $ AsKey r

--- a/src/Grisette/Internal/Core/Data/Class/SafeLogBase.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SafeLogBase.hs
@@ -20,11 +20,12 @@ where
 import Control.Exception (ArithException (RatioZeroDenominator))
 import Control.Monad.Error.Class (MonadError (throwError))
 import Grisette.Internal.Core.Control.Monad.Class.Union (MonadUnion)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.Core.Data.Class.Mergeable (Mergeable)
 import Grisette.Internal.Core.Data.Class.SimpleMergeable (mrgIf)
 import Grisette.Internal.Core.Data.Class.SymEq (SymEq ((.==)))
-import Grisette.Internal.Core.Data.Class.TryMerge (TryMerge)
+import Grisette.Internal.Core.Data.Class.TryMerge (TryMerge, mrgSingle)
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
 
 -- $setup
@@ -68,4 +69,15 @@ instance
   where
   safeLogBase base a =
     mrgIf (base .== 1) (throwError RatioZeroDenominator) $ pure $ logBase base a
+  {-# INLINE safeLogBase #-}
+
+instance (LogBaseOr a) => LogBaseOr (AsKey a) where
+  logBaseOr (AsKey d) (AsKey base) (AsKey a) =
+    AsKey $ logBaseOr d base a
+  {-# INLINE logBaseOr #-}
+
+instance (SafeLogBase e a m) => SafeLogBase e (AsKey a) m where
+  safeLogBase (AsKey base) (AsKey a) = do
+    r <- safeLogBase base a
+    mrgSingle $ AsKey r
   {-# INLINE safeLogBase #-}

--- a/src/Grisette/Internal/Core/Data/Class/SymFromIntegral.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SymFromIntegral.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeOperators #-}
@@ -18,6 +19,7 @@ module Grisette.Internal.Core.Data.Class.SymFromIntegral
 where
 
 import GHC.TypeLits (KnownNat, type (<=))
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.SymPrim.FP (ValidFP)
 import Grisette.Internal.SymPrim.Prim.Internal.Term
   ( PEvalFromIntegralTerm (pevalFromIntegralTerm),
@@ -107,4 +109,28 @@ instance
   SymFromIntegral (SymIntN n) (SymFP eb sb)
   where
   symFromIntegral (SymIntN x) = SymFP $ pevalFromIntegralTerm x
+  {-# INLINE symFromIntegral #-}
+
+instance
+  {-# INCOHERENT #-}
+  (SymFromIntegral a b) =>
+  SymFromIntegral (AsKey a) (AsKey b)
+  where
+  symFromIntegral (AsKey x) = AsKey $ symFromIntegral x
+  {-# INLINE symFromIntegral #-}
+
+instance
+  {-# INCOHERENT #-}
+  (SymFromIntegral a b) =>
+  SymFromIntegral (AsKey a) b
+  where
+  symFromIntegral (AsKey x) = symFromIntegral x
+  {-# INLINE symFromIntegral #-}
+
+instance
+  {-# INCOHERENT #-}
+  (SymFromIntegral a b) =>
+  SymFromIntegral a (AsKey b)
+  where
+  symFromIntegral x = AsKey $ symFromIntegral x
   {-# INLINE symFromIntegral #-}

--- a/src/Grisette/Internal/Core/Data/Class/SymIEEEFP.hs
+++ b/src/Grisette/Internal/Core/Data/Class/SymIEEEFP.hs
@@ -15,6 +15,7 @@ module Grisette.Internal.Core.Data.Class.SymIEEEFP
   )
 where
 
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.Core.Data.Class.IEEEFP
   ( fpIsInfinite,
     fpIsNaN,
@@ -123,3 +124,40 @@ deriving via
   (ConcreteFloat (FP eb sb))
   instance
     (ValidFP eb sb) => SymIEEEFPTraits (FP eb sb)
+
+instance (SymIEEEFPTraits a) => SymIEEEFPTraits (AsKey a) where
+  symFpIsNaN (AsKey a) = symFpIsNaN a
+  {-# INLINE symFpIsNaN #-}
+
+  symFpIsPositive (AsKey a) = symFpIsPositive a
+  {-# INLINE symFpIsPositive #-}
+
+  symFpIsNegative (AsKey a) = symFpIsNegative a
+  {-# INLINE symFpIsNegative #-}
+
+  symFpIsInfinite (AsKey a) = symFpIsInfinite a
+  {-# INLINE symFpIsInfinite #-}
+
+  symFpIsPositiveZero (AsKey a) = symFpIsPositiveZero a
+  {-# INLINE symFpIsPositiveZero #-}
+
+  symFpIsNegativeZero (AsKey a) = symFpIsNegativeZero a
+  {-# INLINE symFpIsNegativeZero #-}
+
+  symFpIsZero (AsKey a) = symFpIsZero a
+  {-# INLINE symFpIsZero #-}
+
+  symFpIsNormal (AsKey a) = symFpIsNormal a
+  {-# INLINE symFpIsNormal #-}
+
+  symFpIsSubnormal (AsKey a) = symFpIsSubnormal a
+  {-# INLINE symFpIsSubnormal #-}
+
+  symFpIsPoint (AsKey a) = symFpIsPoint a
+  {-# INLINE symFpIsPoint #-}
+
+  symFpIsPositiveInfinite (AsKey a) = symFpIsPositiveInfinite a
+  {-# INLINE symFpIsPositiveInfinite #-}
+
+  symFpIsNegativeInfinite (AsKey a) = symFpIsNegativeInfinite a
+  {-# INLINE symFpIsNegativeInfinite #-}

--- a/src/Grisette/Internal/Internal/Decl/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Internal/Internal/Decl/Core/Data/Class/Mergeable.hs
@@ -84,6 +84,7 @@ import Generics.Deriving
     type (:*:) ((:*:)),
     type (:+:) (L1, R1),
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey, getAsKey), AsKey1 (AsKey1, getAsKey1))
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.SymPrim.SymBool (SymBool)
 import Grisette.Internal.Utils.Derive (Arity0, Arity1)
@@ -531,3 +532,16 @@ instance Mergeable Ordering where
   rootStrategy =
     let sub = SimpleStrategy $ \_ t _ -> t
      in SortedStrategy id $ const sub
+
+instance (Mergeable a) => Mergeable (AsKey a) where
+  rootStrategy = wrapStrategy (rootStrategy @a) AsKey getAsKey
+  {-# INLINE rootStrategy #-}
+
+instance (Mergeable (f a)) => Mergeable (AsKey1 f a) where
+  rootStrategy = wrapStrategy (rootStrategy @(f a)) AsKey1 getAsKey1
+  {-# INLINE rootStrategy #-}
+
+instance (Mergeable1 f) => Mergeable1 (AsKey1 f) where
+  liftRootStrategy (s :: MergingStrategy a) =
+    wrapStrategy (liftRootStrategy s) AsKey1 getAsKey1
+  {-# INLINE liftRootStrategy #-}

--- a/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
@@ -325,6 +325,7 @@ instance
   liftMrgIte m c (AsKey1 t) (AsKey1 f) = AsKey1 $ liftMrgIte m c t f
   {-# INLINE liftMrgIte #-}
 
+#if MIN_VERSION_base(4,16,0)
 instance (SymBranching f) => SymBranching (AsKey1 f) where
   mrgIfWithStrategy strategy cond (AsKey1 t) (AsKey1 f) =
     AsKey1 $ mrgIfWithStrategy strategy cond t f
@@ -332,3 +333,4 @@ instance (SymBranching f) => SymBranching (AsKey1 f) where
     AsKey1 $ mrgIfPropagatedStrategy cond t f
   {-# INLINE mrgIfWithStrategy #-}
   {-# INLINE mrgIfPropagatedStrategy #-}
+#endif

--- a/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Internal/Decl/Core/Data/Class/SimpleMergeable.hs
@@ -57,6 +57,7 @@ import GHC.Generics
     type (:*:) ((:*:)),
   )
 import Generics.Deriving (Default (Default), Default1 (Default1))
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp (symIte))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.Mergeable
   ( GMergeable,
@@ -308,3 +309,26 @@ instance SimpleMergeable SymBool where
 instance {-# OVERLAPPABLE #-} (SimpleMergeable a) => ITEOp a where
   symIte = mrgIte
   {-# INLINE symIte #-}
+
+instance (SimpleMergeable a) => SimpleMergeable (AsKey a) where
+  mrgIte c (AsKey t) (AsKey f) = AsKey $ mrgIte c t f
+  {-# INLINE mrgIte #-}
+
+instance (SimpleMergeable (f a)) => SimpleMergeable (AsKey1 f a) where
+  mrgIte c (AsKey1 t) (AsKey1 f) = AsKey1 $ mrgIte c t f
+  {-# INLINE mrgIte #-}
+
+instance
+  (SimpleMergeable1 f) =>
+  SimpleMergeable1 (AsKey1 f)
+  where
+  liftMrgIte m c (AsKey1 t) (AsKey1 f) = AsKey1 $ liftMrgIte m c t f
+  {-# INLINE liftMrgIte #-}
+
+instance (SymBranching f) => SymBranching (AsKey1 f) where
+  mrgIfWithStrategy strategy cond (AsKey1 t) (AsKey1 f) =
+    AsKey1 $ mrgIfWithStrategy strategy cond t f
+  mrgIfPropagatedStrategy cond (AsKey1 t) (AsKey1 f) =
+    AsKey1 $ mrgIfPropagatedStrategy cond t f
+  {-# INLINE mrgIfWithStrategy #-}
+  {-# INLINE mrgIfPropagatedStrategy #-}

--- a/src/Grisette/Internal/Internal/Decl/Core/Data/Class/TryMerge.hs
+++ b/src/Grisette/Internal/Internal/Decl/Core/Data/Class/TryMerge.hs
@@ -20,6 +20,7 @@ module Grisette.Internal.Internal.Decl.Core.Data.Class.TryMerge
   )
 where
 
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey1 (AsKey1))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
     MergingStrategy,
@@ -104,3 +105,8 @@ toUnionSym ::
   m b
 toUnionSym = tryMerge . pure . toSym
 {-# INLINE toUnionSym #-}
+
+instance (TryMerge m) => TryMerge (AsKey1 m) where
+  tryMergeWithStrategy strategy (AsKey1 t) =
+    AsKey1 $ tryMergeWithStrategy strategy t
+  {-# INLINE tryMergeWithStrategy #-}

--- a/src/Grisette/Internal/Internal/Decl/SymPrim/AllSyms.hs
+++ b/src/Grisette/Internal/Internal/Decl/SymPrim/AllSyms.hs
@@ -61,6 +61,7 @@ import Generics.Deriving
   ( Default (unDefault),
     Default1 (unDefault1),
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.SymPrim.Prim.SomeTerm
   ( SomeTerm (SomeTerm),
   )
@@ -254,3 +255,15 @@ instance
 instance (Generic1 f, GAllSyms Arity1 (Rep1 f)) => AllSyms1 (Default1 f) where
   liftAllSymsS f = genericLiftAllSymsS f . unDefault1
   {-# INLINE liftAllSymsS #-}
+
+instance (AllSyms a) => AllSyms (AsKey a) where
+  allSymsS (AsKey a) = allSymsS a
+  {-# INLINE allSymsS #-}
+
+instance (AllSyms1 f) => AllSyms1 (AsKey1 f) where
+  liftAllSymsS f (AsKey1 a) = liftAllSymsS f a
+  {-# INLINE liftAllSymsS #-}
+
+instance (AllSyms1 f, AllSyms a) => AllSyms (AsKey1 f a) where
+  allSymsS (AsKey1 a) = allSymsS a
+  {-# INLINE allSymsS #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Control/Monad/Union.hs
@@ -48,7 +48,6 @@ import Data.Functor.Classes
     showsPrec1,
   )
 import Data.Hashable (Hashable (hashWithSalt))
-import Data.Hashable.Lifted (Hashable1 (liftHashWithSalt))
 import qualified Data.Serialize as Cereal
 import GHC.TypeNats (KnownNat, type (<=))
 import Grisette.Internal.Core.Control.Monad.Class.Union (MonadUnion)
@@ -57,7 +56,6 @@ import Grisette.Internal.Core.Data.Class.AsKey
     KeyEq1 (liftKeyEq),
     KeyHashable (keyHashWithSalt),
     KeyHashable1 (liftKeyHashWithSalt),
-    shouldUseAsKeyError,
     shouldUseAsKeyHasSymbolicVersionError,
   )
 import Grisette.Internal.Core.Data.Class.EvalSym
@@ -402,12 +400,6 @@ instance KeyHashable1 Union where
     liftKeyHashWithSalt f s a `hashWithSalt` (0 :: Int)
   liftKeyHashWithSalt f s (UMrg _ a) =
     liftKeyHashWithSalt f s a `hashWithSalt` (1 :: Int)
-
-instance (Hashable a) => Hashable (Union a) where
-  hashWithSalt = shouldUseAsKeyError "Union" "hashWithSalt"
-
-instance Hashable1 Union where
-  liftHashWithSalt = shouldUseAsKeyError "Union" "liftHashWithSalt"
 
 instance (Eq a) => KeyEq (Union a) where
   keyEq = liftKeyEq (==)

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/EvalSym.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/EvalSym.hs
@@ -67,6 +67,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.EvalSym
   ( EvalSym (evalSym),
     EvalSym1 (liftEvalSym),
@@ -338,3 +339,14 @@ instance (EvalSym (SymType b)) => EvalSym (a --> b) where
   evalSym fillDefault model (GeneralFun s t) =
     GeneralFun s $
       evalTerm fillDefault model (HS.singleton $ someTypedSymbol s) t
+
+instance (EvalSym a) => EvalSym (AsKey a) where
+  evalSym fillDefault model (AsKey t) = AsKey $ evalSym fillDefault model t
+  {-# INLINE evalSym #-}
+
+instance (EvalSym1 f, EvalSym a) => EvalSym (AsKey1 f a) where
+  evalSym fillDefault model (AsKey1 t) = AsKey1 $ evalSym fillDefault model t
+
+instance (EvalSym1 a) => EvalSym1 (AsKey1 a) where
+  liftEvalSym f fillDefault model (AsKey1 t) = AsKey1 $ liftEvalSym f fillDefault model t
+  {-# INLINE liftEvalSym #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ExtractSym.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ExtractSym.hs
@@ -69,6 +69,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.ExtractSym
   ( ExtractSym (extractSymMaybe),
     ExtractSym1 (liftExtractSymMaybe),
@@ -394,3 +395,15 @@ instance (ExtractSym (SymType b)) => ExtractSym (a --> b) where
     case decideSymbolKind @knd of
       Left HRefl -> Nothing
       Right HRefl -> SymbolSet <$> extractTerm (HS.singleton $ someTypedSymbol t) f
+
+instance (ExtractSym a) => ExtractSym (AsKey a) where
+  extractSymMaybe (AsKey t) = extractSymMaybe t
+  {-# INLINE extractSymMaybe #-}
+
+instance (ExtractSym1 f, ExtractSym a) => ExtractSym (AsKey1 f a) where
+  extractSymMaybe (AsKey1 t) = extractSymMaybe1 t
+  {-# INLINE extractSymMaybe #-}
+
+instance (ExtractSym1 a) => ExtractSym1 (AsKey1 a) where
+  liftExtractSymMaybe f (AsKey1 t) = liftExtractSymMaybe f t
+  {-# INLINE liftExtractSymMaybe #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/PPrint.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/PPrint.hs
@@ -64,6 +64,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Symbol (Identifier, Symbol)
 import Grisette.Internal.Internal.Decl.Core.Data.Class.PPrint
   ( Doc,
@@ -412,3 +413,12 @@ instance PPrint (SymbolSet knd) where
       n
       "SymbolSet"
       [pformatListLike "{" "}" $ pformat <$> HS.toList s]
+
+instance (PPrint a) => PPrint (AsKey a) where
+  pformatPrec p (AsKey t) = pformatPrec p t
+
+instance (PPrint1 f, PPrint a) => PPrint (AsKey1 f a) where
+  pformatPrec p (AsKey1 t) = pformatPrec p t
+
+instance (PPrint1 f) => PPrint1 (AsKey1 f) where
+  liftPFormatPrec f l n (AsKey1 t) = liftPFormatPrec f l n t

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SubstSym.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SubstSym.hs
@@ -66,6 +66,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.SubstSym
   ( SubstSym (substSym),
     SubstSym1 (liftSubstSym),
@@ -359,3 +360,15 @@ instance (SubstSym (SymType b)) => SubstSym (a --> b) where
     GeneralFun s $
       substTerm sym (underlyingTerm val) (HS.singleton $ someTypedSymbol s) t
   {-# INLINE substSym #-}
+
+instance (SubstSym a) => SubstSym (AsKey a) where
+  substSym sym val (AsKey t) = AsKey $ substSym sym val t
+  {-# INLINE substSym #-}
+
+instance (SubstSym1 f, SubstSym a) => SubstSym (AsKey1 f a) where
+  substSym sym val (AsKey1 t) = AsKey1 $ substSym sym val t
+  {-# INLINE substSym #-}
+
+instance (SubstSym1 f) => SubstSym1 (AsKey1 f) where
+  liftSubstSym f sym val (AsKey1 t) = AsKey1 $ liftSubstSym f sym val t
+  {-# INLINE liftSubstSym #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymEq.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymEq.hs
@@ -61,6 +61,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.LogicalOp (LogicalOp ((.&&)))
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.SymEq
@@ -323,3 +324,15 @@ deriving via
   (Default ((f :.: g) p))
   instance
     (SymEq (f (g p))) => SymEq ((f :.: g) p)
+
+instance (SymEq a) => SymEq (AsKey a) where
+  (AsKey l) .== (AsKey r) = l .== r
+  {-# INLINE (.==) #-}
+
+instance (SymEq1 f) => SymEq1 (AsKey1 f) where
+  liftSymEq f (AsKey1 l) (AsKey1 r) = liftSymEq f l r
+  {-# INLINE liftSymEq #-}
+
+instance (SymEq1 f, SymEq a) => SymEq (AsKey1 f a) where
+  (.==) = symEq1
+  {-# INLINE (.==) #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymOrd.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymOrd.hs
@@ -59,6 +59,7 @@ import Grisette.Internal.Core.Control.Exception
     VerificationConditions,
   )
 import Grisette.Internal.Core.Control.Monad.Union (Union)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.LogicalOp
   ( LogicalOp (symNot, (.&&), (.||)),
   )
@@ -476,4 +477,16 @@ instance SymOrd1 Down where
       LT -> mrgSingle GT
       EQ -> mrgSingle EQ
       GT -> mrgSingle LT
+  {-# INLINE liftSymCompare #-}
+
+instance (SymOrd a) => SymOrd (AsKey a) where
+  symCompare (AsKey l) (AsKey r) = symCompare l r
+  {-# INLINE symCompare #-}
+
+instance (SymOrd1 f, SymOrd a) => SymOrd (AsKey1 f a) where
+  symCompare = symCompare1
+  {-# INLINE symCompare #-}
+
+instance (SymOrd1 f) => SymOrd1 (AsKey1 f) where
+  liftSymCompare f (AsKey1 l) (AsKey1 r) = liftSymCompare f l r
   {-# INLINE liftSymCompare #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ToCon.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ToCon.hs
@@ -65,6 +65,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1 (AsKey1))
 import Grisette.Internal.Core.Data.Class.BitCast (bitCastOrCanonical)
 import Grisette.Internal.Core.Data.Class.Solvable
   ( Solvable (conView),
@@ -438,3 +439,21 @@ deriving via
   (Default ((f :.: g) p))
   instance
     (ToCon (f0 (g0 p0)) (f (g p))) => ToCon ((f0 :.: g0) p0) ((f :.: g) p)
+
+instance {-# INCOHERENT #-} (ToCon a b) => ToCon (AsKey a) b where
+  toCon (AsKey a) = toCon a
+
+instance {-# INCOHERENT #-} (ToCon a b) => ToCon a (AsKey b) where
+  toCon a = AsKey <$> toCon a
+
+instance {-# INCOHERENT #-} (ToCon a b) => ToCon (AsKey a) (AsKey b) where
+  toCon (AsKey a) = AsKey <$> toCon a
+
+instance {-# INCOHERENT #-} (ToCon (f a) b) => ToCon (AsKey1 f a) b where
+  toCon (AsKey1 a) = toCon a
+
+instance {-# INCOHERENT #-} (ToCon a (f b)) => ToCon a (AsKey1 f b) where
+  toCon a = AsKey1 <$> toCon a
+
+instance {-# INCOHERENT #-} (ToCon (f a) (f b)) => ToCon (AsKey1 f a) (AsKey1 f b) where
+  toCon (AsKey1 a) = AsKey1 <$> toCon a

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ToSym.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/ToSym.hs
@@ -70,6 +70,7 @@ import Grisette.Internal.Core.Control.Exception
   ( AssertionError,
     VerificationConditions,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey))
 import Grisette.Internal.Core.Data.Class.BitCast (BitCast (bitCast))
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con))
 import Grisette.Internal.Internal.Decl.Core.Data.Class.ToSym
@@ -500,3 +501,15 @@ deriving via
   (Default ((f :.: g) p))
   instance
     (ToSym (f0 (g0 p0)) (f (g p))) => ToSym ((f0 :.: g0) p0) ((f :.: g) p)
+
+instance {-# INCOHERENT #-} (ToSym a b) => ToSym (AsKey a) (AsKey b) where
+  toSym (AsKey a) = AsKey $ toSym a
+  {-# INLINE toSym #-}
+
+instance {-# INCOHERENT #-} (ToSym a b) => ToSym a (AsKey b) where
+  toSym a = AsKey $ toSym a
+  {-# INLINE toSym #-}
+
+instance {-# INCOHERENT #-} (ToSym a b) => ToSym (AsKey a) b where
+  toSym (AsKey a) = toSym a
+  {-# INLINE toSym #-}

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/UnionBase.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/UnionBase.hs
@@ -38,12 +38,10 @@ import Data.Functor.Classes
     showsUnaryWith,
   )
 import Data.Hashable (Hashable (hashWithSalt))
-import Data.Hashable.Lifted (Hashable1 (liftHashWithSalt))
 import qualified Data.Serialize as Cereal
 import Grisette.Internal.Core.Data.Class.AsKey
   ( KeyHashable (keyHashWithSalt),
     KeyHashable1 (liftKeyHashWithSalt),
-    shouldUseAsKeyError,
   )
 import Grisette.Internal.Core.Data.Class.Mergeable
   ( Mergeable (rootStrategy),
@@ -153,12 +151,6 @@ instance KeyHashable1 UnionBase where
         )
           `g` l
           `g` r
-
-instance (Hashable a) => Hashable (UnionBase a) where
-  hashWithSalt = shouldUseAsKeyError "UnionBase" "hashWithSalt"
-
-instance Hashable1 UnionBase where
-  liftHashWithSalt = shouldUseAsKeyError "UnionBase" "liftHashWithSalt"
 
 instance (AllSyms a) => AllSyms (UnionBase a) where
   allSymsS (UnionSingle v) = allSymsS v

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/UnionBase.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/UnionBase.hs
@@ -137,7 +137,7 @@ instance PPrint1 UnionBase where
                 liftPFormatPrec fa fl 11 f
               ]
 
-instance (Hashable a) => KeyHashable (UnionBase a) where
+instance (Eq a, Hashable a) => KeyHashable (UnionBase a) where
   keyHashWithSalt = liftKeyHashWithSalt hashWithSalt
   {-# INLINE keyHashWithSalt #-}
 

--- a/src/Grisette/Internal/SymPrim/SomeBV.hs
+++ b/src/Grisette/Internal/SymPrim/SomeBV.hs
@@ -123,6 +123,7 @@ import Grisette.Internal.Core.Control.Monad.Union (Union)
 import Grisette.Internal.Core.Data.Class.AsKey
   ( KeyEq (keyEq),
     KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyError,
   )
 import Grisette.Internal.Core.Data.Class.BitVector
   ( BV (bv, bvConcat, bvExt, bvSelect, bvSext, bvZext),
@@ -392,8 +393,13 @@ data SomeBVLit where
   SomeBVIntLit :: Integer -> SomeBVLit
   SomeBVCondLit :: Union Integer -> SomeBVLit
   deriving (Eq, Generic, Lift)
-  deriving anyclass (Hashable, NFData)
+  deriving anyclass (NFData)
   deriving (Mergeable, ExtractSym, AllSyms) via (Default SomeBVLit)
+
+instance Hashable SomeBVLit where
+  hashWithSalt s (SomeBVIntLit i) = s `hashWithSalt` (0 :: Int) `hashWithSalt` i
+  hashWithSalt _ (SomeBVCondLit _) =
+    shouldUseAsKeyError "SomeBVLit (with SomeBVCondLit)" "hashWithSalt"
 
 instance KeyEq SomeBVLit where
   keyEq (SomeBVIntLit l) (SomeBVIntLit r) = l == r

--- a/src/Grisette/Internal/SymPrim/SymAlgReal.hs
+++ b/src/Grisette/Internal/SymPrim/SymAlgReal.hs
@@ -23,7 +23,12 @@ import Data.Hashable (Hashable (hashWithSalt))
 import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError, shouldUseSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyHasSymbolicVersionError,
+    shouldUseSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.Function (Apply (FunType, apply))
 import Grisette.Internal.Core.Data.Class.Solvable
   ( Solvable (con, conView, ssym, sym),
@@ -127,15 +132,6 @@ instance Ord SymAlgReal where
 
 instance Real SymAlgReal where
   toRational = error "toRational: toRational isn't supported for SymAlgReal"
-
--- | This will crash the program.
---
--- 'SymAlgReal' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymAlgReal'@ instead.
-instance Hashable SymAlgReal where
-  hashWithSalt = shouldUseAsKeyError "SymAlgReal" "hashWithSalt"
 
 instance KeyHashable SymAlgReal where
   keyHashWithSalt s (SymAlgReal v) = s `hashWithSalt` v

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -72,7 +72,11 @@ import GHC.TypeNats
     type (+),
     type (<=),
   )
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyHasSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.BitCast (BitCast (bitCast))
 import Grisette.Internal.Core.Data.Class.BitVector
   ( SizedBV
@@ -438,28 +442,12 @@ SHOW_BV(SymWordN)
 
 -- Hashable
 
-#define HASHABLE_BV(symtype) \
-instance (KnownNat n, 1 <= n) => Hashable (symtype n) where \
-  hashWithSalt = shouldUseAsKeyError "symtype" "hashWithSalt"
-
 #define KEY_HASHABLE_BV(symtype) \
 instance (KnownNat n, 1 <= n) => KeyHashable (symtype n) where \
   keyHashWithSalt s (symtype v) = s `hashWithSalt` v
 
 #if 1
--- | This will crash the program.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' ('SymIntN' n)@ instead.
-HASHABLE_BV(SymIntN)
 KEY_HASHABLE_BV(SymIntN)
--- | This will crash the program.
---
--- 'SymWordN' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' ('SymWordN' n)@ instead.
-HASHABLE_BV(SymWordN)
 KEY_HASHABLE_BV(SymWordN)
 #endif
 

--- a/src/Grisette/Internal/SymPrim/SymBV.hs
+++ b/src/Grisette/Internal/SymPrim/SymBV.hs
@@ -72,6 +72,7 @@ import GHC.TypeNats
     type (+),
     type (<=),
   )
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
 import Grisette.Internal.Core.Data.Class.BitCast (BitCast (bitCast))
 import Grisette.Internal.Core.Data.Class.BitVector
   ( SizedBV
@@ -439,36 +440,56 @@ SHOW_BV(SymWordN)
 
 #define HASHABLE_BV(symtype) \
 instance (KnownNat n, 1 <= n) => Hashable (symtype n) where \
-  hashWithSalt s (symtype v) = s `hashWithSalt` v
+  hashWithSalt = shouldUseAsKeyError "symtype" "hashWithSalt"
+
+#define KEY_HASHABLE_BV(symtype) \
+instance (KnownNat n, 1 <= n) => KeyHashable (symtype n) where \
+  keyHashWithSalt s (symtype v) = s `hashWithSalt` v
 
 #if 1
+-- | This will crash the program.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' ('SymIntN' n)@ instead.
 HASHABLE_BV(SymIntN)
+KEY_HASHABLE_BV(SymIntN)
+-- | This will crash the program.
+--
+-- 'SymWordN' cannot be hashed concretely.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' ('SymWordN' n)@ instead.
 HASHABLE_BV(SymWordN)
+KEY_HASHABLE_BV(SymWordN)
 #endif
 
 -- Eq
 
 #define EQ_BV(symtype) \
 instance (KnownNat n, 1 <= n) => Eq (symtype n) where \
-  (symtype l) == (symtype r) = l == r
+  (==) = shouldUseAsKeyHasSymbolicVersionError "symtype" "(==)" "(.==)"
+
+#define KEY_EQ_BV(symtype) \
+instance (KnownNat n, 1 <= n) => KeyEq (symtype n) where \
+  keyEq (symtype l) (symtype r) = l == r
 
 #if 1
--- | Checks if two formulas are the same. Not building the actual symbolic
--- equality formula.
+-- This will crash the program.
 --
--- The reason why we choose this behavior is to allow symbolic variables to be
--- used as keys in hash maps, which can be useful for memoization.
+-- 'SymIntN' cannot be compared concretely.
 --
--- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' ('SymIntN' n)@ instead.
 EQ_BV(SymIntN)
--- | Checks if two formulas are the same. Not building the actual symbolic
--- equality formula.
+KEY_EQ_BV(SymIntN)
+-- | This will crash the program.
 --
--- The reason why we choose this behavior is to allow symbolic variables to be
--- used as keys in hash maps, which can be useful for memoization.
+-- 'SymWordN' cannot be compared concretely.
 --
--- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' ('SymWordN' n)@ instead.
 EQ_BV(SymWordN)
+KEY_EQ_BV(SymWordN)
 #endif
 
 -- IsString

--- a/src/Grisette/Internal/SymPrim/SymBool.hs
+++ b/src/Grisette/Internal/SymPrim/SymBool.hs
@@ -25,7 +25,6 @@ import GHC.Generics (Generic)
 import Grisette.Internal.Core.Data.Class.AsKey
   ( KeyEq (keyEq),
     KeyHashable (keyHashWithSalt),
-    shouldUseAsKeyError,
     shouldUseAsKeyHasSymbolicVersionError,
   )
 import Grisette.Internal.Core.Data.Class.Function (Apply (FunType, apply))
@@ -95,15 +94,6 @@ instance Eq SymBool where
 
 instance KeyEq SymBool where
   keyEq (SymBool l) (SymBool r) = l == r
-
--- | This will crash the program.
---
--- 'SymBool' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymBool'@ instead.
-instance Hashable SymBool where
-  hashWithSalt = shouldUseAsKeyError "SymBool" "hashWithSalt"
 
 instance KeyHashable SymBool where
   keyHashWithSalt s (SymBool v) = s `hashWithSalt` v

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -38,6 +38,7 @@ import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownNat, type (+), type (<=))
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
 import Grisette.Internal.Core.Data.Class.BitCast
   ( BitCast (bitCast),
     BitCastCanonical (bitCastCanonicalValue),
@@ -209,18 +210,32 @@ instance (ValidFP eb sb) => Apply (SymFP eb sb) where
   type FunType (SymFP eb sb) = SymFP eb sb
   apply = id
 
--- | Checks if two formulas are the same. Not building the actual symbolic
--- equality formula.
+-- | This will crash the program.
 --
--- The reason why we choose this behavior is to allow symbolic variables to be
--- used as keys in hash maps, which can be useful for memoization.
+-- 'SymFP' cannot be compared concretely.
 --
--- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymFP'@ instead.
+--
+-- If you want symbolic version of the equality operator, use
+-- t'Grisette.Core.SymEq' instead.
 instance (ValidFP eb sb) => Eq (SymFP eb sb) where
-  SymFP a == SymFP b = a == b
+  (==) = shouldUseAsKeyHasSymbolicVersionError "SymFP" "(==)" "(.==)"
 
+instance (ValidFP eb sb) => KeyEq (SymFP eb sb) where
+  keyEq (SymFP l) (SymFP r) = l == r
+
+-- | This will crash the program.
+--
+-- 'SymFP' cannot be hashed concretely.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymFP'@ instead.
 instance (ValidFP eb sb) => Hashable (SymFP eb sb) where
-  hashWithSalt s (SymFP a) = hashWithSalt s a
+  hashWithSalt = shouldUseAsKeyError "SymFP" "hashWithSalt"
+
+instance (ValidFP eb sb) => KeyHashable (SymFP eb sb) where
+  keyHashWithSalt s (SymFP a) = hashWithSalt s a
 
 instance (ValidFP eb sb) => IsString (SymFP eb sb) where
   fromString = ssym . fromString
@@ -288,11 +303,30 @@ instance Apply SymFPRoundingMode where
   type FunType SymFPRoundingMode = SymFPRoundingMode
   apply = id
 
+-- | This will crash the program.
+--
+-- 'SymFPRoundingMode' cannot be compared concretely.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymFPRoundingMode'@ instead.
 instance Eq SymFPRoundingMode where
-  SymFPRoundingMode a == SymFPRoundingMode b = a == b
+  (==) =
+    shouldUseAsKeyHasSymbolicVersionError "SymFPRoundingMode" "(==)" "(.==)"
 
+instance KeyEq SymFPRoundingMode where
+  keyEq (SymFPRoundingMode l) (SymFPRoundingMode r) = l == r
+
+-- | This will crash the program.
+--
+-- 'SymFPRoundingMode' cannot be hashed concretely.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymFPRoundingMode'@ instead.
 instance Hashable SymFPRoundingMode where
-  hashWithSalt s (SymFPRoundingMode a) = hashWithSalt s a
+  hashWithSalt = shouldUseAsKeyError "SymFPRoundingMode" "hashWithSalt"
+
+instance KeyHashable SymFPRoundingMode where
+  keyHashWithSalt s (SymFPRoundingMode a) = hashWithSalt s a
 
 instance IsString SymFPRoundingMode where
   fromString = ssym . fromString

--- a/src/Grisette/Internal/SymPrim/SymFP.hs
+++ b/src/Grisette/Internal/SymPrim/SymFP.hs
@@ -38,7 +38,12 @@ import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownNat, type (+), type (<=))
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyError,
+    shouldUseAsKeyHasSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.BitCast
   ( BitCast (bitCast),
     BitCastCanonical (bitCastCanonicalValue),
@@ -315,15 +320,6 @@ instance Eq SymFPRoundingMode where
 
 instance KeyEq SymFPRoundingMode where
   keyEq (SymFPRoundingMode l) (SymFPRoundingMode r) = l == r
-
--- | This will crash the program.
---
--- 'SymFPRoundingMode' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymFPRoundingMode'@ instead.
-instance Hashable SymFPRoundingMode where
-  hashWithSalt = shouldUseAsKeyError "SymFPRoundingMode" "hashWithSalt"
 
 instance KeyHashable SymFPRoundingMode where
   keyHashWithSalt s (SymFPRoundingMode a) = hashWithSalt s a

--- a/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
@@ -35,7 +35,11 @@ import Data.Hashable (Hashable (hashWithSalt))
 import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyHasSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.Function
   ( Apply (FunType, apply),
     Function ((#)),
@@ -207,15 +211,6 @@ instance Eq (sa -~> sb) where
 
 instance KeyEq (sa -~> sb) where
   keyEq (SymGeneralFun l) (SymGeneralFun r) = l == r
-
--- | This will crash the program.
---
--- 'SymGeneralFun' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymGeneralFun'@ instead.
-instance Hashable (sa -~> sb) where
-  hashWithSalt = shouldUseAsKeyError "SymGeneralFun" "hashWithSalt"
 
 instance KeyHashable (sa -~> sb) where
   keyHashWithSalt s (SymGeneralFun v) = hashWithSalt s v

--- a/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymGeneralFun.hs
@@ -35,6 +35,7 @@ import Data.Hashable (Hashable (hashWithSalt))
 import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
 import Grisette.Internal.Core.Data.Class.Function
   ( Apply (FunType, apply),
     Function ((#)),
@@ -195,18 +196,29 @@ instance
 instance Show (sa -~> sb) where
   show (SymGeneralFun t) = pformatTerm t
 
--- | Checks if two formulas are the same. Not building the actual symbolic
--- equality formula.
+-- | This will crash the program.
 --
--- The reason why we choose this behavior is to allow symbolic variables to be
--- used as keys in hash maps, which can be useful for memoization.
+-- 'SymGeneralFun' cannot be compared concretely.
 --
--- Use with caution. Usually you should use t'Grisette.Core.SymEq' instead.
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymGeneralFun'@ instead.
 instance Eq (sa -~> sb) where
-  SymGeneralFun l == SymGeneralFun r = l == r
+  (==) = shouldUseAsKeyHasSymbolicVersionError "SymGeneralFun" "(==)" "(.==)"
 
+instance KeyEq (sa -~> sb) where
+  keyEq (SymGeneralFun l) (SymGeneralFun r) = l == r
+
+-- | This will crash the program.
+--
+-- 'SymGeneralFun' cannot be hashed concretely.
+--
+-- If you want to use the type as keys in hash maps based on term equality, say
+-- memo table, you should use @'AsKey' 'SymGeneralFun'@ instead.
 instance Hashable (sa -~> sb) where
-  hashWithSalt s (SymGeneralFun v) = s `hashWithSalt` v
+  hashWithSalt = shouldUseAsKeyError "SymGeneralFun" "hashWithSalt"
+
+instance KeyHashable (sa -~> sb) where
+  keyHashWithSalt s (SymGeneralFun v) = hashWithSalt s v
 
 instance AllSyms (sa -~> sb) where
   allSymsS v@SymGeneralFun {} = (SomeSym v :)

--- a/src/Grisette/Internal/SymPrim/SymInteger.hs
+++ b/src/Grisette/Internal/SymPrim/SymInteger.hs
@@ -22,7 +22,12 @@ import Data.Hashable (Hashable (hashWithSalt))
 import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
 import GHC.Generics (Generic)
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError, shouldUseSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyHasSymbolicVersionError,
+    shouldUseSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.Function (Apply (FunType, apply))
 import Grisette.Internal.Core.Data.Class.Solvable
   ( Solvable (con, conView, ssym, sym),
@@ -165,15 +170,6 @@ instance Eq SymInteger where
 
 instance KeyEq SymInteger where
   keyEq (SymInteger l) (SymInteger r) = l == r
-
--- | This will crash the program.
---
--- 'SymInteger' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymInteger'@ instead.
-instance Hashable SymInteger where
-  hashWithSalt = shouldUseAsKeyError "SymInteger" "hashWithSalt"
 
 instance KeyHashable SymInteger where
   keyHashWithSalt s (SymInteger v) = s `hashWithSalt` v

--- a/src/Grisette/Internal/SymPrim/SymPrim.hs
+++ b/src/Grisette/Internal/SymPrim/SymPrim.hs
@@ -17,7 +17,6 @@ module Grisette.Internal.SymPrim.SymPrim (Prim, SymPrim, BasicSymPrim) where
 import Control.DeepSeq (NFData)
 import Data.Binary (Binary)
 import Data.Bytes.Serial (Serial)
-import Data.Hashable (Hashable)
 import Data.Serialize (Serialize)
 import Grisette.Internal.Core.Data.Class.AsKey (KeyEq, KeyHashable)
 import Grisette.Internal.Core.Data.Class.EvalSym (EvalSym)
@@ -60,7 +59,6 @@ type Prim a =
     SymEq a,
     SymOrd a,
     AllSyms a,
-    Hashable a,
     KeyEq a,
     KeyHashable a,
     Lift a,

--- a/src/Grisette/Internal/SymPrim/SymPrim.hs
+++ b/src/Grisette/Internal/SymPrim/SymPrim.hs
@@ -19,6 +19,7 @@ import Data.Binary (Binary)
 import Data.Bytes.Serial (Serial)
 import Data.Hashable (Hashable)
 import Data.Serialize (Serialize)
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq, KeyHashable)
 import Grisette.Internal.Core.Data.Class.EvalSym (EvalSym)
 import Grisette.Internal.Core.Data.Class.ExtractSym (ExtractSym)
 import Grisette.Internal.Core.Data.Class.Function (Apply (FunType))
@@ -60,6 +61,8 @@ type Prim a =
     SymOrd a,
     AllSyms a,
     Hashable a,
+    KeyEq a,
+    KeyHashable a,
     Lift a,
     Typeable a
   )

--- a/src/Grisette/Internal/SymPrim/SymTabularFun.hs
+++ b/src/Grisette/Internal/SymPrim/SymTabularFun.hs
@@ -30,7 +30,11 @@ import Data.Bytes.Serial (Serial (deserialize, serialize))
 import Data.Hashable (Hashable (hashWithSalt))
 import qualified Data.Serialize as Cereal
 import Data.String (IsString (fromString))
-import Grisette.Internal.Core.Data.Class.AsKey (KeyEq (keyEq), KeyHashable (keyHashWithSalt), shouldUseAsKeyError, shouldUseAsKeyHasSymbolicVersionError)
+import Grisette.Internal.Core.Data.Class.AsKey
+  ( KeyEq (keyEq),
+    KeyHashable (keyHashWithSalt),
+    shouldUseAsKeyHasSymbolicVersionError,
+  )
 import Grisette.Internal.Core.Data.Class.Function
   ( Apply (FunType, apply),
     Function ((#)),
@@ -161,15 +165,6 @@ instance Eq (sa =~> sb) where
 
 instance KeyEq (sa =~> sb) where
   keyEq (SymTabularFun l) (SymTabularFun r) = l == r
-
--- | This will crash the program.
---
--- 'SymTabularFun' cannot be hashed concretely.
---
--- If you want to use the type as keys in hash maps based on term equality, say
--- memo table, you should use @'AsKey' 'SymTabularFun'@ instead.
-instance Hashable (sa =~> sb) where
-  hashWithSalt = shouldUseAsKeyError "SymTabularFun" "hashWithSalt"
 
 instance KeyHashable (sa =~> sb) where
   keyHashWithSalt s (SymTabularFun v) = hashWithSalt s v

--- a/src/Grisette/Internal/TH/Derivation/Derive.hs
+++ b/src/Grisette/Internal/TH/Derivation/Derive.hs
@@ -25,10 +25,13 @@ module Grisette.Internal.TH.Derivation.Derive
     basicClasses012,
     noExistentialClasses0,
     concreteOrdClasses0,
+    hashableClasses0,
     noExistentialClasses1,
     concreteOrdClasses1,
+    hashableClasses1,
     noExistentialClasses2,
     concreteOrdClasses2,
+    hashableClasses2,
     showClasses,
     pprintClasses,
     evalSymClasses,
@@ -348,7 +351,8 @@ deriveSingle deriveConfig typName className = do
                 needExtraMergeableUnderEvalMode = False,
                 needExtraMergeableWithConcretizedEvalMode = False
               }
-        | className `elem` [''Ord, ''Ord1, ''Ord2] =
+        | className
+            `elem` [''Ord, ''Ord1, ''Ord2, ''Hashable, ''Hashable1, ''Hashable2] =
             deriveConfig
               { evalModeConfig =
                   second
@@ -410,9 +414,9 @@ deriveWith' deriveConfig typName classNameList = do
 -- * 'NFData'
 -- * 'NFData1'
 -- * 'NFData2'
--- * 'Hashable'
--- * 'Hashable1'
--- * 'Hashable2'
+-- * 'Hashable' (will fail to derive if the type contains any symbolic variables)
+-- * 'Hashable1' (will fail to derive if the type contains any symbolic variables)
+-- * 'Hashable2' (will fail to derive if the type contains any symbolic variables)
 -- * 'Show'
 -- * 'Show1'
 -- * 'Show2'
@@ -425,9 +429,9 @@ deriveWith' deriveConfig typName classNameList = do
 -- * 'Eq'
 -- * 'Eq1'
 -- * 'Eq2'
--- * 'Ord'
--- * 'Ord1'
--- * 'Ord2'
+-- * 'Ord' (will fail to derive if the type contains any symbolic variables)
+-- * 'Ord1' (will fail to derive if the type contains any symbolic variables)
+-- * 'Ord2' (will fail to derive if the type contains any symbolic variables)
 -- * 'SymOrd'
 -- * 'SymOrd1'
 -- * 'SymOrd2'
@@ -492,7 +496,7 @@ derive = deriveWith mempty
 -- * 'ExtractSym'
 -- * 'SubstSym'
 -- * 'NFData'
--- * 'Hashable'
+-- * 'Hashable' (will fail to derive if the type contains any symbolic variables)
 -- * 'Show'
 -- * 'PPrint'
 -- * 'AllSyms'
@@ -500,13 +504,13 @@ derive = deriveWith mempty
 -- * 'SymEq'
 -- * 'SymOrd'
 -- * 'UnifiedSymEq'
--- * 'Ord'
+-- * 'Ord' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd'
 -- * 'Serial'
 -- * 'ToCon'
 -- * 'ToSym'
 allClasses0 :: [Name]
-allClasses0 = basicClasses0 ++ concreteOrdClasses0 ++ noExistentialClasses0
+allClasses0 = basicClasses0 ++ concreteOrdClasses0 ++ noExistentialClasses0 ++ hashableClasses0
 
 -- | All the @*1@ classes that can be derived for GADT functors.
 --
@@ -517,7 +521,7 @@ allClasses0 = basicClasses0 ++ concreteOrdClasses0 ++ noExistentialClasses0
 -- * 'ExtractSym1'
 -- * 'SubstSym1'
 -- * 'NFData1'
--- * 'Hashable1'
+-- * 'Hashable1' (will fail to derive if the type contains any symbolic variables)
 -- * 'Show1'
 -- * 'PPrint1'
 -- * 'AllSyms1'
@@ -525,13 +529,13 @@ allClasses0 = basicClasses0 ++ concreteOrdClasses0 ++ noExistentialClasses0
 -- * 'SymEq1'
 -- * 'SymOrd1'
 -- * 'UnifiedSymEq1'
--- * 'Ord1'
+-- * 'Ord1' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd1'
 -- * 'Serial1'
 -- * 'ToCon1'
 -- * 'ToSym1'
 allClasses1 :: [Name]
-allClasses1 = basicClasses1 ++ concreteOrdClasses1 ++ noExistentialClasses1
+allClasses1 = basicClasses1 ++ concreteOrdClasses1 ++ noExistentialClasses1 ++ hashableClasses1
 
 -- | All the classes that can be derived for GADT functors.
 --
@@ -548,7 +552,7 @@ allClasses01 = allClasses0 ++ allClasses1
 -- * 'ExtractSym2'
 -- * 'SubstSym2'
 -- * 'NFData2'
--- * 'Hashable2'
+-- * 'Hashable2' (will fail to derive if the type contains any symbolic variables)
 -- * 'Show2'
 -- * 'PPrint2'
 -- * 'AllSyms2'
@@ -556,13 +560,13 @@ allClasses01 = allClasses0 ++ allClasses1
 -- * 'SymEq2'
 -- * 'SymOrd2'
 -- * 'UnifiedSymEq2'
--- * 'Ord2'
+-- * 'Ord2' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd2'
 -- * 'Serial2'
 -- * 'ToCon2'
 -- * 'ToSym2'
 allClasses2 :: [Name]
-allClasses2 = basicClasses2 ++ concreteOrdClasses2 ++ noExistentialClasses2
+allClasses2 = basicClasses2 ++ concreteOrdClasses2 ++ noExistentialClasses2 ++ hashableClasses2
 
 -- | All the classes that can be derived for GADT functors.
 --
@@ -580,7 +584,6 @@ allClasses012 = allClasses0 ++ allClasses1 ++ allClasses2
 -- * 'ExtractSym'
 -- * 'SubstSym'
 -- * 'NFData'
--- * 'Hashable'
 -- * 'Show'
 -- * 'PPrint'
 -- * 'AllSyms'
@@ -597,7 +600,6 @@ basicClasses0 =
     ''ExtractSym,
     ''SubstSym,
     ''NFData,
-    ''Hashable,
     ''Show,
     ''PPrint,
     ''AllSyms,
@@ -627,10 +629,18 @@ noExistentialClasses0 = [''Serial, ''ToCon, ''ToSym, ''Serialize, ''Binary]
 --
 -- This includes:
 --
--- * 'Ord'
+-- * 'Ord' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd'
 concreteOrdClasses0 :: [Name]
 concreteOrdClasses0 = [''Ord, ''UnifiedSymOrd]
+
+-- | Hashable classes that can be derived for GADTs.
+--
+-- This includes:
+--
+-- * 'Hashable' (will fail to derive if the type contains any symbolic variables)
+hashableClasses0 :: [Name]
+hashableClasses0 = [''Hashable]
 
 -- | Basic classes for GADT functors.
 --
@@ -641,7 +651,6 @@ concreteOrdClasses0 = [''Ord, ''UnifiedSymOrd]
 -- * 'ExtractSym1'
 -- * 'SubstSym1'
 -- * 'NFData1'
--- * 'Hashable1'
 -- * 'Show1'
 -- * 'PPrint1'
 -- * 'AllSyms1'
@@ -656,7 +665,6 @@ basicClasses1 =
     ''ExtractSym1,
     ''SubstSym1,
     ''NFData1,
-    ''Hashable1,
     ''Show1,
     ''PPrint1,
     ''AllSyms1,
@@ -690,10 +698,18 @@ noExistentialClasses1 = [''Serial1, ''ToCon1, ''ToSym1]
 --
 -- This includes:
 --
--- * 'Ord1'
+-- * 'Ord1' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd1'
 concreteOrdClasses1 :: [Name]
 concreteOrdClasses1 = [''Ord1, ''UnifiedSymOrd1]
+
+-- | Hashable classes that can be derived for GADT functors.
+--
+-- This includes:
+--
+-- * 'Hashable1' (will fail to derive if the type contains any symbolic variables)
+hashableClasses1 :: [Name]
+hashableClasses1 = [''Hashable1]
 
 -- | Basic classes for GADT functors.
 --
@@ -704,7 +720,6 @@ concreteOrdClasses1 = [''Ord1, ''UnifiedSymOrd1]
 -- * 'ExtractSym2'
 -- * 'SubstSym2'
 -- * 'NFData2'
--- * 'Hashable2'
 -- * 'Show2'
 -- * 'PPrint2'
 -- * 'AllSyms2'
@@ -719,7 +734,6 @@ basicClasses2 =
     ''ExtractSym2,
     ''SubstSym2,
     ''NFData2,
-    ''Hashable2,
     ''Show2,
     ''PPrint2,
     ''AllSyms2,
@@ -754,10 +768,18 @@ noExistentialClasses2 = [''Serial2, ''ToCon2, ''ToSym2]
 --
 -- This includes:
 --
--- * 'Ord2'
+-- * 'Ord2' (will fail to derive if the type contains any symbolic variables)
 -- * 'UnifiedSymOrd2'
 concreteOrdClasses2 :: [Name]
 concreteOrdClasses2 = [''Ord2, ''UnifiedSymOrd2]
+
+-- | Hashable classes that can be derived for GADT functors.
+--
+-- This includes:
+--
+-- * 'Hashable2' (will fail to derive if the type contains any symbolic variables)
+hashableClasses2 :: [Name]
+hashableClasses2 = [''Hashable2]
 
 -- | 'Show' classes that can be derived for GADTs.
 --
@@ -853,9 +875,9 @@ unifiedSymEqClasses = [''UnifiedSymEq, ''UnifiedSymEq1, ''UnifiedSymEq2]
 --
 -- This includes:
 --
--- * 'Ord'
--- * 'Ord1'
--- * 'Ord2'
+-- * 'Ord' (will fail to derive if the type contains any symbolic variables)
+-- * 'Ord1' (will fail to derive if the type contains any symbolic variables)
+-- * 'Ord2' (will fail to derive if the type contains any symbolic variables)
 ordClasses :: [Name]
 ordClasses = [''Ord, ''Ord1, ''Ord2]
 
@@ -904,9 +926,9 @@ nfDataClasses = [''NFData, ''NFData1, ''NFData2]
 --
 -- This includes:
 --
--- * 'Hashable'
--- * 'Hashable1'
--- * 'Hashable2'
+-- * 'Hashable' (will fail to derive if the type contains any symbolic variables)
+-- * 'Hashable1' (will fail to derive if the type contains any symbolic variables)
+-- * 'Hashable2' (will fail to derive if the type contains any symbolic variables)
 hashableClasses :: [Name]
 hashableClasses = [''Hashable, ''Hashable1, ''Hashable2]
 

--- a/src/Grisette/Internal/Unified/UnifiedData.hs
+++ b/src/Grisette/Internal/Unified/UnifiedData.hs
@@ -70,7 +70,6 @@ class
     (PPrint v) => PPrint u,
     (Eq v) => KeyEq u,
     (Hashable v) => KeyHashable u,
-    (Hashable v) => Hashable u,
     (Lift v) => Lift u,
     (LogicalOp v, Mergeable v) => LogicalOp u,
     (NFData v) => NFData u,

--- a/src/Grisette/Internal/Unified/UnifiedData.hs
+++ b/src/Grisette/Internal/Unified/UnifiedData.hs
@@ -33,6 +33,7 @@ import Control.Monad.Identity (Identity (Identity, runIdentity))
 import Data.Bytes.Serial (Serial)
 import Data.Hashable (Hashable)
 import Grisette.Internal.Core.Control.Monad.Union (Union)
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq, KeyHashable)
 import Grisette.Internal.Core.Data.Class.EvalSym (EvalSym)
 import Grisette.Internal.Core.Data.Class.ExtractSym (ExtractSym)
 import Grisette.Internal.Core.Data.Class.ITEOp (ITEOp)
@@ -67,6 +68,8 @@ class
     (ExtractSym v) => ExtractSym u,
     (ITEOp v, Mergeable v) => ITEOp u,
     (PPrint v) => PPrint u,
+    (Eq v) => KeyEq u,
+    (Hashable v) => KeyHashable u,
     (Hashable v) => Hashable u,
     (Lift v) => Lift u,
     (LogicalOp v, Mergeable v) => LogicalOp u,

--- a/src/Grisette/Internal/Unified/UnifiedData.hs
+++ b/src/Grisette/Internal/Unified/UnifiedData.hs
@@ -69,7 +69,7 @@ class
     (ITEOp v, Mergeable v) => ITEOp u,
     (PPrint v) => PPrint u,
     (Eq v) => KeyEq u,
-    (Hashable v) => KeyHashable u,
+    (Eq v, Hashable v) => KeyHashable u,
     (Lift v) => Lift u,
     (LogicalOp v, Mergeable v) => LogicalOp u,
     (NFData v) => NFData u,

--- a/src/Grisette/Internal/Unified/UnifiedFun.hs
+++ b/src/Grisette/Internal/Unified/UnifiedFun.hs
@@ -45,7 +45,6 @@ import Data.Foldable (Foldable (foldl'))
 import Control.DeepSeq (NFData)
 import Data.Binary (Binary)
 import Data.Bytes.Serial (Serial)
-import Data.Hashable (Hashable)
 import qualified Data.Kind
 import Data.Serialize (Serialize)
 import Data.Typeable (Typeable)
@@ -182,7 +181,6 @@ type UnifiedFunConstraint mode a b ca cb sa sb =
     Mergeable (GetFun mode a b),
     PPrint (GetFun mode a b),
     SubstSym (GetFun mode a b),
-    Hashable (GetFun mode a b),
     Lift (GetFun mode a b),
     Typeable (GetFun mode a b),
     ToCon (GetFun mode a b) (ca =-> cb),

--- a/test/Grisette/Backend/CEGISTests.hs
+++ b/test/Grisette/Backend/CEGISTests.hs
@@ -15,6 +15,7 @@ import Data.String (IsString (fromString))
 import GHC.Stack (HasCallStack)
 import Grisette
   ( Apply (apply),
+    AsKey (AsKey),
     CEGISResult (CEGISSolverFailure, CEGISSuccess, CEGISVerifierFailure),
     EvalSym (evalSym),
     ExtractSym,
@@ -54,7 +55,7 @@ import Grisette.SymPrim
   )
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit (Assertion, assertFailure, (@=?), (@?=))
+import Test.HUnit (Assertion, assertFailure, (@?=))
 
 testCegis ::
   (HasCallStack, ExtractSym a, EvalSym a, SymEq a) =>
@@ -69,17 +70,17 @@ testCegis config shouldSuccess inputs bs = do
       \(cexInputs, internal) -> buildFormula internal (bs cexInputs)
   case cegisExceptVCResult of
     (_, CEGISSuccess m) -> do
-      shouldSuccess @=? True
+      shouldSuccess @?= True
       verify "cegisExceptVC" m (bs inputs)
-    _ -> shouldSuccess @=? False
+    _ -> shouldSuccess @?= False
   cegisForAllExceptVCResult <-
     cegisForAllExceptVC config (inputs, "internal" :: SymInteger) return $
       buildFormula "internal" (bs inputs)
   case cegisForAllExceptVCResult of
     (_, CEGISSuccess m) -> do
-      shouldSuccess @=? True
+      shouldSuccess @?= True
       verify "cegisForAllExceptVC" m (bs inputs)
-    _ -> shouldSuccess @=? False
+    _ -> shouldSuccess @?= False
   where
     verify _ _ [] = return ()
     verify funName m (v : vs) = do
@@ -120,7 +121,7 @@ cegisTests =
                     [1 :: Integer, 2]
                     (\idx -> cegisPostCond $ fromString $ "a" ++ show idx)
                 Right m2 <- solve z3 ("a1" .&& "a2")
-                m1 @=? m2,
+                m1 @?= m2,
               testCase "Lowering of TabularFun" $ do
                 let s1 = "s1" :: SymInteger =~> SymInteger
                 let s2 = "s2" :: SymInteger =~> SymInteger
@@ -134,10 +135,10 @@ cegisTests =
                           .== 100
                 let s1e = evalSym False m1 s1
                 let s2e = evalSym False m1 s2
-                s1e # 1 @=? 10
-                s1e # 3 @=? 100
-                s2e # 2 @=? 10
-                s2e # 4 @=? 100,
+                AsKey (s1e # 1) @?= AsKey 10
+                AsKey (s1e # 3) @?= AsKey 100
+                AsKey (s2e # 2) @?= AsKey 10
+                AsKey (s2e # 4) @?= AsKey 100,
               testCase "Lowering of GeneralFun" $ do
                 let s1 = "s1" :: SymInteger -~> SymInteger
                 let s2 = "s2" :: SymInteger -~> SymInteger
@@ -151,10 +152,10 @@ cegisTests =
                           .== 100
                 let s1e = evalSym False m1 s1
                 let s2e = evalSym False m1 s2
-                s1e # 1 @=? 10
-                s1e # 3 @=? 100
-                s2e # 2 @=? 10
-                s2e # 4 @=? 100
+                AsKey (s1e # 1) @?= AsKey 10
+                AsKey (s1e # 3) @?= AsKey 100
+                AsKey (s2e # 2) @?= AsKey 10
+                AsKey (s2e # 4) @?= AsKey 100
             ],
           testGroup
             "Boolean"

--- a/test/Grisette/Core/Control/ExceptionTests.hs
+++ b/test/Grisette/Core/Control/ExceptionTests.hs
@@ -8,7 +8,8 @@ import Control.Exception
   )
 import Control.Monad.Except (ExceptT (ExceptT))
 import Grisette
-  ( AssertionError (AssertionError),
+  ( AsKey (AsKey),
+    AssertionError (AssertionError),
     EvalSym (evalSym),
     ExtractSym (extractSym),
     LogicalOp (symNot),
@@ -29,6 +30,7 @@ import Grisette
     mrgSingle,
     symAssert,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey1 (AsKey1))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@?=))
@@ -44,15 +46,14 @@ exceptionTests =
           testCase "ToSym" $ do
             toSym AssertionError @?= AssertionError,
           testCase "SymEq" $ do
-            AssertionError .== AssertionError @?= con True,
+            AsKey (AssertionError .== AssertionError) @?= con True,
           testCase "SymOrd" $ do
-            AssertionError .<= AssertionError @?= con True
-            AssertionError .< AssertionError @?= con False
-            AssertionError .>= AssertionError @?= con True
-            AssertionError .> AssertionError @?= con False
-            AssertionError
-              `symCompare` AssertionError
-              @?= (mrgSingle EQ :: Union Ordering),
+            AsKey (AssertionError .<= AssertionError) @?= con True
+            AsKey (AssertionError .< AssertionError) @?= con False
+            AsKey (AssertionError .>= AssertionError) @?= con True
+            AsKey (AssertionError .> AssertionError) @?= con False
+            AsKey1 (AssertionError `symCompare` AssertionError)
+              @?= (mrgSingle EQ :: AsKey1 Union Ordering),
           testCase "GEvalSym" $ do
             evalSym False emptyModel AssertionError @?= AssertionError,
           testCase "GExtractSym" $ do
@@ -82,42 +83,38 @@ exceptionTests =
             toSym AssertionViolation @?= AssertionViolation
             toSym AssumptionViolation @?= AssumptionViolation,
           testCase "SymEq" $ do
-            AssertionViolation .== AssertionViolation @?= con True
-            AssertionViolation .== AssumptionViolation @?= con False
-            AssumptionViolation .== AssertionViolation @?= con False
-            AssumptionViolation .== AssumptionViolation @?= con True,
+            AsKey (AssertionViolation .== AssertionViolation) @?= con True
+            AsKey (AssertionViolation .== AssumptionViolation) @?= con False
+            AsKey (AssumptionViolation .== AssertionViolation) @?= con False
+            AsKey (AssumptionViolation .== AssumptionViolation) @?= con True,
           testCase "SymOrd" $ do
-            AssertionViolation .<= AssertionViolation @?= con True
-            AssertionViolation .< AssertionViolation @?= con False
-            AssertionViolation .>= AssertionViolation @?= con True
-            AssertionViolation .> AssertionViolation @?= con False
-            AssertionViolation
-              `symCompare` AssertionViolation
-              @?= (mrgSingle EQ :: Union Ordering)
+            AsKey (AssertionViolation .<= AssertionViolation) @?= con True
+            AsKey (AssertionViolation .< AssertionViolation) @?= con False
+            AsKey (AssertionViolation .>= AssertionViolation) @?= con True
+            AsKey (AssertionViolation .> AssertionViolation) @?= con False
+            AsKey1 (AssertionViolation `symCompare` AssertionViolation)
+              @?= (mrgSingle EQ :: AsKey1 Union Ordering)
 
-            AssertionViolation .<= AssumptionViolation @?= con True
-            AssertionViolation .< AssumptionViolation @?= con True
-            AssertionViolation .>= AssumptionViolation @?= con False
-            AssertionViolation .> AssumptionViolation @?= con False
-            AssertionViolation
-              `symCompare` AssumptionViolation
-              @?= (mrgSingle LT :: Union Ordering)
+            AsKey (AssertionViolation .<= AssumptionViolation) @?= con True
+            AsKey (AssertionViolation .< AssumptionViolation) @?= con True
+            AsKey (AssertionViolation .>= AssumptionViolation) @?= con False
+            AsKey (AssertionViolation .> AssumptionViolation) @?= con False
+            AsKey1 (AssertionViolation `symCompare` AssumptionViolation)
+              @?= (mrgSingle LT :: AsKey1 Union Ordering)
 
-            AssumptionViolation .<= AssertionViolation @?= con False
-            AssumptionViolation .< AssertionViolation @?= con False
-            AssumptionViolation .>= AssertionViolation @?= con True
-            AssumptionViolation .> AssertionViolation @?= con True
-            AssumptionViolation
-              `symCompare` AssertionViolation
-              @?= (mrgSingle GT :: Union Ordering)
+            AsKey (AssumptionViolation .<= AssertionViolation) @?= con False
+            AsKey (AssumptionViolation .< AssertionViolation) @?= con False
+            AsKey (AssumptionViolation .>= AssertionViolation) @?= con True
+            AsKey (AssumptionViolation .> AssertionViolation) @?= con True
+            AsKey1 (AssumptionViolation `symCompare` AssertionViolation)
+              @?= (mrgSingle GT :: AsKey1 Union Ordering)
 
-            AssumptionViolation .<= AssumptionViolation @?= con True
-            AssumptionViolation .< AssumptionViolation @?= con False
-            AssumptionViolation .>= AssumptionViolation @?= con True
-            AssumptionViolation .> AssumptionViolation @?= con False
-            AssumptionViolation
-              `symCompare` AssumptionViolation
-              @?= (mrgSingle EQ :: Union Ordering),
+            AsKey (AssumptionViolation .<= AssumptionViolation) @?= con True
+            AsKey (AssumptionViolation .< AssumptionViolation) @?= con False
+            AsKey (AssumptionViolation .>= AssumptionViolation) @?= con True
+            AsKey (AssumptionViolation .> AssumptionViolation) @?= con False
+            AsKey1 (AssumptionViolation `symCompare` AssumptionViolation)
+              @?= (mrgSingle EQ :: AsKey1 Union Ordering),
           testCase "GEvalSym" $ do
             evalSym False emptyModel AssertionViolation
               @?= AssertionViolation
@@ -135,7 +132,7 @@ exceptionTests =
                       (symNot "a")
                       (mrgSingle AssertionViolation)
                       (mrgSingle AssumptionViolation) ::
-                      Union VerificationConditions
+                      AsKey1 Union VerificationConditions
                   ),
           testCase
             "Transform VerificationConditions to VerificationConditions"
@@ -144,7 +141,7 @@ exceptionTests =
               transformError AssumptionViolation @?= AssumptionViolation
         ],
       testCase "symAssert" $ do
-        (symAssert "a" :: ExceptT VerificationConditions Union ())
+        (symAssert "a" :: ExceptT VerificationConditions (AsKey1 Union) ())
           @?= ExceptT
             ( mrgIf
                 (symNot "a")

--- a/test/Grisette/Core/Data/Class/BitCastTests.hs
+++ b/test/Grisette/Core/Data/Class/BitCastTests.hs
@@ -9,7 +9,8 @@ module Grisette.Core.Data.Class.BitCastTests (bitCastTests) where
 
 import Data.Typeable (Proxy (Proxy), Typeable, typeRep)
 import Grisette
-  ( BitCast (bitCast),
+  ( AsKey,
+    BitCast (bitCast),
     FP32,
     IntN,
     IntN32,
@@ -63,8 +64,8 @@ bitCastTests =
         concat
           [ bitCastBit1Tests @Bool @(IntN 1),
             bitCastBit1Tests @Bool @(WordN 1),
-            bitCastBit1Tests @SymBool @(SymIntN 1),
-            bitCastBit1Tests @SymBool @(SymWordN 1)
+            bitCastBit1Tests @(AsKey SymBool) @(AsKey (SymIntN 1)),
+            bitCastBit1Tests @(AsKey SymBool) @(AsKey (SymWordN 1))
           ],
       testGroup
         "FP"
@@ -77,17 +78,17 @@ bitCastTests =
             bitCast (0xc4002800 :: IntN32) @?= (-512.625 :: FP32),
           testCase "SymFP32" $ do
             bitCastOrCanonical (-512.625 :: SymFP32)
-              @?= (0xc4002800 :: SymWordN32)
-            bitCastOrCanonical (fpNaN :: SymFP32) @?= (0x7fc00000 :: SymWordN32)
-            bitCast (0xc4002800 :: SymWordN32) @?= (-512.625 :: SymFP32)
+              @?= (0xc4002800 :: AsKey SymWordN32)
+            bitCastOrCanonical (fpNaN :: SymFP32) @?= (0x7fc00000 :: AsKey SymWordN32)
+            bitCast (0xc4002800 :: SymWordN32) @?= (-512.625 :: AsKey SymFP32)
             bitCastOrCanonical (-512.625 :: SymFP32)
-              @?= (0xc4002800 :: SymIntN32)
-            bitCastOrCanonical (fpNaN :: SymFP32) @?= (0x7fc00000 :: SymIntN32)
-            bitCast (0xc4002800 :: SymIntN32) @?= (-512.625 :: SymFP32)
+              @?= (0xc4002800 :: AsKey SymIntN32)
+            bitCastOrCanonical (fpNaN :: SymFP32) @?= (0x7fc00000 :: AsKey SymIntN32)
+            bitCast (0xc4002800 :: SymIntN32) @?= (-512.625 :: AsKey SymFP32)
         ],
       testCase "Nested" $ do
-        let int32 = "x" :: SymIntN32
-        let word32 = bitCast int32 :: SymWordN32
-        let final = bitCast word32 :: SymIntN32
+        let int32 = "x" :: AsKey SymIntN32
+        let word32 = bitCast int32 :: AsKey SymWordN32
+        let final = bitCast word32 :: AsKey SymIntN32
         final @?= int32
     ]

--- a/test/Grisette/Core/Data/Class/ExtractSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ExtractSymTests.hs
@@ -28,6 +28,7 @@ import Grisette
   ( ExtractSym (extractSym),
     ITEOp (symIte),
     LogicalOp (symNot, (.&&), (.||)),
+    Solvable (ssym),
     SymBool,
     SymEq ((.==)),
     SymbolSetOps (emptySet),
@@ -88,7 +89,7 @@ extractSymTests =
                   @?= buildSymbolSet (ssymbolBool "a", isymbolBool "b" 1),
               testCase "ITE" $
                 extractSym
-                  (symIte (ssymBool "a") (isymBool "b" 1) (ssymBool "c"))
+                  (symIte (ssym "a") (isymBool "b" 1) (ssymBool "c"))
                   @?= buildSymbolSet
                     ( ssymbolBool "a",
                       isymbolBool "b" 1,
@@ -146,11 +147,11 @@ extractSymTests =
             "Either SymBool SymBool"
             [ testCase "Left v" $
                 extractSym
-                  (Left (ssymBool "a") :: Either SymBool SymBool)
+                  (Left (ssym "a") :: Either SymBool SymBool)
                   @?= buildSymbolSet (ssymbolBool "a"),
               testCase "Right v" $
                 extractSym
-                  (Right (ssymBool "a") :: Either SymBool SymBool)
+                  (Right (ssym "a") :: Either SymBool SymBool)
                   @?= buildSymbolSet (ssymbolBool "a")
             ],
           testGroup
@@ -173,13 +174,13 @@ extractSymTests =
                   @?= emptySet,
               testCase "ExceptT (Just (Left v))" $
                 extractSym
-                  ( ExceptT (Just (Left (ssymBool "a"))) ::
+                  ( ExceptT (Just (Left (ssym "a"))) ::
                       ExceptT SymBool Maybe SymBool
                   )
                   @?= buildSymbolSet (ssymbolBool "a"),
               testCase "ExceptT (Just (Right v))" $
                 extractSym
-                  ( ExceptT (Just (Right (ssymBool "a"))) ::
+                  ( ExceptT (Just (Right (ssym "a"))) ::
                       ExceptT SymBool Maybe SymBool
                   )
                   @?= buildSymbolSet (ssymbolBool "a")
@@ -197,7 +198,7 @@ extractSymTests =
                   testCase "WriterT (Just (v1, v2))" $
                     extractSym
                       ( WriterLazy.WriterT
-                          (Just (ssymBool "a", ssymBool "b")) ::
+                          (Just (ssym "a", ssym "b")) ::
                           WriterLazy.WriterT SymBool Maybe SymBool
                       )
                       @?= buildSymbolSet (ssymbolBool "a", ssymbolBool "b")
@@ -213,7 +214,7 @@ extractSymTests =
                   testCase "WriterT (Just (v1, v2))" $
                     extractSym
                       ( WriterStrict.WriterT
-                          (Just (ssymBool "a", ssymBool "b")) ::
+                          (Just (ssym "a", ssym "b")) ::
                           WriterStrict.WriterT SymBool Maybe SymBool
                       )
                       @?= buildSymbolSet (ssymbolBool "a", ssymbolBool "b")
@@ -241,13 +242,13 @@ extractSymTests =
             "IdentityT (Either SymBool) SymBool"
             [ testCase "Identity (Left v)" $
                 extractSym
-                  ( IdentityT $ Left (ssymBool "a") ::
+                  ( IdentityT $ Left (ssym "a") ::
                       IdentityT (Either SymBool) SymBool
                   )
                   @?= buildSymbolSet (ssymbolBool "a"),
               testCase "Identity (Right v)" $
                 extractSym
-                  ( IdentityT $ Right (ssymBool "a") ::
+                  ( IdentityT $ Right (ssym "a") ::
                       IdentityT (Either SymBool) SymBool
                   )
                   @?= buildSymbolSet (ssymbolBool "a")
@@ -260,10 +261,10 @@ extractSymTests =
             [ testCase "A1" $
                 extractSym A1 @?= emptySet,
               testCase "A2" $
-                extractSym (A2 (ssymBool "a"))
+                extractSym (A2 (ssym "a"))
                   @?= buildSymbolSet (ssymbolBool "a"),
               testCase "A3" $
-                extractSym (A3 (ssymBool "a") (ssymBool "b"))
+                extractSym (A3 (ssym "a") (ssym "b"))
                   @?= buildSymbolSet (ssymbolBool "a", ssymbolBool "b")
             ]
         ]

--- a/test/Grisette/Core/Data/Class/PlainUnionTests.hs
+++ b/test/Grisette/Core/Data/Class/PlainUnionTests.hs
@@ -19,6 +19,7 @@ import Grisette
     pattern If,
     pattern Single,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey (AsKey), AsKey1)
 import Grisette.Internal.Core.Data.Class.PlainUnion
   ( PlainUnion (overestimateUnionValues),
   )
@@ -33,7 +34,7 @@ plainUnionTests =
     [ testCase "simpleMerge" $ do
         simpleMerge
           ( mrgIfPropagatedStrategy "a" (return "b") (return "c") ::
-              Union SymBool
+              AsKey1 Union (AsKey SymBool)
           )
           @?= symIte "a" "b" "c",
       testCase "(.#)" $ do
@@ -43,7 +44,7 @@ plainUnionTests =
                  "cond"
                  (return ["a"])
                  (return ["b", "c"]) ::
-                 Union [SymBool]
+                 AsKey1 Union [AsKey SymBool]
              )
           @?= symIte "cond" "a" ("b" .&& "c"),
       testCase "onUnion" $ do
@@ -51,35 +52,35 @@ plainUnionTests =
         let symAllU = onUnion symAll
         symAllU
           ( mrgIfPropagatedStrategy "cond" (return ["a"]) (return ["b", "c"]) ::
-              Union [SymBool]
+              AsKey1 Union [AsKey SymBool]
           )
           @?= symIte "cond" "a" ("b" .&& "c"),
       testGroup
         "Single and If pattern"
         [ testCase "Unmerged" $
             case mrgIfPropagatedStrategy "a" (return "b") (return "c") ::
-                   Union SymBool of
+                   AsKey1 Union (AsKey SymBool) of
               Single _ -> fail "Expected If"
               If c l r -> do
-                c @?= "a"
+                AsKey c @?= "a"
                 l @?= return "b"
                 r @?= return "c",
           testCase "Merged" $
-            case mrgIf "a" (return "b") (return "c") :: Union SymBool of
+            case mrgIf "a" (return "b") (return "c") :: AsKey1 Union (AsKey SymBool) of
               If {} -> fail "Expected Single"
               Single v -> v @?= symIte "a" "b" "c",
           testCase "Construct single" $
-            (Single "a" :: Union SymBool) @?= mrgSingle "a",
+            (Single "a" :: AsKey1 Union (AsKey SymBool)) @?= mrgSingle "a",
           testCase "Construct If" $ do
-            let actual = If "a" (return "b") (return "c") :: Union SymBool
+            let actual = If "a" (return "b") (return "c") :: AsKey1 Union (AsKey SymBool)
             let expected = mrgIf "a" (return "b") (return "c")
             actual @?= expected
         ],
       testCase "overestimateUnionValues" $ do
-        overestimateUnionValues (return 1 :: Union Int) @?= [1]
-        overestimateUnionValues (mrgIf "a" (return 1) (return 2) :: Union Int)
+        overestimateUnionValues (return 1 :: AsKey1 Union Int) @?= [1]
+        overestimateUnionValues (mrgIf "a" (return 1) (return 2) :: AsKey1 Union Int)
           @?= [1, 2 :: Int]
         overestimateUnionValues
-          (mrgIf "a" (return 1) (mrgIf "x" (return 3) (return 2)) :: Union Int)
+          (mrgIf "a" (return 1) (mrgIf "x" (return 3) (return 2)) :: AsKey1 Union Int)
           @?= [1, 2, 3 :: Int]
     ]

--- a/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
+++ b/test/Grisette/Core/Data/Class/SimpleMergeableTests.hs
@@ -31,18 +31,20 @@ import Grisette
     LogicalOp (symNot, (.&&), (.||)),
     Mergeable,
     SimpleMergeable (mrgIte),
+    Solvable (con, ssym),
     SymBool,
     Union,
     mrgIf,
     mrgIte1,
     mrgSingle,
   )
-import Grisette.Core.Data.Class.TestValues (conBool, ssymBool)
+import Grisette.Core.Data.Class.TestValues (ssymBool)
+import Grisette.Internal.Core.Data.Class.AsKey (AsKey, AsKey1)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@?=))
 
-newtype AndMonoidSymBool = AndMonoidSymBool SymBool
+newtype AndMonoidSymBool = AndMonoidSymBool (AsKey SymBool)
   deriving (Show, Generic, Eq)
   deriving (Mergeable) via (Default AndMonoidSymBool)
 
@@ -50,7 +52,7 @@ instance Semigroup AndMonoidSymBool where
   (AndMonoidSymBool a) <> (AndMonoidSymBool b) = AndMonoidSymBool (a .&& b)
 
 instance Monoid AndMonoidSymBool where
-  mempty = AndMonoidSymBool $ conBool True
+  mempty = AndMonoidSymBool $ con True
 
 simpleMergeableTests :: Test
 simpleMergeableTests =
@@ -59,313 +61,320 @@ simpleMergeableTests =
     [ testGroup
         "SimpleMergeable for common types"
         [ testCase "SymBool" $ do
-            mrgIte (ssymBool "a") (ssymBool "b") (ssymBool "c")
-              @?= symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
+            mrgIte (ssym "a") (ssym "b" :: AsKey SymBool) (ssym "c")
+              @?= symIte (ssym "a") (ssym "b") (ssym "c"),
           testCase "()" $ do
-            mrgIte (ssymBool "a") () () @?= (),
+            mrgIte (ssym "a") () () @?= (),
           testCase "(SymBool, SymBool)" $ do
             mrgIte
-              (ssymBool "a")
-              (ssymBool "b", ssymBool "d")
-              (ssymBool "c", ssymBool "e")
-              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e")
+              (ssym "a")
+              (ssym "b" :: AsKey SymBool, ssym "d" :: AsKey SymBool)
+              (ssym "c", ssym "e")
+              @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                    symIte (ssym "a") (ssym "d") (ssym "e")
                   ),
           testCase "(SymBool, SymBool, SymBool)" $ do
             mrgIte
-              (ssymBool "a")
-              (ssymBool "b", ssymBool "d", ssymBool "f")
-              (ssymBool "c", ssymBool "e", ssymBool "g")
-              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g")
+              (ssym "a")
+              ( ssym "b" :: AsKey SymBool,
+                ssym "d" :: AsKey SymBool,
+                ssym "f" :: AsKey SymBool
+              )
+              (ssym "c", ssym "e", ssym "g")
+              @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                    symIte (ssym "a") (ssym "d") (ssym "e"),
+                    symIte (ssym "a") (ssym "f") (ssym "g")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
-              (ssymBool "a")
-              (ssymBool "b", ssymBool "d", ssymBool "f", ssymBool "h")
-              (ssymBool "c", ssymBool "e", ssymBool "g", ssymBool "i")
-              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i")
+              (ssym "a")
+              ( ssym "b" :: AsKey SymBool,
+                ssym "d" :: AsKey SymBool,
+                ssym "f" :: AsKey SymBool,
+                ssym "h" :: AsKey SymBool
+              )
+              (ssym "c", ssym "e", ssym "g", ssym "i")
+              @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                    symIte (ssym "a") (ssym "d") (ssym "e"),
+                    symIte (ssym "a") (ssym "f") (ssym "g"),
+                    symIte (ssym "a") (ssym "h") (ssym "i")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
-              (ssymBool "a")
-              ( ssymBool "b",
-                ssymBool "d",
-                ssymBool "f",
-                ssymBool "h",
-                ssymBool "j"
+              (ssym "a")
+              ( ssym "b" :: AsKey SymBool,
+                ssym "d" :: AsKey SymBool,
+                ssym "f" :: AsKey SymBool,
+                ssym "h" :: AsKey SymBool,
+                ssym "j" :: AsKey SymBool
               )
-              ( ssymBool "c",
-                ssymBool "e",
-                ssymBool "g",
-                ssymBool "i",
-                ssymBool "k"
+              ( ssym "c",
+                ssym "e",
+                ssym "g",
+                ssym "i",
+                ssym "k"
               )
-              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                    symIte (ssymBool "a") (ssymBool "j") (ssymBool "k")
+              @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                    symIte (ssym "a") (ssym "d") (ssym "e"),
+                    symIte (ssym "a") (ssym "f") (ssym "g"),
+                    symIte (ssym "a") (ssym "h") (ssym "i"),
+                    symIte (ssym "a") (ssym "j") (ssym "k")
                   ),
           testCase "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)" $ do
             mrgIte
-              (ssymBool "a")
-              ( ssymBool "b",
-                ssymBool "d",
-                ssymBool "f",
-                ssymBool "h",
-                ssymBool "j",
-                ssymBool "l"
+              (ssym "a")
+              ( ssym "b" :: AsKey SymBool,
+                ssym "d" :: AsKey SymBool,
+                ssym "f" :: AsKey SymBool,
+                ssym "h" :: AsKey SymBool,
+                ssym "j" :: AsKey SymBool,
+                ssym "l" :: AsKey SymBool
               )
-              ( ssymBool "c",
-                ssymBool "e",
-                ssymBool "g",
-                ssymBool "i",
-                ssymBool "k",
-                ssymBool "m"
+              ( ssym "c",
+                ssym "e",
+                ssym "g",
+                ssym "i",
+                ssym "k",
+                ssym "m"
               )
-              @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                    symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                    symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                    symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                    symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                    symIte (ssymBool "a") (ssymBool "l") (ssymBool "m")
+              @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                    symIte (ssym "a") (ssym "d") (ssym "e"),
+                    symIte (ssym "a") (ssym "f") (ssym "g"),
+                    symIte (ssym "a") (ssym "h") (ssym "i"),
+                    symIte (ssym "a") (ssym "j") (ssym "k"),
+                    symIte (ssym "a") (ssym "l") (ssym "m")
                   ),
           testCase
             "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
             $ do
               mrgIte
-                (ssymBool "a")
-                ( ssymBool "b",
-                  ssymBool "d",
-                  ssymBool "f",
-                  ssymBool "h",
-                  ssymBool "j",
-                  ssymBool "l",
-                  ssymBool "n"
+                (ssym "a")
+                ( ssym "b" :: AsKey SymBool,
+                  ssym "d" :: AsKey SymBool,
+                  ssym "f" :: AsKey SymBool,
+                  ssym "h" :: AsKey SymBool,
+                  ssym "j" :: AsKey SymBool,
+                  ssym "l" :: AsKey SymBool,
+                  ssym "n" :: AsKey SymBool
                 )
-                ( ssymBool "c",
-                  ssymBool "e",
-                  ssymBool "g",
-                  ssymBool "i",
-                  ssymBool "k",
-                  ssymBool "m",
-                  ssymBool "o"
+                ( ssym "c",
+                  ssym "e",
+                  ssym "g",
+                  ssym "i",
+                  ssym "k",
+                  ssym "m",
+                  ssym "o"
                 )
-                @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                      symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                      symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                      symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                      symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                      symIte (ssymBool "a") (ssymBool "l") (ssymBool "m"),
-                      symIte (ssymBool "a") (ssymBool "n") (ssymBool "o")
+                @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                      symIte (ssym "a") (ssym "d") (ssym "e"),
+                      symIte (ssym "a") (ssym "f") (ssym "g"),
+                      symIte (ssym "a") (ssym "h") (ssym "i"),
+                      symIte (ssym "a") (ssym "j") (ssym "k"),
+                      symIte (ssym "a") (ssym "l") (ssym "m"),
+                      symIte (ssym "a") (ssym "n") (ssym "o")
                     ),
           testCase
             "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
             $ do
               mrgIte
                 (ssymBool "a")
-                ( ssymBool "b",
-                  ssymBool "d",
-                  ssymBool "f",
-                  ssymBool "h",
-                  ssymBool "j",
-                  ssymBool "l",
-                  ssymBool "n",
-                  ssymBool "p"
+                ( ssym "b" :: AsKey SymBool,
+                  ssym "d" :: AsKey SymBool,
+                  ssym "f" :: AsKey SymBool,
+                  ssym "h" :: AsKey SymBool,
+                  ssym "j" :: AsKey SymBool,
+                  ssym "l" :: AsKey SymBool,
+                  ssym "n" :: AsKey SymBool,
+                  ssym "p" :: AsKey SymBool
                 )
-                ( ssymBool "c",
-                  ssymBool "e",
-                  ssymBool "g",
-                  ssymBool "i",
-                  ssymBool "k",
-                  ssymBool "m",
-                  ssymBool "o",
-                  ssymBool "q"
+                ( ssym "c" :: AsKey SymBool,
+                  ssym "e" :: AsKey SymBool,
+                  ssym "g" :: AsKey SymBool,
+                  ssym "i" :: AsKey SymBool,
+                  ssym "k" :: AsKey SymBool,
+                  ssym "m" :: AsKey SymBool,
+                  ssym "o" :: AsKey SymBool,
+                  ssym "q" :: AsKey SymBool
                 )
-                @?= ( symIte (ssymBool "a") (ssymBool "b") (ssymBool "c"),
-                      symIte (ssymBool "a") (ssymBool "d") (ssymBool "e"),
-                      symIte (ssymBool "a") (ssymBool "f") (ssymBool "g"),
-                      symIte (ssymBool "a") (ssymBool "h") (ssymBool "i"),
-                      symIte (ssymBool "a") (ssymBool "j") (ssymBool "k"),
-                      symIte (ssymBool "a") (ssymBool "l") (ssymBool "m"),
-                      symIte (ssymBool "a") (ssymBool "n") (ssymBool "o"),
-                      symIte (ssymBool "a") (ssymBool "p") (ssymBool "q")
+                @?= ( symIte (ssym "a") (ssym "b") (ssym "c"),
+                      symIte (ssym "a") (ssym "d") (ssym "e"),
+                      symIte (ssym "a") (ssym "f") (ssym "g"),
+                      symIte (ssym "a") (ssym "h") (ssym "i"),
+                      symIte (ssym "a") (ssym "j") (ssym "k"),
+                      symIte (ssym "a") (ssym "l") (ssym "m"),
+                      symIte (ssym "a") (ssym "n") (ssym "o"),
+                      symIte (ssym "a") (ssym "p") (ssym "q")
                     ),
           testCase "SymBool -> SymBool" $ do
-            let f = mrgIte (ssymBool "a") symNot ((ssymBool "b") .&&)
-            f (ssymBool "c")
+            let f = mrgIte (ssym "a") symNot ((ssym "b" :: AsKey SymBool) .&&)
+            f (ssym "c")
               @?= symIte
-                (ssymBool "a")
-                (symNot $ ssymBool "c")
-                ((ssymBool "b") .&& (ssymBool "c")),
+                (ssym "a")
+                (symNot $ ssym "c")
+                ((ssym "b") .&& (ssym "c")),
           testCase "MaybeT (Union) SymBool" $ do
-            let l :: MaybeT (Union) SymBool =
+            let l :: MaybeT (AsKey1 Union) (AsKey SymBool) =
                   MaybeT
                     ( mrgIf
-                        (ssymBool "b")
+                        (ssym "b")
                         (mrgSingle Nothing)
-                        (mrgSingle $ Just $ ssymBool "c")
+                        (mrgSingle $ Just $ ssym "c")
                     )
-            let r :: MaybeT (Union) SymBool =
+            let r :: MaybeT (AsKey1 Union) (AsKey SymBool) =
                   MaybeT
                     ( mrgIf
-                        (ssymBool "d")
+                        (ssym "d")
                         (mrgSingle Nothing)
-                        (mrgSingle $ Just $ ssymBool "e")
+                        (mrgSingle $ Just $ ssym "e")
                     )
-            let res :: MaybeT (Union) SymBool =
+            let res :: MaybeT (AsKey1 Union) (AsKey SymBool) =
                   MaybeT
                     ( mrgIf
-                        (ssymBool "a")
+                        (ssym "a")
                         ( mrgIf
-                            (ssymBool "b")
+                            (ssym "b")
                             (mrgSingle Nothing)
-                            (mrgSingle $ Just $ ssymBool "c")
+                            (mrgSingle $ Just $ ssym "c")
                         )
                         ( mrgIf
-                            (ssymBool "d")
+                            (ssym "d")
                             (mrgSingle Nothing)
-                            (mrgSingle $ Just $ ssymBool "e")
+                            (mrgSingle $ Just $ ssym "e")
                         )
                     )
-            mrgIte (ssymBool "a") l r @?= res
-            mrgIte1 (ssymBool "a") l r @?= res
-            mrgIf (ssymBool "a") l r @?= res,
+            mrgIte (ssym "a") l r @?= res
+            mrgIte1 (ssym "a") l r @?= res
+            mrgIf (ssym "a") l r @?= res,
           testCase "ExceptT SymBool (Union) SymBool" $ do
-            let l :: ExceptT SymBool (Union) SymBool =
+            let l :: ExceptT (AsKey SymBool) (AsKey1 Union) (AsKey SymBool) =
                   ExceptT
                     ( mrgIf
-                        (ssymBool "b")
-                        (mrgSingle $ Left $ ssymBool "c")
-                        (mrgSingle $ Right $ ssymBool "d")
+                        (ssym "b")
+                        (mrgSingle $ Left $ ssym "c")
+                        (mrgSingle $ Right $ ssym "d")
                     )
             let r =
                   ExceptT
                     ( mrgIf
-                        (ssymBool "e")
-                        (mrgSingle $ Left $ ssymBool "f")
-                        (mrgSingle $ Right $ ssymBool "g")
+                        (ssym "e")
+                        (mrgSingle $ Left $ ssym "f")
+                        (mrgSingle $ Right $ ssym "g")
                     )
             let res =
                   ExceptT
                     ( mrgIf
-                        (ssymBool "a")
+                        (ssym "a")
                         ( mrgIf
-                            (ssymBool "b")
-                            (mrgSingle $ Left $ ssymBool "c")
-                            (mrgSingle $ Right $ ssymBool "d")
+                            (ssym "b")
+                            (mrgSingle $ Left $ ssym "c")
+                            (mrgSingle $ Right $ ssym "d")
                         )
                         ( mrgIf
-                            (ssymBool "e")
-                            (mrgSingle $ Left $ ssymBool "f")
-                            (mrgSingle $ Right $ ssymBool "g")
+                            (ssym "e")
+                            (mrgSingle $ Left $ ssym "f")
+                            (mrgSingle $ Right $ ssym "g")
                         )
                     )
-            mrgIte (ssymBool "a") l r @?= res
-            mrgIte1 (ssymBool "a") l r @?= res
-            mrgIf (ssymBool "a") l r @?= res,
+            mrgIte (ssym "a") l r @?= res
+            mrgIte1 (ssym "a") l r @?= res
+            mrgIf (ssym "a") l r @?= res,
           testGroup
             "StateT Integer (Union) SymBool"
             [ testCase "Lazy" $ do
-                let st1 :: StateLazy.StateT Integer (Union) SymBool =
+                let st1 :: StateLazy.StateT Integer (AsKey1 Union) (AsKey SymBool) =
                       StateLazy.StateT $ \(x :: Integer) ->
-                        mrgSingle (ssymBool "a", x + 2)
-                let st2 :: StateLazy.StateT Integer (Union) SymBool =
+                        mrgSingle (ssym "a", x + 2)
+                let st2 :: StateLazy.StateT Integer (AsKey1 Union) (AsKey SymBool) =
                       StateLazy.StateT $ \(x :: Integer) ->
-                        mrgSingle (ssymBool "b", x * 2)
-                let st3 = mrgIte (ssymBool "c") st1 st2
-                let st31 = mrgIte1 (ssymBool "c") st1 st2
-                let st3u1 = mrgIf (ssymBool "c") st1 st2
+                        mrgSingle (ssym "b", x * 2)
+                let st3 = mrgIte (ssym "c") st1 st2
+                let st31 = mrgIte1 (ssym "c") st1 st2
+                let st3u1 = mrgIf (ssym "c") st1 st2
                 StateLazy.runStateT st3 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateLazy.runStateT st3 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6))
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6))
                 StateLazy.runStateT st31 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateLazy.runStateT st31 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6))
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6))
                 StateLazy.runStateT st3u1 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateLazy.runStateT st3u1 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6)),
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6)),
               testCase "Strict" $ do
-                let st1 :: StateStrict.StateT Integer (Union) SymBool =
+                let st1 :: StateStrict.StateT Integer (AsKey1 Union) (AsKey SymBool) =
                       StateStrict.StateT $ \(x :: Integer) ->
-                        mrgSingle (ssymBool "a", x + 2)
-                let st2 :: StateStrict.StateT Integer (Union) SymBool =
+                        mrgSingle (ssym "a", x + 2)
+                let st2 :: StateStrict.StateT Integer (AsKey1 Union) (AsKey SymBool) =
                       StateStrict.StateT $ \(x :: Integer) ->
-                        mrgSingle (ssymBool "b", x * 2)
-                let st3 = mrgIte (ssymBool "c") st1 st2
-                let st31 = mrgIte1 (ssymBool "c") st1 st2
-                let st3u1 = mrgIf (ssymBool "c") st1 st2
+                        mrgSingle (ssym "b", x * 2)
+                let st3 = mrgIte (ssym "c") st1 st2
+                let st31 = mrgIte1 (ssym "c") st1 st2
+                let st3u1 = mrgIf (ssym "c") st1 st2
                 StateStrict.runStateT st3 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateStrict.runStateT st3 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6))
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6))
                 StateStrict.runStateT st31 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateStrict.runStateT st31 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6))
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6))
                 StateStrict.runStateT st3u1 2
                   @?= mrgSingle
-                    (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"), 4)
+                    (symIte (ssym "c") (ssym "a") (ssym "b"), 4)
                 StateStrict.runStateT st3u1 3
                   @?= mrgIf
-                    (ssymBool "c")
-                    (mrgSingle (ssymBool "a", 5))
-                    (mrgSingle (ssymBool "b", 6))
+                    (ssym "c")
+                    (mrgSingle (ssym "a", 5))
+                    (mrgSingle (ssym "b", 6))
             ],
           testCase "ContT (SymBool, Integer) (Union) (SymBool, Integer)" $ do
-            let c1 :: ContT (SymBool, Integer) (Union) (SymBool, Integer) =
-                  ContT $ \f -> f (ssymBool "a", 2)
-            let c2 :: ContT (SymBool, Integer) (Union) (SymBool, Integer) =
-                  ContT $ \f -> f (ssymBool "b", 3)
-            let c3 = mrgIte (ssymBool "c") c1 c2
-            let c3u1 = mrgIf (ssymBool "c") c1 c2
+            let c1 :: ContT (AsKey SymBool, Integer) (AsKey1 Union) (AsKey SymBool, Integer) =
+                  ContT $ \f -> f (ssym "a", 2)
+            let c2 :: ContT (AsKey SymBool, Integer) (AsKey1 Union) (AsKey SymBool, Integer) =
+                  ContT $ \f -> f (ssym "b", 3)
+            let c3 = mrgIte (ssym "c") c1 c2
+            let c3u1 = mrgIf (ssym "c") c1 c2
             let r =
                   mrgIf
-                    (ssymBool "c")
+                    (ssym "c")
                     ( mrgIf
-                        (ssymBool "p")
-                        (mrgSingle (ssymBool "a", 2))
-                        (mrgSingle (symNot $ ssymBool "a", 3))
+                        (ssym "p")
+                        (mrgSingle (ssym "a", 2))
+                        (mrgSingle (symNot $ ssym "a", 3))
                     )
                     ( mrgIf
-                        (ssymBool "p")
-                        (mrgSingle (ssymBool "b", 3))
-                        (mrgSingle (symNot $ ssymBool "b", 4))
+                        (ssym "p")
+                        (mrgSingle (ssym "b", 3))
+                        (mrgSingle (symNot $ ssym "b", 4))
                     )
             let f (a, x) =
                   mrgIf
-                    (ssymBool "p")
+                    (ssym "p")
                     (mrgSingle (a, x))
                     (mrgSingle (symNot a, x + 1)) ::
-                    Union (SymBool, Integer)
+                    AsKey1 Union (AsKey SymBool, Integer)
             runContT c3 f @?= r
             runContT c3u1 f @?= r,
           testGroup
@@ -373,11 +382,11 @@ simpleMergeableTests =
             [ testCase "Lazy" $ do
                 let rws1 ::
                       RWSTLazy.RWST
-                        (Integer, SymBool)
+                        (Integer, AsKey SymBool)
                         (Monoid.Sum Integer, AndMonoidSymBool)
-                        (Integer, SymBool)
-                        (Union)
-                        (Integer, SymBool) =
+                        (Integer, AsKey SymBool)
+                        (AsKey1 Union)
+                        (Integer, AsKey SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
                             ( (ir + is, br .&& bs),
@@ -388,11 +397,11 @@ simpleMergeableTests =
                             )
                 let rws2 ::
                       RWSTLazy.RWST
-                        (Integer, SymBool)
+                        (Integer, AsKey SymBool)
                         (Monoid.Sum Integer, AndMonoidSymBool)
-                        (Integer, SymBool)
-                        (Union)
-                        (Integer, SymBool) =
+                        (Integer, AsKey SymBool)
+                        (AsKey1 Union)
+                        (Integer, AsKey SymBool) =
                         RWSTLazy.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
                             ( (ir + is, br .|| bs),
@@ -405,43 +414,44 @@ simpleMergeableTests =
                 let rws3u1 = mrgIf (ssymBool "c") rws1 rws2
 
                 let res1 ::
-                      Union
-                        ( (Integer, SymBool),
-                          (Integer, SymBool),
+                      AsKey1
+                        Union
+                        ( (Integer, AsKey SymBool),
+                          (Integer, AsKey SymBool),
                           (Monoid.Sum Integer, AndMonoidSymBool)
                         ) =
                         mrgIf
-                          (ssymBool "c")
+                          (ssym "c")
                           ( mrgSingle
-                              ( (1, ssymBool "a" .&& ssymBool "b"),
-                                (-1, ssymBool "a" .|| ssymBool "b"),
+                              ( (1, ssym "a" .&& ssym "b"),
+                                (-1, ssym "a" .|| ssym "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" .&& ssymBool "a"
+                                    ssym "b" .&& ssym "a"
                                 )
                               )
                           )
                           ( mrgSingle
-                              ( (1, ssymBool "a" .|| ssymBool "b"),
-                                (-1, ssymBool "a" .&& ssymBool "b"),
+                              ( (1, ssym "a" .|| ssym "b"),
+                                (-1, ssym "a" .&& ssym "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" .|| ssymBool "a"
+                                    ssym "b" .|| ssym "a"
                                 )
                               )
                           )
-                RWSTLazy.runRWST rws3 (0, ssymBool "a") (1, ssymBool "b")
+                RWSTLazy.runRWST rws3 (0, ssym "a") (1, ssym "b")
                   @?= res1
-                RWSTLazy.runRWST rws3u1 (0, ssymBool "a") (1, ssymBool "b")
+                RWSTLazy.runRWST rws3u1 (0, ssym "a") (1, ssym "b")
                   @?= res1,
               testCase "Strict" $ do
                 let rws1 ::
                       RWSTStrict.RWST
-                        (Integer, SymBool)
+                        (Integer, AsKey SymBool)
                         (Monoid.Sum Integer, AndMonoidSymBool)
-                        (Integer, SymBool)
-                        (Union)
-                        (Integer, SymBool) =
+                        (Integer, AsKey SymBool)
+                        (AsKey1 Union)
+                        (Integer, AsKey SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
                             ( (ir + is, br .&& bs),
@@ -452,11 +462,11 @@ simpleMergeableTests =
                             )
                 let rws2 ::
                       RWSTStrict.RWST
-                        (Integer, SymBool)
+                        (Integer, AsKey SymBool)
                         (Monoid.Sum Integer, AndMonoidSymBool)
-                        (Integer, SymBool)
-                        (Union)
-                        (Integer, SymBool) =
+                        (Integer, AsKey SymBool)
+                        (AsKey1 Union)
+                        (Integer, AsKey SymBool) =
                         RWSTStrict.RWST $ \(ir, br) (is, bs) ->
                           mrgSingle
                             ( (ir + is, br .|| bs),
@@ -469,34 +479,35 @@ simpleMergeableTests =
                 let rws3u1 = mrgIf (ssymBool "c") rws1 rws2
 
                 let res1 ::
-                      Union
-                        ( (Integer, SymBool),
-                          (Integer, SymBool),
+                      AsKey1
+                        Union
+                        ( (Integer, AsKey SymBool),
+                          (Integer, AsKey SymBool),
                           (Monoid.Sum Integer, AndMonoidSymBool)
                         ) =
                         mrgIf
                           (ssymBool "c")
                           ( mrgSingle
-                              ( (1, ssymBool "a" .&& ssymBool "b"),
-                                (-1, ssymBool "a" .|| ssymBool "b"),
+                              ( (1, ssym "a" .&& ssym "b"),
+                                (-1, ssym "a" .|| ssym "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" .&& ssymBool "a"
+                                    ssym "b" .&& ssym "a"
                                 )
                               )
                           )
                           ( mrgSingle
-                              ( (1, ssymBool "a" .|| ssymBool "b"),
-                                (-1, ssymBool "a" .&& ssymBool "b"),
+                              ( (1, ssym "a" .|| ssym "b"),
+                                (-1, ssym "a" .&& ssym "b"),
                                 ( 0,
                                   AndMonoidSymBool $
-                                    ssymBool "b" .|| ssymBool "a"
+                                    ssym "b" .|| ssym "a"
                                 )
                               )
                           )
-                RWSTStrict.runRWST rws3 (0, ssymBool "a") (1, ssymBool "b")
+                RWSTStrict.runRWST rws3 (0, ssym "a") (1, ssym "b")
                   @?= res1
-                RWSTStrict.runRWST rws3u1 (0, ssymBool "a") (1, ssymBool "b")
+                RWSTStrict.runRWST rws3u1 (0, ssym "a") (1, ssym "b")
                   @?= res1
             ],
           testGroup
@@ -505,150 +516,150 @@ simpleMergeableTests =
                 let st1 ::
                       WriterLazy.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterLazy.WriterT $ mrgSingle (ssymBool "a", 1)
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterLazy.WriterT $ mrgSingle (ssym "a", 1)
                 let st2 ::
                       WriterLazy.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterLazy.WriterT $ mrgSingle (ssymBool "b", 2)
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterLazy.WriterT $ mrgSingle (ssym "b", 2)
                 let st3 ::
                       WriterLazy.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterLazy.WriterT $ mrgSingle (ssymBool "c", 1)
-                let st4 = mrgIte (ssymBool "d") st1 st2
-                let st41 = mrgIte1 (ssymBool "d") st1 st2
-                let st4u1 = mrgIf (ssymBool "d") st1 st2
-                let st5 = mrgIte (ssymBool "d") st1 st3
-                let st51 = mrgIte1 (ssymBool "d") st1 st3
-                let st5u1 = mrgIf (ssymBool "d") st1 st3
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterLazy.WriterT $ mrgSingle (ssym "c", 1)
+                let st4 = mrgIte (ssym "d") st1 st2
+                let st41 = mrgIte1 (ssym "d") st1 st2
+                let st4u1 = mrgIf (ssym "d") st1 st2
+                let st5 = mrgIte (ssym "d") st1 st3
+                let st51 = mrgIte1 (ssym "d") st1 st3
+                let st5u1 = mrgIf (ssym "d") st1 st3
                 WriterLazy.runWriterT st4
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterLazy.runWriterT st41
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterLazy.runWriterT st4u1
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterLazy.runWriterT st5
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
                 WriterLazy.runWriterT st51
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
                 WriterLazy.runWriterT st5u1
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1),
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1),
               testCase "Strict" $ do
                 let st1 ::
                       WriterStrict.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterStrict.WriterT $ mrgSingle (ssymBool "a", 1)
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterStrict.WriterT $ mrgSingle (ssym "a", 1)
                 let st2 ::
                       WriterStrict.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterStrict.WriterT $ mrgSingle (ssymBool "b", 2)
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterStrict.WriterT $ mrgSingle (ssym "b", 2)
                 let st3 ::
                       WriterStrict.WriterT
                         (Monoid.Sum Integer)
-                        (Union)
-                        SymBool =
-                        WriterStrict.WriterT $ mrgSingle (ssymBool "c", 1)
-                let st4 = mrgIte (ssymBool "d") st1 st2
-                let st41 = mrgIte1 (ssymBool "d") st1 st2
-                let st4u1 = mrgIf (ssymBool "d") st1 st2
-                let st5 = mrgIte (ssymBool "d") st1 st3
-                let st51 = mrgIte1 (ssymBool "d") st1 st3
-                let st5u1 = mrgIf (ssymBool "d") st1 st3
+                        (AsKey1 Union)
+                        (AsKey SymBool) =
+                        WriterStrict.WriterT $ mrgSingle (ssym "c", 1)
+                let st4 = mrgIte (ssym "d") st1 st2
+                let st41 = mrgIte1 (ssym "d") st1 st2
+                let st4u1 = mrgIf (ssym "d") st1 st2
+                let st5 = mrgIte (ssym "d") st1 st3
+                let st51 = mrgIte1 (ssym "d") st1 st3
+                let st5u1 = mrgIf (ssym "d") st1 st3
                 WriterStrict.runWriterT st4
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterStrict.runWriterT st41
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterStrict.runWriterT st4u1
                   @?= mrgIf
-                    (ssymBool "d")
-                    (mrgSingle (ssymBool "a", 1))
-                    (mrgSingle (ssymBool "b", 2))
+                    (ssym "d")
+                    (mrgSingle (ssym "a", 1))
+                    (mrgSingle (ssym "b", 2))
                 WriterStrict.runWriterT st5
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
                 WriterStrict.runWriterT st51
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
                 WriterStrict.runWriterT st5u1
                   @?= mrgSingle
-                    (symIte (ssymBool "d") (ssymBool "a") (ssymBool "c"), 1)
+                    (symIte (ssym "d") (ssym "a") (ssym "c"), 1)
             ],
           testCase "ReaderT Integer (Union) Integer" $ do
-            let r1 :: ReaderT Integer (Union) Integer =
+            let r1 :: ReaderT Integer (AsKey1 Union) Integer =
                   ReaderT $ \(x :: Integer) -> mrgSingle $ x + 2
-            let r2 :: ReaderT Integer (Union) Integer =
+            let r2 :: ReaderT Integer (AsKey1 Union) Integer =
                   ReaderT $ \(x :: Integer) -> mrgSingle $ x * 2
-            let r3 = mrgIte (ssymBool "c") r1 r2
-            let r3u1 = mrgIf (ssymBool "c") r1 r2
+            let r3 = mrgIte (ssym "c") r1 r2
+            let r3u1 = mrgIf (ssym "c") r1 r2
             runReaderT r3 2 @?= mrgSingle 4
-            runReaderT r3 3 @?= mrgIf (ssymBool "c") (mrgSingle 5) (mrgSingle 6)
+            runReaderT r3 3 @?= mrgIf (ssym "c") (mrgSingle 5) (mrgSingle 6)
             runReaderT r3u1 2 @?= mrgSingle 4
             runReaderT r3u1 3
               @?= mrgIf
-                (ssymBool "c")
+                (ssym "c")
                 (mrgSingle 5)
                 (mrgSingle 6)
 
-            let r4 :: ReaderT SymBool (Union) SymBool =
-                  ReaderT $ \x -> mrgSingle $ x .&& ssymBool "x"
-            let r5 :: ReaderT SymBool (Union) SymBool =
-                  ReaderT $ \x -> mrgSingle $ x .|| ssymBool "y"
-            let r61 = mrgIte1 (ssymBool "c") r4 r5
-            runReaderT r61 (ssymBool "a")
+            let r4 :: ReaderT (AsKey SymBool) (AsKey1 Union) (AsKey SymBool) =
+                  ReaderT $ \x -> mrgSingle $ x .&& ssym "x"
+            let r5 :: ReaderT (AsKey SymBool) (AsKey1 Union) (AsKey SymBool) =
+                  ReaderT $ \x -> mrgSingle $ x .|| ssym "y"
+            let r61 = mrgIte1 (ssym "c") r4 r5
+            runReaderT r61 (ssym "a")
               @?= mrgSingle
                 ( symIte
-                    (ssymBool "c")
-                    (ssymBool "a" .&& ssymBool "x")
-                    (ssymBool "a" .|| ssymBool "y")
+                    (ssym "c")
+                    (ssym "a" .&& ssym "x")
+                    (ssym "a" .|| ssym "y")
                 ),
           testCase "Identity SymBool" $ do
-            let i1 :: Identity SymBool = Identity $ ssymBool "a"
-            let i2 :: Identity SymBool = Identity $ ssymBool "b"
-            let i3 = mrgIte (ssymBool "c") i1 i2
-            let i31 = mrgIte1 (ssymBool "c") i1 i2
-            runIdentity i3 @?= symIte (ssymBool "c") (ssymBool "a") (ssymBool "b")
+            let i1 :: Identity (AsKey SymBool) = Identity $ ssym "a"
+            let i2 :: Identity (AsKey SymBool) = Identity $ ssym "b"
+            let i3 = mrgIte (ssym "c") i1 i2
+            let i31 = mrgIte1 (ssym "c") i1 i2
+            runIdentity i3 @?= symIte (ssym "c") (ssym "a") (ssym "b")
             runIdentity i31
-              @?= symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"),
+              @?= symIte (ssym "c") (ssym "a") (ssym "b"),
           testCase "IdentityT (Union) SymBool" $ do
-            let i1 :: IdentityT (Union) SymBool =
-                  IdentityT $ mrgSingle $ ssymBool "a"
-            let i2 :: IdentityT (Union) SymBool =
-                  IdentityT $ mrgSingle $ ssymBool "b"
-            let i3 = mrgIte (ssymBool "c") i1 i2
-            let i31 = mrgIte1 (ssymBool "c") i1 i2
-            let i3u1 = mrgIf (ssymBool "c") i1 i2
+            let i1 :: IdentityT (AsKey1 Union) (AsKey SymBool) =
+                  IdentityT $ mrgSingle $ ssym "a"
+            let i2 :: IdentityT (AsKey1 Union) (AsKey SymBool) =
+                  IdentityT $ mrgSingle $ ssym "b"
+            let i3 = mrgIte (ssym "c") i1 i2
+            let i31 = mrgIte1 (ssym "c") i1 i2
+            let i3u1 = mrgIf (ssym "c") i1 i2
             runIdentityT i3
-              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssym "c") (ssym "a") (ssym "b"))
             runIdentityT i31
-              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssym "c") (ssym "a") (ssym "b"))
             runIdentityT i3u1
-              @?= mrgSingle (symIte (ssymBool "c") (ssymBool "a") (ssymBool "b"))
+              @?= mrgSingle (symIte (ssym "c") (ssym "a") (ssym "b"))
         ]
     ]

--- a/test/Grisette/Core/Data/Class/SubstSymTests.hs
+++ b/test/Grisette/Core/Data/Class/SubstSymTests.hs
@@ -19,7 +19,7 @@ import Data.Functor.Sum (Sum (InL, InR))
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Stack (HasCallStack)
-import Grisette (LogicalOp ((.||)), SubstSym (substSym), SymBool)
+import Grisette (AsKey (getAsKey), LogicalOp ((.||)), Solvable (ssym), SubstSym (substSym), SymBool)
 import Grisette.Core.Data.Class.TestValues (ssymBool, ssymbolBool)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
@@ -40,10 +40,10 @@ substSymTests =
         "SubstSym for common types"
         [ testCase "SymBool" $ do
             let asym = ssymbolBool "a"
-            let a = ssymBool "a"
-            let b = ssymBool "b"
-            let c = ssymBool "c"
-            let subst = substSym asym b
+            let a = ssym "a" :: AsKey SymBool
+            let b = ssym "b" :: AsKey SymBool
+            let c = ssym "c" :: AsKey SymBool
+            let subst = substSym asym (getAsKey b)
             subst a @?= b
             subst c @?= c
             subst (a .|| c) @?= b .|| c,
@@ -74,10 +74,10 @@ substSymTests =
                 ioProperty . concreteSubstSymOkProp @[Integer],
               testCase "[SymBool]" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                let subst = substSym asym b
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                let subst = substSym asym (getAsKey b)
                 subst [a, c] @?= [b, c]
             ],
           testGroup
@@ -86,11 +86,11 @@ substSymTests =
                 ioProperty . concreteSubstSymOkProp @(Maybe Integer),
               testCase "Maybe SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                let subst :: Maybe SymBool -> Maybe SymBool
-                    subst = substSym asym b
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                let subst :: Maybe (AsKey SymBool) -> Maybe (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (Just a) @?= Just b
                 subst (Just c) @?= Just c
                 subst Nothing @?= Nothing
@@ -102,11 +102,11 @@ substSymTests =
                   . concreteSubstSymOkProp @(Either Integer Integer),
               testCase "Either SymBool SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                let subst :: Either SymBool SymBool -> Either SymBool SymBool
-                    subst = substSym asym b
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                let subst :: Either (AsKey SymBool) (AsKey SymBool) -> Either (AsKey SymBool) (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (Left a) @?= Left b
                 subst (Left c) @?= Left c
                 subst (Right a) @?= Right b
@@ -120,11 +120,11 @@ substSymTests =
                   . MaybeT,
               testCase "MaybeT Maybe SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                let subst :: MaybeT Maybe SymBool -> MaybeT Maybe SymBool
-                    subst = substSym asym b
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                let subst :: MaybeT Maybe (AsKey SymBool) -> MaybeT Maybe (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (MaybeT Nothing) @?= MaybeT Nothing
                 subst (MaybeT (Just Nothing)) @?= MaybeT (Just Nothing)
                 subst (MaybeT (Just (Just a))) @?= MaybeT (Just (Just b))
@@ -138,13 +138,13 @@ substSymTests =
                   . ExceptT,
               testCase "ExceptT SymBool Maybe SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
                 let subst ::
-                      ExceptT SymBool Maybe SymBool ->
-                      ExceptT SymBool Maybe SymBool
-                    subst = substSym asym b
+                      ExceptT (AsKey SymBool) Maybe (AsKey SymBool) ->
+                      ExceptT (AsKey SymBool) Maybe (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (ExceptT Nothing) @?= ExceptT Nothing
                 subst (ExceptT $ Just $ Left a) @?= ExceptT (Just $ Left b)
                 subst (ExceptT $ Just $ Left c) @?= ExceptT (Just $ Left c)
@@ -158,10 +158,10 @@ substSymTests =
                 ioProperty . concreteSubstSymOkProp @(Integer, Integer),
               testCase "(SymBool, SymBool)" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                substSym asym b (a, c) @?= (b, c)
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                substSym asym (getAsKey b) (a, c) @?= (b, c)
             ],
           testGroup
             "(,,)"
@@ -170,10 +170,10 @@ substSymTests =
                   . concreteSubstSymOkProp @(Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool)" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                substSym asym b (a, c, a) @?= (b, c, b)
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                substSym asym (getAsKey b) (a, c, a) @?= (b, c, b)
             ],
           testGroup
             "(,,,)"
@@ -183,10 +183,10 @@ substSymTests =
                     @(Integer, Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool, SymBool)" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                substSym asym b (a, c, a, c) @?= (b, c, b, c)
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                substSym asym (getAsKey b) (a, c, a, c) @?= (b, c, b, c)
             ],
           testGroup
             "(,,,,)"
@@ -196,10 +196,10 @@ substSymTests =
                     @(Integer, Integer, Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool, SymBool, SymBool)" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                substSym asym b (a, c, a, c, a) @?= (b, c, b, c, b)
+                let a = ssym "a" :: AsKey SymBool
+                let b = ssym "b" :: AsKey SymBool
+                let c = ssym "c" :: AsKey SymBool
+                substSym asym (getAsKey b) (a, c, a, c, a) @?= (b, c, b, c, b)
             ],
           testGroup
             "(,,,,,)"
@@ -212,10 +212,10 @@ substSymTests =
                 "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
                 $ do
                   let asym = ssymbolBool "a"
-                  let a = ssymBool "a"
-                  let b = ssymBool "b"
-                  let c = ssymBool "c"
-                  substSym asym b (a, c, a, c, a, c) @?= (b, c, b, c, b, c)
+                  let a = ssym "a" :: AsKey SymBool
+                  let b = ssym "b" :: AsKey SymBool
+                  let c = ssym "c" :: AsKey SymBool
+                  substSym asym (getAsKey b) (a, c, a, c, a, c) @?= (b, c, b, c, b, c)
             ],
           testGroup
             "(,,,,,,)"
@@ -235,10 +235,10 @@ substSymTests =
                 "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
                 $ do
                   let asym = ssymbolBool "a"
-                  let a = ssymBool "a"
-                  let b = ssymBool "b"
-                  let c = ssymBool "c"
-                  substSym asym b (a, c, a, c, a, c, a)
+                  let a = ssym "a" :: AsKey SymBool
+                  let b = ssym "b" :: AsKey SymBool
+                  let c = ssym "c" :: AsKey SymBool
+                  substSym asym (getAsKey b) (a, c, a, c, a, c, a)
                     @?= (b, c, b, c, b, c, b)
             ],
           testGroup
@@ -260,10 +260,10 @@ substSymTests =
                 "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
                 $ do
                   let asym = ssymbolBool "a"
-                  let a = ssymBool "a"
-                  let b = ssymBool "b"
-                  let c = ssymBool "c"
-                  substSym asym b (a, c, a, c, a, c, a, c)
+                  let a = ssym "a" :: AsKey SymBool
+                  let b = ssym "b" :: AsKey SymBool
+                  let c = ssym "c" :: AsKey SymBool
+                  substSym asym (getAsKey b) (a, c, a, c, a, c, a, c)
                     @?= (b, c, b, c, b, c, b, c)
             ],
           testProperty "ByteString" $
@@ -285,13 +285,13 @@ substSymTests =
                 "Sum Maybe Maybe SymBool"
                 ( do
                     let asym = ssymbolBool "a"
-                    let a = ssymBool "a"
-                    let b = ssymBool "b"
-                    let c = ssymBool "c"
+                    let a = ssym "a"
+                    let b = ssym "b"
+                    let c = ssym "c"
                     let subst ::
-                          Sum Maybe Maybe SymBool ->
-                          Sum Maybe Maybe SymBool
-                        subst = substSym asym b
+                          Sum Maybe Maybe (AsKey SymBool) ->
+                          Sum Maybe Maybe (AsKey SymBool)
+                        subst = substSym asym (getAsKey b)
                     subst (InL Nothing) @?= InL Nothing
                     subst (InL (Just a)) @?= InL (Just b)
                     subst (InL (Just c)) @?= InL (Just c)
@@ -313,13 +313,13 @@ substSymTests =
                     ),
                   testCase "WriterT SymBool (Either SymBool) SymBool" $ do
                     let asym = ssymbolBool "a"
-                    let a = ssymBool "a"
-                    let b = ssymBool "b"
-                    let c = ssymBool "c"
+                    let a = ssym "a"
+                    let b = ssym "b"
+                    let c = ssym "c"
                     let subst ::
-                          WriterLazy.WriterT SymBool (Either SymBool) SymBool ->
-                          WriterLazy.WriterT SymBool (Either SymBool) SymBool
-                        subst = substSym asym b
+                          WriterLazy.WriterT (AsKey SymBool) (Either (AsKey SymBool)) (AsKey SymBool) ->
+                          WriterLazy.WriterT (AsKey SymBool) (Either (AsKey SymBool)) (AsKey SymBool)
+                        subst = substSym asym (getAsKey b)
                     subst
                       (WriterLazy.WriterT (Left a))
                       @?= WriterLazy.WriterT (Left b)
@@ -348,19 +348,19 @@ substSymTests =
                     ),
                   testCase "WriterT SymBool (Either SymBool) SymBool" $ do
                     let asym = ssymbolBool "a"
-                    let a = ssymBool "a"
-                    let b = ssymBool "b"
-                    let c = ssymBool "c"
+                    let a = ssym "a"
+                    let b = ssym "b"
+                    let c = ssym "c"
                     let subst ::
                           WriterStrict.WriterT
-                            SymBool
-                            (Either SymBool)
-                            SymBool ->
+                            (AsKey SymBool)
+                            (Either (AsKey SymBool))
+                            (AsKey SymBool) ->
                           WriterStrict.WriterT
-                            SymBool
-                            (Either SymBool)
-                            SymBool
-                        subst = substSym asym b
+                            (AsKey SymBool)
+                            (Either (AsKey SymBool))
+                            (AsKey SymBool)
+                        subst = substSym asym (getAsKey b)
                     subst
                       (WriterStrict.WriterT (Left a))
                       @?= WriterStrict.WriterT (Left b)
@@ -382,11 +382,11 @@ substSymTests =
                 (ioProperty . concreteSubstSymOkProp @(Identity Integer)),
               testCase "Identity SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
-                let subst :: Identity SymBool -> Identity SymBool
-                    subst = substSym asym b
+                let a = ssym "a"
+                let b = ssym "b"
+                let c = ssym "c"
+                let subst :: Identity (AsKey SymBool) -> Identity (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (Identity a) @?= Identity b
                 subst (Identity c) @?= Identity c
             ],
@@ -400,13 +400,13 @@ substSymTests =
                   . IdentityT,
               testCase "IdentityT (Either SymBool) SymBool" $ do
                 let asym = ssymbolBool "a"
-                let a = ssymBool "a"
-                let b = ssymBool "b"
-                let c = ssymBool "c"
+                let a = ssym "a"
+                let b = ssym "b"
+                let c = ssym "c"
                 let subst ::
-                      IdentityT (Either SymBool) SymBool ->
-                      IdentityT (Either SymBool) SymBool
-                    subst = substSym asym b
+                      IdentityT (Either (AsKey SymBool)) (AsKey SymBool) ->
+                      IdentityT (Either (AsKey SymBool)) (AsKey SymBool)
+                    subst = substSym asym (getAsKey b)
                 subst (IdentityT (Left a)) @?= IdentityT (Left b)
                 subst (IdentityT (Left c)) @?= IdentityT (Left c)
                 subst (IdentityT (Right a)) @?= IdentityT (Right b)

--- a/test/Grisette/Core/Data/Class/SymFiniteBitsTests.hs
+++ b/test/Grisette/Core/Data/Class/SymFiniteBitsTests.hs
@@ -30,7 +30,6 @@ import Grisette.Internal.Core.Data.Class.SymFiniteBits
 import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
 import Type.Reflection (Typeable, typeRep)
 
 someBVSymFiniteBitsTest ::
@@ -50,10 +49,10 @@ someBVSymFiniteBitsTest _ =
     (show $ typeRep @bv)
     [ testCase "symTestBit" $ do
         let a = bv 4 0b0101 :: bv
-        symTestBit a 0 @?= true
-        symTestBit a 1 @?= false
-        symTestBit a 2 @?= true
-        symTestBit a 3 @?= false,
+        symTestBit a 0 .@?= true
+        symTestBit a 1 .@?= false
+        symTestBit a 2 .@?= true
+        symTestBit a 3 .@?= false,
       testCase "symSetBitTo" $ do
         let a = bv 4 0b0101 :: bv
         symSetBitTo a 0 "b" .@?= symIte "b" (bv 4 0b0101) (bv 4 0b0100)
@@ -67,28 +66,28 @@ someBVSymFiniteBitsTest _ =
                 (symIte "b" (bv 4 0b0110) (bv 4 0b0100))
         actual .@?= expected,
       testCase "symBitBlast" $ do
-        symBitBlast (bv 4 0b0101 :: bv) @?= [true, false, true, false],
+        symBitBlast (bv 4 0b0101 :: bv) .@?= [true, false, true, false],
       testCase "symLsb" $ do
-        symLsb (bv 4 0b0101 :: bv) @?= true
-        symLsb (bv 4 0b0100 :: bv) @?= false,
+        symLsb (bv 4 0b0101 :: bv) .@?= true
+        symLsb (bv 4 0b0100 :: bv) .@?= false,
       testCase "symMsb" $ do
-        symMsb (bv 4 0b0101 :: bv) @?= false
-        symMsb (bv 4 0b1101 :: bv) @?= true,
+        symMsb (bv 4 0b0101 :: bv) .@?= false
+        symMsb (bv 4 0b1101 :: bv) .@?= true,
       testCase "symPopCount" $ do
-        symPopCount (bv 4 0 :: bv) @?= 0
-        symPopCount (bv 4 0b0101 :: bv) @?= 2
-        symPopCount (bv 4 0b1101 :: bv) @?= 3
-        symPopCount (bv 4 0b1111 :: bv) @?= 4,
+        symPopCount (bv 4 0 :: bv) .@?= 0
+        symPopCount (bv 4 0b0101 :: bv) .@?= 2
+        symPopCount (bv 4 0b1101 :: bv) .@?= 3
+        symPopCount (bv 4 0b1111 :: bv) .@?= 4,
       testCase "symCountLeadingZeros" $ do
-        symCountLeadingZeros (bv 4 0 :: bv) @?= 4
-        symCountLeadingZeros (bv 4 0b0101 :: bv) @?= 1
-        symCountLeadingZeros (bv 4 0b1101 :: bv) @?= 0
-        symCountLeadingZeros (bv 4 0b0011 :: bv) @?= 2,
+        symCountLeadingZeros (bv 4 0 :: bv) .@?= 4
+        symCountLeadingZeros (bv 4 0b0101 :: bv) .@?= 1
+        symCountLeadingZeros (bv 4 0b1101 :: bv) .@?= 0
+        symCountLeadingZeros (bv 4 0b0011 :: bv) .@?= 2,
       testCase "symCountTrailingZeros" $ do
-        symCountTrailingZeros (bv 4 0 :: bv) @?= 4
-        symCountTrailingZeros (bv 4 0b1010 :: bv) @?= 1
-        symCountTrailingZeros (bv 4 0b1011 :: bv) @?= 0
-        symCountTrailingZeros (bv 4 0b1100 :: bv) @?= 2
+        symCountTrailingZeros (bv 4 0 :: bv) .@?= 4
+        symCountTrailingZeros (bv 4 0b1010 :: bv) .@?= 1
+        symCountTrailingZeros (bv 4 0b1011 :: bv) .@?= 0
+        symCountTrailingZeros (bv 4 0b1100 :: bv) .@?= 2
     ]
 
 bvSymFiniteBitsTest ::
@@ -107,10 +106,10 @@ bvSymFiniteBitsTest _ =
     (show $ typeRep @bv)
     [ testCase "symTestBit" $ do
         let a = 5 :: bv 4
-        symTestBit a 0 @?= true
-        symTestBit a 1 @?= false
-        symTestBit a 2 @?= true
-        symTestBit a 3 @?= false,
+        symTestBit a 0 .@?= true
+        symTestBit a 1 .@?= false
+        symTestBit a 2 .@?= true
+        symTestBit a 3 .@?= false,
       testCase "symSetBitTo" $ do
         let a = 5 :: bv 4
         symSetBitTo a 0 "b" .@?= symIte "b" 0b0101 0b0100
@@ -124,28 +123,28 @@ bvSymFiniteBitsTest _ =
                 (symIte "b" 0b0110 0b0100)
         actual .@?= expected,
       testCase "symBitBlast" $ do
-        symBitBlast (0b0101 :: bv 4) @?= [true, false, true, false],
+        symBitBlast (0b0101 :: bv 4) .@?= [true, false, true, false],
       testCase "symLsb" $ do
-        symLsb (0b0101 :: bv 4) @?= true
-        symLsb (0b0100 :: bv 4) @?= false,
+        symLsb (0b0101 :: bv 4) .@?= true
+        symLsb (0b0100 :: bv 4) .@?= false,
       testCase "symMsb" $ do
-        symMsb (0b0101 :: bv 4) @?= false
-        symMsb (0b1101 :: bv 4) @?= true,
+        symMsb (0b0101 :: bv 4) .@?= false
+        symMsb (0b1101 :: bv 4) .@?= true,
       testCase "symPopCount" $ do
-        symPopCount (0 :: bv 4) @?= 0
-        symPopCount (0b0101 :: bv 4) @?= 2
-        symPopCount (0b1101 :: bv 4) @?= 3
-        symPopCount (0b1111 :: bv 4) @?= 4,
+        symPopCount (0 :: bv 4) .@?= 0
+        symPopCount (0b0101 :: bv 4) .@?= 2
+        symPopCount (0b1101 :: bv 4) .@?= 3
+        symPopCount (0b1111 :: bv 4) .@?= 4,
       testCase "symCountLeadingZeros" $ do
-        symCountLeadingZeros (0 :: bv 4) @?= 4
-        symCountLeadingZeros (0b0101 :: bv 4) @?= 1
-        symCountLeadingZeros (0b1101 :: bv 4) @?= 0
-        symCountLeadingZeros (0b0011 :: bv 4) @?= 2,
+        symCountLeadingZeros (0 :: bv 4) .@?= 4
+        symCountLeadingZeros (0b0101 :: bv 4) .@?= 1
+        symCountLeadingZeros (0b1101 :: bv 4) .@?= 0
+        symCountLeadingZeros (0b0011 :: bv 4) .@?= 2,
       testCase "symCountTrailingZeros" $ do
-        symCountTrailingZeros (0 :: bv 4) @?= 4
-        symCountTrailingZeros (0b1010 :: bv 4) @?= 1
-        symCountTrailingZeros (0b1011 :: bv 4) @?= 0
-        symCountTrailingZeros (0b1100 :: bv 4) @?= 2
+        symCountTrailingZeros (0 :: bv 4) .@?= 4
+        symCountTrailingZeros (0b1010 :: bv 4) .@?= 1
+        symCountTrailingZeros (0b1011 :: bv 4) .@?= 0
+        symCountTrailingZeros (0b1100 :: bv 4) .@?= 2
     ]
 
 symFiniteBitsTests :: Test

--- a/test/Grisette/Core/Data/Class/SymRotateTests.hs
+++ b/test/Grisette/Core/Data/Class/SymRotateTests.hs
@@ -8,13 +8,15 @@ import Data.Data (Proxy (Proxy), Typeable, typeRep)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Grisette
-  ( IntN,
+  ( AsKey (AsKey),
+    IntN,
     Solvable (con),
     SymIntN,
     SymRotate (symRotate, symRotateNegated),
     SymWordN,
     WordN,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit (Assertion, (@?=))
@@ -126,7 +128,8 @@ symbolicTypeSymRotateTests ::
     Typeable s,
     Integral c,
     Solvable c s,
-    Show c
+    Show c,
+    KeyEq s
   ) =>
   proxy s ->
   Test
@@ -139,15 +142,15 @@ symbolicTypeSymRotateTests p =
             forAll (chooseInt (-finiteBitSize x, finiteBitSize x)) $
               \(s :: Int) ->
                 ioProperty $
-                  symRotate (con x :: s) (fromIntegral s)
+                  AsKey (symRotate (con x :: s) (fromIntegral s))
                     @?= con (symRotate x (fromIntegral s)),
           testProperty "symRotate max" $ \(x :: c) ->
             ioProperty $
-              symRotate (con x :: s) (con maxBound)
+              AsKey (symRotate (con x :: s) (con maxBound))
                 @?= con (symRotate x maxBound),
           testProperty "symRotate min" $ \(x :: c) ->
             ioProperty $ do
-              symRotate (con x :: s) (con minBound)
+              AsKey (symRotate (con x :: s) (con minBound))
                 @?= con (symRotate x minBound)
         ]
     ]

--- a/test/Grisette/Core/Data/Class/SymShiftTests.hs
+++ b/test/Grisette/Core/Data/Class/SymShiftTests.hs
@@ -8,13 +8,15 @@ import Data.Data (Proxy (Proxy), Typeable, typeRep)
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Word (Word16, Word32, Word64, Word8)
 import Grisette
-  ( IntN,
+  ( AsKey (AsKey),
+    IntN,
     Solvable (con),
     SymIntN,
     SymShift (symShift, symShiftNegated),
     SymWordN,
     WordN,
   )
+import Grisette.Internal.Core.Data.Class.AsKey (KeyEq)
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.HUnit ((@?=))
@@ -116,7 +118,8 @@ symbolicTypeSymShiftTests ::
     Typeable s,
     Integral c,
     Solvable c s,
-    Show c
+    Show c,
+    KeyEq s
   ) =>
   proxy s ->
   Test
@@ -129,29 +132,29 @@ symbolicTypeSymShiftTests p =
             forAll (chooseInt (-finiteBitSize x, finiteBitSize x)) $
               \(s :: Int) ->
                 ioProperty $
-                  symShift (con x :: s) (fromIntegral s)
+                  AsKey (symShift (con x :: s) (fromIntegral s))
                     @?= con (symShift x (fromIntegral s)),
           testProperty "concrete/concrete symShiftNegated" $ \(x :: c) ->
             forAll (chooseInt (-finiteBitSize x, finiteBitSize x)) $
               \(s :: Int) ->
                 ioProperty $
-                  symShiftNegated (con x :: s) (fromIntegral s)
+                  AsKey (symShiftNegated (con x :: s) (fromIntegral s))
                     @?= con (symShiftNegated x (fromIntegral s)),
           testProperty "symShift max" $ \(x :: c) ->
             ioProperty $
-              symShift (con x :: s) (con maxBound)
+              AsKey (symShift (con x :: s) (con maxBound))
                 @?= con (symShift x maxBound),
           testProperty "symShiftNegated max" $ \(x :: c) ->
             ioProperty $
-              symShiftNegated (con x :: s) (con maxBound)
+              AsKey (symShiftNegated (con x :: s) (con maxBound))
                 @?= con (symShiftNegated x maxBound),
           testProperty "symShift min" $ \(x :: c) ->
             ioProperty $ do
-              symShift (con x :: s) (con minBound)
+              AsKey (symShift (con x :: s) (con minBound))
                 @?= con (symShift x minBound),
           testProperty "symShiftNegated min" $ \(x :: c) ->
             ioProperty $ do
-              symShiftNegated (con x :: s) (con minBound)
+              AsKey (symShiftNegated (con x :: s) (con minBound))
                 @?= con (symShiftNegated x minBound)
         ]
     ]

--- a/test/Grisette/Core/Data/Class/ToConTests.hs
+++ b/test/Grisette/Core/Data/Class/ToConTests.hs
@@ -32,6 +32,7 @@ import Grisette.Core.Data.Class.TestValues
     symFalse,
     symTrue,
   )
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
@@ -77,7 +78,7 @@ toConTests =
                         ssymBool "a" .== ssymBool "b",
                         symIte (ssymBool "a") (ssymBool "b") (ssymBool "c")
                       ]
-                traverse_ (\v -> toCon v @?= Just v) sbools
+                traverse_ (\v -> toCon v .@?= Just v) sbools
             ],
           testProperty "Bool" $ ioProperty . toConForConcreteOkProp @Bool,
           testProperty "Integer" $ ioProperty . toConForConcreteOkProp @Integer,

--- a/test/Grisette/Core/Data/Class/ToSymTests.hs
+++ b/test/Grisette/Core/Data/Class/ToSymTests.hs
@@ -29,6 +29,7 @@ import Grisette
     SymEq ((.==)),
     ToSym (toSym),
   )
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
@@ -48,7 +49,7 @@ toSymTests =
             "SymBool"
             [ testCase "From Bool" $ do
                 let bools = [True, False]
-                traverse_ (\v -> toSym v @?= (con v :: SymBool)) bools,
+                traverse_ (\v -> toSym v .@?= (con v :: SymBool)) bools,
               testCase "From SymBool" $ do
                 let sbools :: [SymBool] =
                       [ con True,
@@ -60,7 +61,7 @@ toSymTests =
                         (ssym "a" :: SymBool) .== ssym "b",
                         symIte (ssym "a") (ssym "b") (ssym "c")
                       ]
-                traverse_ (\v -> toSym v @?= v) sbools
+                traverse_ (\v -> toSym v .@?= v) sbools
             ],
           testProperty "Bool" $ ioProperty . toSymForConcreteOkProp @Bool,
           testProperty "Integer" $ ioProperty . toSymForConcreteOkProp @Integer,
@@ -85,9 +86,9 @@ toSymTests =
                 ioProperty
                   . toSymForConcreteOkProp @[Integer],
               testCase "[SymBool]" $ do
-                toSym ([] :: [Bool]) @?= ([] :: [SymBool])
+                toSym ([] :: [Bool]) .@?= ([] :: [SymBool])
                 toSym ([True, False] :: [Bool])
-                  @?= ([con True, con False] :: [SymBool])
+                  .@?= ([con True, con False] :: [SymBool])
             ],
           testGroup
             "Maybe"
@@ -95,9 +96,9 @@ toSymTests =
                 ioProperty
                   . toSymForConcreteOkProp @(Maybe Integer),
               testCase "Maybe SymBool" $ do
-                toSym (Nothing :: Maybe Bool) @?= (Nothing :: Maybe SymBool)
+                toSym (Nothing :: Maybe Bool) .@?= (Nothing :: Maybe SymBool)
                 toSym (Just True :: Maybe Bool)
-                  @?= (Just $ con True :: Maybe SymBool)
+                  .@?= (Just $ con True :: Maybe SymBool)
             ],
           testGroup
             "Either"
@@ -105,9 +106,9 @@ toSymTests =
                 ioProperty . toSymForConcreteOkProp @(Either Integer Integer),
               testCase "Eithe SymBool SymBool" $ do
                 toSym (Left True :: Either Bool Bool)
-                  @?= (Left $ con True :: Either SymBool SymBool)
+                  .@?= (Left $ con True :: Either SymBool SymBool)
                 toSym (Right True :: Either Bool Bool)
-                  @?= (Right $ con True :: Either SymBool SymBool)
+                  .@?= (Right $ con True :: Either SymBool SymBool)
             ],
           testGroup
             "MaybeT"
@@ -116,11 +117,11 @@ toSymTests =
                   toSymForConcreteOkProp $ MaybeT v,
               testCase "MaybeT Maybe SymBool" $ do
                 toSym (MaybeT Nothing :: MaybeT Maybe Bool)
-                  @?= (MaybeT Nothing :: MaybeT Maybe SymBool)
+                  .@?= (MaybeT Nothing :: MaybeT Maybe SymBool)
                 toSym (MaybeT $ Just Nothing :: MaybeT Maybe Bool)
-                  @?= (MaybeT $ Just Nothing :: MaybeT Maybe SymBool)
+                  .@?= (MaybeT $ Just Nothing :: MaybeT Maybe SymBool)
                 toSym (MaybeT $ Just $ Just True :: MaybeT Maybe Bool)
-                  @?= (MaybeT $ Just $ Just $ con True :: MaybeT Maybe SymBool)
+                  .@?= (MaybeT $ Just $ Just $ con True :: MaybeT Maybe SymBool)
             ],
           testGroup
             "ExceptT"
@@ -129,15 +130,15 @@ toSymTests =
                   toSymForConcreteOkProp $ ExceptT v,
               testCase "ExceptT SymBool Maybe SymBool" $ do
                 toSym (ExceptT Nothing :: ExceptT Bool Maybe Bool)
-                  @?= (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
+                  .@?= (ExceptT Nothing :: ExceptT SymBool Maybe SymBool)
                 toSym (ExceptT $ Just $ Left True :: ExceptT Bool Maybe Bool)
-                  @?= ( ExceptT $ Just $ Left $ con True ::
-                          ExceptT SymBool Maybe SymBool
-                      )
+                  .@?= ( ExceptT $ Just $ Left $ con True ::
+                           ExceptT SymBool Maybe SymBool
+                       )
                 toSym (ExceptT $ Just $ Right False :: ExceptT Bool Maybe Bool)
-                  @?= ( ExceptT $ Just $ Right $ con False ::
-                          ExceptT SymBool Maybe SymBool
-                      )
+                  .@?= ( ExceptT $ Just $ Right $ con False ::
+                           ExceptT SymBool Maybe SymBool
+                       )
             ],
           testGroup
             "(,)"
@@ -145,7 +146,7 @@ toSymTests =
                 ioProperty . toSymForConcreteOkProp @(Integer, Integer),
               testCase "(SymBool, SymBool)" $
                 toSym (True, False)
-                  @?= (con True :: SymBool, con False :: SymBool)
+                  .@?= (con True :: SymBool, con False :: SymBool)
             ],
           testGroup
             "(,,)"
@@ -155,10 +156,10 @@ toSymTests =
                     @(Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool)" $
                 toSym (True, False, True)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool
+                       )
             ],
           testGroup
             "(,,,)"
@@ -168,11 +169,11 @@ toSymTests =
                     @(Integer, Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool, SymBool)" $
                 toSym (True, False, True, False)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool
+                       )
             ],
           testGroup
             "(,,,,)"
@@ -182,12 +183,12 @@ toSymTests =
                     @(Integer, Integer, Integer, Integer, Integer),
               testCase "(SymBool, SymBool, SymBool, SymBool, SymBool)" $
                 toSym (True, False, True, False, True)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool
+                       )
             ],
           testGroup
             "(,,,,,)"
@@ -199,13 +200,13 @@ toSymTests =
               testCase
                 "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
                 $ toSym (True, False, True, False, True, False)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool
+                       )
             ],
           testGroup
             "(,,,,,,)"
@@ -223,14 +224,14 @@ toSymTests =
                      ),
               testCase "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)" $
                 toSym (True, False, True, False, True, False, True)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool
+                       )
             ],
           testGroup
             "(,,,,,,,)"
@@ -250,15 +251,15 @@ toSymTests =
               testCase
                 "(SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool, SymBool)"
                 $ toSym (True, False, True, False, True, False, True, False)
-                  @?= ( con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool,
-                        con True :: SymBool,
-                        con False :: SymBool
-                      )
+                  .@?= ( con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool,
+                         con True :: SymBool,
+                         con False :: SymBool
+                       )
             ],
           testGroup
             "Sum"
@@ -276,17 +277,17 @@ toSymTests =
                           (InR v),
               testCase "Sum Maybe (Either SymBool) SymBool" $ do
                 toSym (InL $ Just True :: Sum Maybe (Either Bool) Bool)
-                  @?= ( InL $ Just $ con True ::
-                          Sum Maybe (Either SymBool) SymBool
-                      )
+                  .@?= ( InL $ Just $ con True ::
+                           Sum Maybe (Either SymBool) SymBool
+                       )
                 toSym (InR $ Left True :: Sum Maybe (Either Bool) Bool)
-                  @?= ( InR $ Left $ con True ::
-                          Sum Maybe (Either SymBool) SymBool
-                      )
+                  .@?= ( InR $ Left $ con True ::
+                           Sum Maybe (Either SymBool) SymBool
+                       )
                 toSym (InR $ Right False :: Sum Maybe (Either Bool) Bool)
-                  @?= ( InR $ Right $ con False ::
-                          Sum Maybe (Either SymBool) SymBool
-                      )
+                  .@?= ( InR $ Right $ con False ::
+                           Sum Maybe (Either SymBool) SymBool
+                       )
             ],
           testProperty "functions" $
             ioProperty
@@ -297,7 +298,7 @@ toSymTests =
                       func ((fk, fv) : _) xv | fk == xv = fv
                       func (_ : fs) xv = func fs xv
                    in (toSym (func f x) :: Either SymBool SymBool)
-                        @?= toSym (func f) x,
+                        .@?= toSym (func f) x,
           testGroup
             "StateT"
             [ testProperty "Lazy" $
@@ -313,7 +314,7 @@ toSymTests =
                        in ( StateLazy.runStateT (toSym st) x ::
                               Either SymBool (SymBool, Bool)
                           )
-                            @?= toSym (func f) x,
+                            .@?= toSym (func f) x,
               testProperty "Strict" $
                 ioProperty
                   . \( f :: [(Bool, Either Bool (Bool, Bool))],
@@ -327,7 +328,7 @@ toSymTests =
                        in ( StateStrict.runStateT (toSym st) x ::
                               Either SymBool (SymBool, Bool)
                           )
-                            @?= toSym (func f) x
+                            .@?= toSym (func f) x
             ],
           testGroup
             "WriterT"
@@ -338,7 +339,7 @@ toSymTests =
                    in ( WriterLazy.runWriterT (toSym w) ::
                           Either SymBool (SymBool, Integer)
                       )
-                        @?= toSym f,
+                        .@?= toSym f,
               testProperty "Strict" $
                 ioProperty . \(f :: Either Bool (Bool, Integer)) ->
                   let w :: WriterStrict.WriterT Integer (Either Bool) Bool =
@@ -346,7 +347,7 @@ toSymTests =
                    in ( WriterStrict.runWriterT (toSym w) ::
                           Either SymBool (SymBool, Integer)
                       )
-                        @?= toSym f
+                        .@?= toSym f
             ],
           testProperty "ReaderT" $
             ioProperty . \(f :: [(Bool, Either Bool Bool)], x :: Bool) ->
@@ -355,7 +356,7 @@ toSymTests =
                   func (_ : fs) xv = func fs xv
                   st :: ReaderT Bool (Either Bool) Bool = ReaderT (func f)
                in (runReaderT (toSym st) x :: Either SymBool SymBool)
-                    @?= toSym (func f) x,
+                    .@?= toSym (func f) x,
           testGroup
             "Identity"
             [ testProperty "Identity Integer" $
@@ -363,7 +364,7 @@ toSymTests =
                   . toSymForConcreteOkProp @(Identity Integer),
               testCase "Identity SymBool" $ do
                 toSym (Identity True :: Identity Bool)
-                  @?= (Identity $ con True :: Identity SymBool)
+                  .@?= (Identity $ con True :: Identity SymBool)
             ],
           testGroup
             "IdentityT"
@@ -373,9 +374,9 @@ toSymTests =
                     (IdentityT x),
               testCase "IdentityT Maybe SymBool" $ do
                 toSym (IdentityT (Just True) :: IdentityT Maybe Bool)
-                  @?= (IdentityT $ Just $ con True :: IdentityT Maybe SymBool)
+                  .@?= (IdentityT $ Just $ con True :: IdentityT Maybe SymBool)
                 toSym (IdentityT Nothing :: IdentityT Maybe Bool)
-                  @?= (IdentityT Nothing :: IdentityT Maybe SymBool)
+                  .@?= (IdentityT Nothing :: IdentityT Maybe SymBool)
             ]
         ]
     ]

--- a/test/Grisette/Core/TH/DerivationData.hs
+++ b/test/Grisette/Core/TH/DerivationData.hs
@@ -60,6 +60,7 @@ import Grisette
   ( AllSyms,
     AllSyms1,
     AllSyms2,
+    AsKey,
     BasicSymPrim,
     Default (Default),
     DeriveConfig (unconstrainedPositions),
@@ -451,7 +452,7 @@ deriveWith
 
 data Serializable a
   = Se1 a
-  | Se2 SymBool
+  | Se2 (AsKey SymBool)
   deriving (Show, Eq)
 
 instance (Arbitrary a) => Arbitrary (Serializable a) where

--- a/test/Grisette/Core/TH/DerivationData.hs
+++ b/test/Grisette/Core/TH/DerivationData.hs
@@ -287,8 +287,6 @@ derive
 instance (Eq1 f) => Eq1 (Expr f) where
   liftEq = undefined
 
-derive [''Expr] [''Hashable, ''Hashable1]
-
 data P a b = P a | Q Int
 
 derive

--- a/test/Grisette/Lib/Control/Monad/ExceptTests.hs
+++ b/test/Grisette/Lib/Control/Monad/ExceptTests.hs
@@ -23,9 +23,9 @@ import Grisette.Lib.Control.Monad.Except
     mrgWithError,
   )
 import Grisette.SymPrim (SymBool, SymInteger)
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
 
 exceptUnion :: ExceptT SymInteger Union SymInteger
 exceptUnion = mrgIfPropagatedStrategy "a" (throwError "b") (return "c")
@@ -36,29 +36,29 @@ monadExceptFunctionTests =
     "Except"
     [ testCase "mrgThrowError" $
         runExceptT (mrgThrowError 1 :: ExceptT Integer Union ())
-          @?= mrgSingle (Left 1),
+          .@?= mrgSingle (Left 1),
       testCase "mrgCatchError" $
         ( mrgIfPropagatedStrategy "a" (throwError "b") (return "c") ::
             ExceptT SymBool Union SymBool
         )
           `mrgCatchError` return
-          @?= mrgSingle (symIte "a" "b" "c"),
+          .@?= mrgSingle (symIte "a" "b" "c"),
       testCase "mrgLiftEither" $ do
         runExceptT (mrgLiftEither (Left "a") :: ExceptT SymBool Union ())
-          @?= mrgSingle (Left "a"),
+          .@?= mrgSingle (Left "a"),
       testCase "mrgTryError" $ do
         let expected = mrgIf "a" (mrgSingle (Left "b")) (mrgSingle (Right "c"))
-        mrgTryError exceptUnion @?= expected,
+        mrgTryError exceptUnion .@?= expected,
       testCase "mrgWithError" $ do
         let expected = mrgIf "a" (mrgThrowError $ "b" + 1) (mrgSingle "c")
-        mrgWithError (+ 1) exceptUnion @?= expected,
+        mrgWithError (+ 1) exceptUnion .@?= expected,
       testCase "mrgCatchError" $
         mrgHandleError
           return
           ( mrgIfPropagatedStrategy "a" (throwError "b") (return "c") ::
               ExceptT SymBool Union SymBool
           )
-          @?= mrgSingle (symIte "a" "b" "c"),
+          .@?= mrgSingle (symIte "a" "b" "c"),
       testCase "mrgMapError" $ do
         let expected =
               ( mrgIf
@@ -76,7 +76,7 @@ monadExceptFunctionTests =
                 Right (Right v) -> return $ Right $ Right $ v .== 1
           )
           exceptUnion
-          @?= expected,
+          .@?= expected,
       testCase "mrgModifyError" $ do
         let original =
               mrgIf "a" (mrgThrowError "b") (mrgSingle "c") ::
@@ -86,5 +86,5 @@ monadExceptFunctionTests =
                 "a"
                 (mrgThrowError $ ("b" :: SymInteger) .== 1)
                 (mrgSingle "c")
-        mrgModifyError (.== 1) original @?= expected
+        mrgModifyError (.== 1) original .@?= expected
     ]

--- a/test/Grisette/Lib/Control/Monad/Trans/ClassTests.hs
+++ b/test/Grisette/Lib/Control/Monad/Trans/ClassTests.hs
@@ -7,7 +7,9 @@ where
 
 import Control.Monad.Except (ExceptT)
 import Grisette
-  ( ITEOp (symIte),
+  ( AsKey,
+    AsKey1,
+    ITEOp (symIte),
     SymBranching (mrgIfPropagatedStrategy),
     Union,
     mrgSingle,
@@ -25,9 +27,9 @@ monadTransClassTests =
     [ testCase "mrgLift" $ do
         ( mrgLift
             ( mrgIfPropagatedStrategy "a" (return "b") (return "c") ::
-                Union SymBool
+                AsKey1 Union (AsKey SymBool)
             ) ::
-            ExceptT SymBool Union SymBool
+            ExceptT (AsKey SymBool) (AsKey1 Union) (AsKey SymBool)
           )
           @?= mrgSingle (symIte "a" "b" "c")
     ]

--- a/test/Grisette/Lib/Control/Monad/Trans/ExceptTests.hs
+++ b/test/Grisette/Lib/Control/Monad/Trans/ExceptTests.hs
@@ -22,9 +22,9 @@ import Grisette.Lib.Control.Monad.Trans.Except
     mrgWithExceptT,
   )
 import Grisette.SymPrim (SymBool, SymInteger)
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
 
 unmergedExceptT :: ExceptT SymInteger Union SymBool
 unmergedExceptT =
@@ -50,15 +50,15 @@ exceptTests =
     [ testCase "mrgExcept" $ do
         let actual = mrgExcept (Left "a") :: ExceptT SymInteger Union SymBool
         let expected = ExceptT (mrgSingle (Left "a"))
-        actual @?= expected,
+        actual .@?= expected,
       testCase "mrgRunExceptT" $ do
-        mrgRunExceptT unmergedExceptT @?= runExceptT mergedExceptT,
+        mrgRunExceptT unmergedExceptT .@?= runExceptT mergedExceptT,
       testCase "mrgWithExceptT" $ do
-        mrgWithExceptT (+ 1) unmergedExceptT @?= mergedExceptTPlus1,
+        mrgWithExceptT (+ 1) unmergedExceptT .@?= mergedExceptTPlus1,
       testCase "mrgThrowE" $ do
         let actual = mrgThrowE "a" :: ExceptT SymInteger Union SymBool
-        actual @?= ExceptT (mrgSingle (Left "a")),
+        actual .@?= ExceptT (mrgSingle (Left "a")),
       testCase "mrgCatchE" $ do
         let actual = mrgCatchE unmergedExceptT (throwError . (+ 1))
-        actual @?= mergedExceptTPlus1
+        actual .@?= mergedExceptTPlus1
     ]

--- a/test/Grisette/Lib/Control/MonadTests.hs
+++ b/test/Grisette/Lib/Control/MonadTests.hs
@@ -12,7 +12,8 @@ import Control.Monad.State
   )
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Grisette
-  ( ITEOp (symIte),
+  ( AsKey1 (AsKey1),
+    ITEOp (symIte),
     LogicalOp ((.&&), (.||)),
     Solvable (con),
     SymBranching (mrgIfPropagatedStrategy),
@@ -84,19 +85,19 @@ monadFunctionTests :: Test
 monadFunctionTests =
   testGroup
     "Monad"
-    [ testCase "mrgReturn" $ (mrgReturn 1 :: Union Integer) @?= mrgSingle 1,
+    [ testCase "mrgReturn" $ (mrgReturn 1 :: Union Integer) .@?= mrgSingle 1,
       testGroup
         ".>>="
         [ testCase "merge result" $ do
             let actual =
                   mrgIfPropagatedStrategy "a" (return $ -1) (return 1)
                     .>>= (\x -> return $ x * x)
-            actual @?= (mrgSingle 1 :: Union Integer),
+            actual .@?= (mrgSingle 1 :: Union Integer),
           testCase "merge argument" $ do
             let actual =
                   mrgIfPropagatedStrategy "a" (return (1 :: Int)) (return 1)
                     .>>= const (return NoMerge)
-            actual @?= (mrgSingle NoMerge :: Union NoMerge)
+            AsKey1 actual @?= AsKey1 (mrgSingle NoMerge :: Union NoMerge)
         ],
       testGroup
         ".>>"
@@ -109,7 +110,7 @@ monadFunctionTests =
             let expected =
                   mrgIf "a" (mrgReturn $ -1) (mrgReturn 1) ::
                     Union Integer
-            actual @?= expected,
+            actual .@?= expected,
           testCase "merge lhs" $ do
             let actual =
                   ( mrgIfPropagatedStrategy "a" (return 1) (return 1) ::
@@ -117,23 +118,23 @@ monadFunctionTests =
                   )
                     .>> return NoMerge
             let expected = mrgReturn NoMerge :: Union NoMerge
-            actual @?= expected
+            AsKey1 actual @?= AsKey1 expected
         ],
       testCase "mrgFail" $ do
         let actual = mrgFail "a" :: MaybeT Union Int
-        actual @?= MaybeT (mrgSingle Nothing),
+        actual .@?= MaybeT (mrgSingle Nothing),
       testCase "mrgMzero" $ do
-        (mrgMzero :: MaybeT Union Integer) @?= MaybeT (mrgReturn Nothing),
+        (mrgMzero :: MaybeT Union Integer) .@?= MaybeT (mrgReturn Nothing),
       testGroup
         "mrgMplus"
         [ testCase "merge result" $ do
             let actual = (mzero `mrgMplus` return 1 :: MaybeT Union Integer)
-            actual @?= mrgReturn 1,
+            actual .@?= mrgReturn 1,
           testCase "merge lhs" $ do
             let lhs =
                   MaybeT $
                     mrgIfPropagatedStrategy "a" (return Nothing) (return Nothing) ::
-                    MaybeT Union NoMerge
+                    MaybeT (AsKey1 Union) NoMerge
             let rhs = return NoMerge
             lhs `mrgMplus` rhs @?= MaybeT (mrgReturn $ Just NoMerge)
         ],
@@ -143,12 +144,12 @@ monadFunctionTests =
             let actual =
                   (\x -> return $ x * x)
                     .=<< mrgIfPropagatedStrategy "a" (return $ -1) (return 1)
-            actual @?= (mrgSingle 1 :: Union Integer),
+            actual .@?= (mrgSingle 1 :: Union Integer),
           testCase "merge argument" $ do
             let actual =
                   const (return NoMerge)
                     .=<< mrgIfPropagatedStrategy "a" (return (1 :: Int)) (return 1)
-            actual @?= (mrgSingle NoMerge :: Union NoMerge)
+            actual @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testGroup
         ".>=>"
@@ -162,7 +163,7 @@ monadFunctionTests =
                         Union Integer
                     )
             let actual = lhs .>=> (\x -> return $ x * x)
-            actual (0 :: Integer) @?= (mrgSingle 1 :: Union Integer),
+            actual (0 :: Integer) .@?= (mrgSingle 1 :: Union Integer),
           testCase "merge lhs result" $ do
             let lhs =
                   const
@@ -170,7 +171,7 @@ monadFunctionTests =
                         "a"
                         (return 1)
                         (return 1) ::
-                        Union Integer
+                        AsKey1 Union Integer
                     )
             let actual = lhs .>=> const (return NoMerge)
             actual (0 :: Integer) @?= mrgSingle NoMerge
@@ -187,7 +188,7 @@ monadFunctionTests =
                         Union Integer
                     )
             let actual = (\x -> return $ x * x) .<=< rhs
-            actual (0 :: Integer) @?= (mrgSingle 1 :: Union Integer),
+            actual (0 :: Integer) .@?= (mrgSingle 1 :: Union Integer),
           testCase "merge rhs result" $ do
             let rhs =
                   const
@@ -195,43 +196,43 @@ monadFunctionTests =
                         "a"
                         (return 1)
                         (return 1) ::
-                        Union Integer
+                        AsKey1 Union Integer
                     )
             let actual = const (return NoMerge) .<=< rhs
             actual (0 :: Integer) @?= mrgSingle NoMerge
         ],
       testCase "mrgForever" $ do
-        let f :: StateT Int (ExceptT NoMerge Union) ()
+        let f :: StateT Int (ExceptT NoMerge (AsKey1 Union)) ()
             f = do
               i <- get
               when (i == 0) $ throwError NoMerge
               put (i - 1)
               lift . lift $
                 mrgIfPropagatedStrategy "a" (return ()) (return ())
-        let actual = mrgForever f :: StateT Int (ExceptT NoMerge Union) NoMerge
+        let actual = mrgForever f :: StateT Int (ExceptT NoMerge (AsKey1 Union)) NoMerge
         runStateT actual 10 @?= ExceptT (mrgReturn $ Left NoMerge),
       testCase "mrgJoin" $
-        mrgJoin (return $ return 1) @?= (mrgSingle 1 :: Union Integer),
+        mrgJoin (return $ return 1) .@?= (mrgSingle 1 :: Union Integer),
       testCase "mrgMfilter" $ do
         let actual = mrgMfilter (const True) (return 1 :: MaybeT Union Int)
-        actual @?= (mrgSingle 1),
+        actual .@?= (mrgSingle 1),
       testCase "symMfilter" $ do
         let actual = symMfilter (.== 0) (return "a" :: MaybeT Union SymInteger)
         let expected =
               mrgIf ("a" .== (0 :: SymInteger)) (mrgReturn "a") mrgMzero
-        actual @?= expected,
+        actual .@?= expected,
       testGroup
         "mrgFilterM"
         [ testCase "merge result" $ do
             let actual = mrgFilterM (return . odd) [1, 2, 3, 4]
             let expected = mrgReturn [1, 3] :: Union [Int]
-            actual @?= expected,
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   mrgFilterM
                     (const $ mrgIfPropagatedStrategy "a" (return True) (return True))
                     [NoMerge, NoMerge]
-            let expected = mrgReturn [NoMerge, NoMerge] :: Union [NoMerge]
+            let expected = mrgReturn [NoMerge, NoMerge] :: AsKey1 Union [NoMerge]
             actual @?= expected
         ],
       testGroup
@@ -239,7 +240,7 @@ monadFunctionTests =
         [ testCase "merge result" $ do
             let actual = symFilterM (return . con . odd) [1, 2, 3, 4]
             let expected = mrgReturn [1, 3] :: Union [Int]
-            actual @?= expected,
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   symFilterM
@@ -250,7 +251,7 @@ monadFunctionTests =
                           (return $ con True)
                     )
                     [NoMerge, NoMerge]
-            let expected = mrgReturn [NoMerge, NoMerge] :: Union [NoMerge]
+            let expected = mrgReturn [NoMerge, NoMerge] :: AsKey1 Union [NoMerge]
             actual @?= expected,
           testCase "symbolic semantics" $ do
             let a = "a" :: SymInteger
@@ -263,7 +264,7 @@ monadFunctionTests =
                       (return [symIte (a ./= 0) a b])
                       (return [a, b]) ::
                     Union [SymInteger]
-            actual @?= expected
+            actual .@?= expected
             actual .@?= expected
         ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
@@ -279,7 +280,7 @@ monadFunctionTests =
                   [1 .. 100] ::
                   Union ([Int], [Int])
           let expected = mrgReturn ([1 .. 100], [2 .. 101])
-          actual @?= expected,
+          actual .@?= expected,
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgZipWithM" $ do
           let actual =
@@ -294,7 +295,7 @@ monadFunctionTests =
                   [1 .. 100] ::
                   Union ([Int])
           let expected = mrgReturn ((* 2) <$> [1 .. 100])
-          actual @?= expected,
+          actual .@?= expected,
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgZipWithM_" $ do
           let actual =
@@ -309,7 +310,7 @@ monadFunctionTests =
                   [1 .. 100] ::
                   Union ()
           let expected = mrgReturn ()
-          actual @?= expected,
+          actual .@?= expected,
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgFoldM" $ do
           let actual =
@@ -323,7 +324,7 @@ monadFunctionTests =
                   10
                   [1 .. 100] ::
                   Union Integer
-          actual @?= mrgReturn 5060,
+          actual .@?= mrgReturn 5060,
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgFoldM_" $ do
           let actual =
@@ -337,7 +338,7 @@ monadFunctionTests =
                   10
                   [1 .. 100 :: Int] ::
                   Union ()
-          actual @?= mrgReturn (),
+          actual .@?= mrgReturn (),
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgReplicateM" $ do
           let actual =
@@ -345,7 +346,7 @@ monadFunctionTests =
                   100
                   (mrgIfPropagatedStrategy "a" (return 1) (return 1)) ::
                   Union [Int]
-          actual @?= mrgReturn [1 | _ <- [1 .. 100]],
+          actual .@?= mrgReturn [1 | _ <- [1 .. 100]],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testGroup
           "symReplicateM"
@@ -356,7 +357,7 @@ monadFunctionTests =
                       (100 :: SymInteger)
                       (mrgIfPropagatedStrategy "a" (return 1) (return 1)) ::
                       Union [Int]
-              actual @?= mrgReturn [1 | _ <- [1 .. 100]],
+              actual .@?= mrgReturn [1 | _ <- [1 .. 100]],
             testCase "symbolic semantics" $ do
               let a = "a" :: SymInteger
               let actual =
@@ -375,52 +376,52 @@ monadFunctionTests =
           ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testCase "mrgReplicateM_" $ do
-          let actual = mrgReplicateM_ 100 noMergeNotMerged :: Union ()
-          actual @?= mrgReturn (),
+          let actual = mrgReplicateM_ 100 noMergeNotMerged :: AsKey1 Union ()
+          actual .@?= mrgReturn (),
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testGroup
           "symReplicateM_"
           [ testCase "merge result and intermediate" $ do
               let actual =
                     symReplicateM_ 200 (100 :: SymInteger) noMergeNotMerged ::
-                      Union ()
-              actual @?= mrgReturn ()
+                      AsKey1 Union ()
+              actual .@?= mrgReturn ()
           ],
       testCase "mrgGuard" $ do
-        mrgGuard True @?= (mrgReturn () :: MaybeT Union ())
-        mrgGuard False @?= (MaybeT $ mrgReturn Nothing :: MaybeT Union ()),
+        mrgGuard True .@?= (mrgReturn () :: MaybeT Union ())
+        mrgGuard False .@?= (MaybeT $ mrgReturn Nothing :: MaybeT Union ()),
       testCase "symGuard" $ do
         let expected =
               MaybeT $
                 mrgIf "a" (return $ Just ()) (return Nothing) ::
                 MaybeT Union ()
-        symGuard "a" @?= expected,
+        symGuard "a" .@?= expected,
       testCase "mrgWhen" $ do
         mrgWhen True (throwError "a")
-          @?= (mrgThrowError "a" :: ExceptT String Union ())
+          .@?= (mrgThrowError "a" :: ExceptT String Union ())
         mrgWhen False (throwError "a")
-          @?= (mrgReturn () :: ExceptT String Union ()),
+          .@?= (mrgReturn () :: ExceptT String Union ()),
       testCase "symWhen" $ do
         let expected =
               mrgIf "a" (mrgThrowError "x") (return ()) ::
                 ExceptT String Union ()
-        symWhen "a" (throwError "x") @?= expected,
+        symWhen "a" (throwError "x") .@?= expected,
       testCase "mrgUnless" $ do
         mrgUnless False (throwError "a")
-          @?= (mrgThrowError "a" :: ExceptT String Union ())
+          .@?= (mrgThrowError "a" :: ExceptT String Union ())
         mrgUnless True (throwError "a")
-          @?= (mrgReturn () :: ExceptT String Union ()),
+          .@?= (mrgReturn () :: ExceptT String Union ()),
       testCase "symUnless" $ do
         let expected =
               mrgIf "a" (return ()) (mrgThrowError "x") ::
                 ExceptT String Union ()
-        symUnless "a" (throwError "x") @?= expected,
+        symUnless "a" (throwError "x") .@?= expected,
       testGroup
         "mrgLiftM"
         [ testCase "merge result" $ do
             let actual = mrgLiftM (const 1) noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual = mrgLiftM (const NoMerge) oneNotMerged
             let expected = mrgReturn NoMerge
@@ -431,8 +432,8 @@ monadFunctionTests =
         [ testCase "merge result" $ do
             let actual =
                   mrgLiftM2 (const $ const 1) noMergeNotMerged noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   mrgLiftM2 (const $ const NoMerge) oneNotMerged oneNotMerged
@@ -448,8 +449,8 @@ monadFunctionTests =
                     noMergeNotMerged
                     noMergeNotMerged
                     noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   mrgLiftM3
@@ -470,8 +471,8 @@ monadFunctionTests =
                     noMergeNotMerged
                     noMergeNotMerged
                     noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   mrgLiftM4
@@ -494,8 +495,8 @@ monadFunctionTests =
                     noMergeNotMerged
                     noMergeNotMerged
                     noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual =
                   mrgLiftM5
@@ -512,8 +513,8 @@ monadFunctionTests =
         "mrgAp"
         [ testCase "merge result" $ do
             let actual = mrgAp (return $ const 1) noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual = mrgAp (return $ const NoMerge) oneNotMerged
             let expected = mrgReturn NoMerge
@@ -523,8 +524,8 @@ monadFunctionTests =
         ".<$!>"
         [ testCase "merge result" $ do
             let actual = const 1 .<$!> noMergeNotMerged
-            let expected = mrgReturn 1 :: Union Int
-            actual @?= expected,
+            let expected = mrgReturn 1 :: AsKey1 Union Int
+            actual .@?= expected,
           testCase "merge argument" $ do
             let actual = const NoMerge .<$!> oneNotMerged
             let expected = mrgReturn NoMerge

--- a/test/Grisette/Lib/Data/FoldableTests.hs
+++ b/test/Grisette/Lib/Data/FoldableTests.hs
@@ -9,7 +9,8 @@ import Control.Monad.Except
   )
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import Grisette
-  ( ITEOp (symIte),
+  ( AsKey1,
+    ITEOp (symIte),
     LogicalOp ((.&&), (.||)),
     SymBool,
     SymBranching (mrgIfPropagatedStrategy),
@@ -109,7 +110,7 @@ foldableFunctionTests =
                       )
                       10
                       [("a", 2), ("b", 3)] ::
-                      Union Integer
+                      AsKey1 Union Integer
               let expected =
                     mrgIf
                       "b"
@@ -118,7 +119,7 @@ foldableFunctionTests =
               actual @?= expected,
             testCase "merge intermediate" $ do
               let actual = mrgFoldrM (const $ const oneNotMerged) 1 [1 .. 1000]
-              let expected = mrgReturn 1 :: Union Int
+              let expected = mrgReturn 1 :: AsKey1 Union Int
               actual @?= expected
           ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
@@ -135,7 +136,7 @@ foldableFunctionTests =
                       )
                       10
                       [("a", 2), ("b", 3)] ::
-                      Union Integer
+                      AsKey1 Union Integer
               let expected =
                     mrgIf
                       "a"
@@ -144,7 +145,7 @@ foldableFunctionTests =
               actual @?= expected,
             testCase "merge intermediate" $ do
               let actual = mrgFoldlM (const $ const oneNotMerged) 1 [1 .. 1000]
-              let expected = mrgReturn 1 :: Union Int
+              let expected = mrgReturn 1 :: AsKey1 Union Int
               actual @?= expected
           ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
@@ -169,7 +170,7 @@ foldableFunctionTests =
                                       (return $ Right c)
                               )
                               [("a", 3), ("b", 2)] ::
-                              ExceptT Integer Union ()
+                              ExceptT Integer (AsKey1 Union) ()
                           )
                   let expected = runExceptT $ do
                         _ <- mrgIf "a" (throwError 3) (return ())
@@ -178,7 +179,7 @@ foldableFunctionTests =
                   actual @?= expected,
                 testCase "discard and merge intermediate" $ do
                   let actual = func1 (const noMergeNotMerged) [1 .. 1000]
-                  let expected = mrgReturn () :: Union ()
+                  let expected = mrgReturn () :: AsKey1 Union ()
                   actual @?= expected
               ]
             ],
@@ -202,7 +203,7 @@ foldableFunctionTests =
                                       (return $ Right c)
                               )
                                 <$> [("a", 3), ("b", 2)] ::
-                              ExceptT Integer Union ()
+                              ExceptT Integer (AsKey1 Union) ()
                           )
                   let expected = runExceptT $ do
                         _ <- mrgIf "a" (throwError 3) (return ())
@@ -211,7 +212,7 @@ foldableFunctionTests =
                   actual @?= expected,
                 testCase "discard and merge intermediate" $ do
                   let actual = func1 (replicate 1000 noMergeNotMerged)
-                  let expected = mrgReturn () :: Union ()
+                  let expected = mrgReturn () :: AsKey1 Union ()
                   actual @?= expected
               ]
             ],

--- a/test/Grisette/Lib/Data/FunctorTests.hs
+++ b/test/Grisette/Lib/Data/FunctorTests.hs
@@ -3,7 +3,9 @@
 module Grisette.Lib.Data.FunctorTests (functorFunctionTests) where
 
 import Grisette
-  ( ITEOp (symIte),
+  ( AsKey,
+    AsKey1,
+    ITEOp (symIte),
     SymBranching (mrgIfPropagatedStrategy),
     SymInteger,
     Union,
@@ -38,10 +40,10 @@ functorFunctionTests =
             let actual =
                   mrgFmap (\x -> x * x) $
                     mrgIfPropagatedStrategy "a" (return $ -1) (return 1)
-            actual @?= (mrgSingle 1 :: Union Integer),
+            actual @?= (mrgSingle 1 :: AsKey1 Union Integer),
           testCase "merge arguments" $ do
             let actual = mrgFmap (const NoMerge) oneNotMerged
-            actual @?= (mrgSingle NoMerge :: Union NoMerge)
+            actual @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testGroup
         ".<$>"
@@ -49,24 +51,24 @@ functorFunctionTests =
             let actual =
                   (\x -> x * x)
                     .<$> mrgIfPropagatedStrategy "a" (return $ -1) (return 1)
-            actual @?= (mrgSingle 1 :: Union Integer),
+            actual @?= (mrgSingle 1 :: AsKey1 Union Integer),
           testCase "merge arguments" $ do
             let actual = (const NoMerge) .<$> oneNotMerged
-            actual @?= (mrgSingle NoMerge :: Union NoMerge)
+            actual @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testGroup
         ".<$"
         [ testCase "merge result" $
-            1 .<$ noMergeNotMerged @?= (mrgSingle 1 :: Union Integer),
+            1 .<$ noMergeNotMerged @?= (mrgSingle 1 :: AsKey1 Union Integer),
           testCase "merge arguments" $
-            NoMerge .<$ oneNotMerged @?= (mrgSingle NoMerge :: Union NoMerge)
+            NoMerge .<$ oneNotMerged @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testGroup
         ".$>"
         [ testCase "merge result" $
-            noMergeNotMerged .$> 1 @?= (mrgSingle 1 :: Union Integer),
+            noMergeNotMerged .$> 1 @?= (mrgSingle 1 :: AsKey1 Union Integer),
           testCase "merge arguments" $
-            oneNotMerged .$> NoMerge @?= (mrgSingle NoMerge :: Union NoMerge)
+            oneNotMerged .$> NoMerge @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testGroup
         ".<&>"
@@ -74,10 +76,10 @@ functorFunctionTests =
             let actual =
                   mrgIfPropagatedStrategy "a" (return $ -1) (return 1)
                     .<&> (\x -> x * x)
-            actual @?= (mrgSingle 1 :: Union Integer),
+            actual @?= (mrgSingle 1 :: AsKey1 Union Integer),
           testCase "merge arguments" $ do
             let actual = oneNotMerged .<&> (const NoMerge)
-            actual @?= (mrgSingle NoMerge :: Union NoMerge)
+            actual @?= (mrgSingle NoMerge :: AsKey1 Union NoMerge)
         ],
       testCase "mrgUnzip" $ do
         let actual =
@@ -87,10 +89,10 @@ functorFunctionTests =
               ( mrgSingle (symIte "x" "a" "b"),
                 mrgIf "x" 1 2
               ) ::
-                (Union SymInteger, Union Integer)
+                (AsKey1 Union (AsKey SymInteger), AsKey1 Union Integer)
         actual @?= expected,
       testCase "mrgVoid" $ do
         let actual = mrgVoid noMergeNotMerged
-        let expected = mrgSingle () :: Union ()
+        let expected = mrgSingle () :: AsKey1 Union ()
         actual @?= expected
     ]

--- a/test/Grisette/Lib/Data/ListTests.hs
+++ b/test/Grisette/Lib/Data/ListTests.hs
@@ -88,10 +88,10 @@ import Grisette.Lib.Data.List
     (.\\),
   )
 import Grisette.SymPrim (SymInteger)
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit ((@?=))
 import Test.QuickCheck (Gen, forAll, ioProperty, listOf, oneof)
 
 aint, bint, cint, dint, eint, fint :: SymInteger
@@ -118,7 +118,7 @@ listTests =
             \(n :: Integer) -> forAll ranilist $ \ranilist -> ioProperty $ do
               let actual = mrgTake n ranilist :: Union [SymInteger]
               let expected = mrgPure $ take (fromInteger n) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = mrgTake aint [bint, cint, dint] :: Union [SymInteger]
             let expected =
@@ -126,7 +126,7 @@ listTests =
                     mrgIf (aint .== 1) (return [bint]) $
                       mrgIf (aint .== 2) (return [bint, cint]) $
                         return [bint, cint, dint]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDrop"
@@ -134,7 +134,7 @@ listTests =
             \(n :: Integer) -> forAll ranilist $ \ranilist -> ioProperty $ do
               let actual = mrgDrop n ranilist :: Union [SymInteger]
               let expected = mrgPure $ drop (fromInteger n) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = mrgDrop aint [bint, cint, dint] :: Union [SymInteger]
             let expected =
@@ -142,7 +142,7 @@ listTests =
                     mrgIf (aint .== 2) (return [dint]) $
                       mrgIf (aint .== 1) (return [cint, dint]) $
                         return [bint, cint, dint]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgSplitAt"
@@ -152,7 +152,7 @@ listTests =
                     mrgSplitAt n ranilist ::
                       Union ([SymInteger], [SymInteger])
               let expected = mrgPure $ splitAt (fromInteger n) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgSplitAt aint [bint, cint, dint] ::
@@ -162,7 +162,7 @@ listTests =
                     mrgIf (aint .== 1) (return ([bint], [cint, dint])) $
                       mrgIf (aint .== 2) (return ([bint, cint], [dint])) $
                         return ([bint, cint, dint], [])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgTakeWhile"
@@ -170,7 +170,7 @@ listTests =
             \ranilist -> ioProperty $ do
               let actual = mrgTakeWhile (.== 0) ranilist :: Union [Integer]
               let expected = mrgPure $ takeWhile (== 0) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgTakeWhile (.== 0) [aint, bint, cint] :: Union [SymInteger]
@@ -179,7 +179,7 @@ listTests =
                     mrgIf (bint ./= 0) (return [aint]) $
                       mrgIf (cint ./= 0) (return ([aint, bint])) $
                         return [aint, bint, cint]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDropWhile"
@@ -187,7 +187,7 @@ listTests =
             \ranilist -> ioProperty $ do
               let actual = mrgDropWhile (.== 0) ranilist :: Union [Integer]
               let expected = mrgPure $ dropWhile (== 0) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgDropWhile (.== 0) [aint, bint, cint] :: Union [SymInteger]
@@ -198,7 +198,7 @@ listTests =
                     $ mrgIf (aint .== 0 .&& bint .== 0) (return [cint])
                     $ mrgIf (aint .== 0) (return ([bint, cint]))
                     $ return [aint, bint, cint]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDropWhileEnd"
@@ -206,7 +206,7 @@ listTests =
             \ranilist -> ioProperty $ do
               let actual = mrgDropWhileEnd (.== 0) ranilist :: Union [Integer]
               let expected = mrgPure $ dropWhileEnd (== 0) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgDropWhileEnd (.== 0) [aint, bint, cint] ::
@@ -218,7 +218,7 @@ listTests =
                     $ mrgIf (cint .== 0 .&& bint .== 0) (return [aint])
                     $ mrgIf (cint .== 0) (return ([aint, bint]))
                     $ return [aint, bint, cint]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgSpan"
@@ -227,7 +227,7 @@ listTests =
               let actual =
                     mrgSpan (.== 0) ranilist :: Union ([Integer], [Integer])
               let expected = mrgPure $ span (== 0) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgSpan (.== 0) [aint, bint, cint] ::
@@ -237,7 +237,7 @@ listTests =
                     mrgIf (bint ./= 0) (return ([aint], [bint, cint])) $
                       mrgIf (cint ./= 0) (return ([aint, bint], [cint])) $
                         return ([aint, bint, cint], [])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgBreak"
@@ -246,7 +246,7 @@ listTests =
               let actual =
                     mrgBreak (.== 0) ranilist :: Union ([Integer], [Integer])
               let expected = mrgPure $ break (== 0) ranilist
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgBreak (.== 0) [aint, bint, cint] ::
@@ -256,7 +256,7 @@ listTests =
                     mrgIf (bint .== 0) (return ([aint], [bint, cint])) $
                       mrgIf (cint .== 0) (return ([aint, bint], [cint])) $
                         return ([aint, bint, cint], [])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgStripPrefix"
@@ -264,7 +264,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgStripPrefix l1 l2 :: Union (Maybe [Integer])
               let expected = mrgPure $ stripPrefix l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgStripPrefix [aint, bint] [cint, dint, eint] ::
@@ -274,7 +274,7 @@ listTests =
                     ((aint ./= cint) .|| (bint ./= dint))
                     (return Nothing)
                     (return $ Just [eint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgGroup"
@@ -282,7 +282,7 @@ listTests =
             \l -> ioProperty $ do
               let actual = mrgGroup l :: Union [[Integer]]
               let expected = mrgPure $ group l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = mrgGroup [aint, bint, cint] :: Union [[SymInteger]]
             let expected =
@@ -296,7 +296,7 @@ listTests =
                       )
                     $ return [[aint], [bint], [cint]]
 
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "symIsPrefixOf"
@@ -304,13 +304,13 @@ listTests =
             \(l1 :: [Int]) l2 -> ioProperty $ do
               let actual = symIsPrefixOf l1 l2 :: SymBool
               let expected = con $ isPrefixOf l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = symIsPrefixOf [aint, bint] [cint, dint, eint]
-            actual @?= (aint .== cint .&& bint .== dint),
+            actual .@?= (aint .== cint .&& bint .== dint),
           testCase "symbolic int, not long enough" $ do
             let actual = symIsPrefixOf [cint, dint, eint] [aint, bint]
-            actual @?= con False
+            actual .@?= con False
         ],
       testGroup
         "symIsSuffixOf"
@@ -318,13 +318,13 @@ listTests =
             \(l1 :: [Int]) l2 -> ioProperty $ do
               let actual = symIsSuffixOf l1 l2 :: SymBool
               let expected = con $ isSuffixOf l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = symIsSuffixOf [aint, bint] [cint, dint, eint]
-            actual @?= (bint .== eint .&& aint .== dint),
+            actual .@?= (bint .== eint .&& aint .== dint),
           testCase "symbolic int, not long enough" $ do
             let actual = symIsSuffixOf [cint, dint, eint] [aint, bint]
-            actual @?= con False
+            actual .@?= con False
         ],
       testGroup
         "symIsInfixOf"
@@ -332,17 +332,17 @@ listTests =
             \(l1 :: [Int]) l2 -> ioProperty $ do
               let actual = symIsInfixOf l1 l2 :: SymBool
               let expected = con $ isInfixOf l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = symIsInfixOf [aint, bint] [cint, dint, eint, fint]
             actual
-              @?= ( (aint .== cint .&& bint .== dint)
-                      .|| (aint .== dint .&& bint .== eint)
-                  )
+              .@?= ( (aint .== cint .&& bint .== dint)
+                       .|| (aint .== dint .&& bint .== eint)
+                   )
               .|| (aint .== eint .&& bint .== fint),
           testCase "symbolic int, not long enough" $ do
             let actual = symIsInfixOf [cint, dint, eint] [aint, bint]
-            actual @?= con False
+            actual .@?= con False
         ],
       testGroup
         "symIsSubsequenceOf"
@@ -350,12 +350,12 @@ listTests =
             \(l1 :: [Int]) l2 -> ioProperty $ do
               let actual = symIsSubsequenceOf l1 l2 :: SymBool
               let expected = con $ isSubsequenceOf l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   symIsSubsequenceOf [aint, bint] [cint, dint, eint, fint]
             actual
-              @?= symIte
+              .@?= symIte
                 (aint .== cint)
                 (bint .== dint .|| (bint .== eint .|| bint .== fint))
                 ( symIte
@@ -365,7 +365,7 @@ listTests =
                 ),
           testCase "symbolic int, not long enough" $ do
             let actual = symIsSubsequenceOf [cint, dint, eint] [aint, bint]
-            actual @?= con False
+            actual .@?= con False
         ],
       testGroup
         "mrgLookup"
@@ -373,7 +373,7 @@ listTests =
             \v l -> ioProperty $ do
               let actual = mrgLookup (v :: Integer) l :: Union (Maybe Integer)
               let expected = mrgPure $ lookup v l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgLookup
@@ -392,7 +392,7 @@ listTests =
                       (aint .== dint)
                       (return $ Just Nothing)
                       (return $ Just $ Just eint)
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgFilter"
@@ -400,7 +400,7 @@ listTests =
             \l -> ioProperty $ do
               let actual = mrgFilter (.== 0) l :: Union [Integer]
               let expected = mrgPure $ filter (== 0) l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgFilter (.== 0) [aint, bint] :: Union [SymInteger]
@@ -410,7 +410,7 @@ listTests =
                       (aint ./= 0 .|| bint ./= 0)
                       (return [symIte (aint .== 0) aint bint])
                       (return [aint, bint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgPartition"
@@ -420,7 +420,7 @@ listTests =
                     mrgPartition (.== 0) l ::
                       Union ([Integer], [Integer])
               let expected = mrgPure $ partition (== 0) l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgPartition (.== 0) [aint, bint] ::
@@ -437,7 +437,7 @@ listTests =
                           )
                       )
                       (return ([aint, bint], []))
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         ".!?"
@@ -447,7 +447,7 @@ listTests =
               let expected =
                     mrgPure $
                       if i < 0 || i >= length l then Nothing else Just $ l !! i
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   [aint, bint, cint] .!? dint :: Union (Maybe SymInteger)
@@ -460,7 +460,7 @@ listTests =
                           symIte (dint .== 0) aint $
                             symIte (dint .== 1) bint cint
                     )
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgElemIndex"
@@ -468,7 +468,7 @@ listTests =
             \(v :: Integer) l -> ioProperty $ do
               let actual = mrgElemIndex v l :: Union (Maybe Int)
               let expected = mrgPure $ elemIndex v l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgElemIndex aint [bint, cint, dint] ::
@@ -481,7 +481,7 @@ listTests =
                         Just $
                           symIte (aint .== bint) 0 (symIte (aint .== cint) 1 2)
                     )
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgElemIndices"
@@ -489,7 +489,7 @@ listTests =
             \(v :: Integer) l -> ioProperty $ do
               let actual = mrgElemIndices v l :: Union [Int]
               let expected = mrgPure $ elemIndices v l
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgFindIndex"
@@ -497,7 +497,7 @@ listTests =
             \(l :: [Integer]) -> ioProperty $ do
               let actual = mrgFindIndex (.== 0) l :: Union (Maybe Int)
               let expected = mrgPure $ findIndex (== 0) l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgFindIndex (.== 0) [aint, bint, cint] ::
@@ -510,7 +510,7 @@ listTests =
                         Just $
                           symIte (aint .== 0) 0 (symIte (bint .== 0) 1 2)
                     )
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgFindIndices"
@@ -518,7 +518,7 @@ listTests =
             \(l :: [Integer]) -> ioProperty $ do
               let actual = mrgFindIndices (.== 0) l :: Union [Int]
               let expected = mrgPure $ findIndices (== 0) l
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgNub"
@@ -526,7 +526,7 @@ listTests =
             \l -> ioProperty $ do
               let actual = mrgNub l :: Union [Integer]
               let expected = mrgPure $ nub l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual = mrgNub [aint, bint, cint] :: Union [SymInteger]
             let expected =
@@ -537,7 +537,7 @@ listTests =
                       (bint .== aint .|| cint .== bint .|| cint .== aint)
                       (return [aint, symIte (bint .== aint) cint bint])
                       (return [aint, bint, cint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDelete"
@@ -545,7 +545,7 @@ listTests =
             \i l -> ioProperty $ do
               let actual = mrgDelete i l :: Union [Integer]
               let expected = mrgPure $ delete i l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgDelete aint [bint, cint, dint] :: Union [SymInteger]
@@ -558,7 +558,7 @@ listTests =
                         ]
                     )
                     (return [bint, cint, dint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         ".\\\\"
@@ -566,7 +566,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = l1 .\\ l2 :: Union [Integer]
               let expected = mrgPure $ l1 \\ l2
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgUnion"
@@ -574,7 +574,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgUnion l1 l2 :: Union [Integer]
               let expected = mrgPure $ union l1 l2
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgIntersect"
@@ -582,7 +582,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgIntersect l1 l2 :: Union [Integer]
               let expected = mrgPure $ intersect l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgIntersect [aint, bint] [cint, dint] :: Union [SymInteger]
@@ -603,7 +603,7 @@ listTests =
                         )
                         (return [aint, bint])
                     )
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgNubBy"
@@ -611,7 +611,7 @@ listTests =
             \l -> ioProperty $ do
               let actual = mrgNubBy (.==) l :: Union [Integer]
               let expected = mrgPure $ nubBy (==) l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgNubBy (.==) [aint, bint, cint] :: Union [SymInteger]
@@ -623,7 +623,7 @@ listTests =
                       (bint .== aint .|| cint .== bint .|| cint .== aint)
                       (return [aint, symIte (bint .== aint) cint bint])
                       (return [aint, bint, cint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDeleteBy"
@@ -631,7 +631,7 @@ listTests =
             \i l -> ioProperty $ do
               let actual = mrgDeleteBy (./=) i l :: Union [Integer]
               let expected = mrgPure $ deleteBy (/=) i l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgDeleteBy (./=) aint [bint, cint, dint] ::
@@ -645,7 +645,7 @@ listTests =
                         ]
                     )
                     (return [bint, cint, dint])
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgDeleteFirstsBy"
@@ -653,7 +653,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgDeleteFirstsBy (./=) l1 l2 :: Union [Integer]
               let expected = mrgPure $ deleteFirstsBy (/=) l1 l2
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgUnionBy"
@@ -661,7 +661,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgUnionBy (.==) l1 l2 :: Union [Integer]
               let expected = mrgPure $ unionBy (==) l1 l2
-              actual @?= expected
+              actual .@?= expected
         ],
       testGroup
         "mrgIntersectBy"
@@ -669,7 +669,7 @@ listTests =
             \l1 l2 -> ioProperty $ do
               let actual = mrgIntersectBy (.==) l1 l2 :: Union [Integer]
               let expected = mrgPure $ intersectBy (==) l1 l2
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgIntersectBy (.==) [aint, bint] [cint, dint] ::
@@ -691,7 +691,7 @@ listTests =
                         )
                         (return [aint, bint])
                     )
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgGroupBy"
@@ -699,7 +699,7 @@ listTests =
             \l -> ioProperty $ do
               let actual = mrgGroupBy (.==) l :: Union [[Integer]]
               let expected = mrgPure $ groupBy (==) l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgGroupBy (.==) [aint, bint, cint] :: Union [[SymInteger]]
@@ -714,7 +714,7 @@ listTests =
                       )
                     $ return [[aint], [bint], [cint]]
 
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgInsert"
@@ -722,7 +722,7 @@ listTests =
             \i l -> ioProperty $ do
               let actual = mrgInsert i l :: Union [Integer]
               let expected = mrgPure $ insert i l
-              actual @?= expected,
+              actual .@?= expected,
           testCase "symbolic int" $ do
             let actual =
                   mrgInsert aint [bint, cint, dint] :: Union [SymInteger]
@@ -738,7 +738,7 @@ listTests =
                         dint
                         aint
                     ]
-            actual @?= expected
+            actual .@?= expected
         ],
       testGroup
         "mrgInsertBy"
@@ -746,6 +746,6 @@ listTests =
             \i l -> ioProperty $ do
               let actual = mrgInsertBy symCompare i l :: Union [Integer]
               let expected = mrgPure $ insertBy compare i l
-              actual @?= expected
+              actual .@?= expected
         ]
     ]

--- a/test/Grisette/Lib/Data/TraversableTests.hs
+++ b/test/Grisette/Lib/Data/TraversableTests.hs
@@ -24,6 +24,7 @@ import Grisette.Lib.Data.Traversable
     mrgTraverse,
   )
 import Grisette.TestUtil.NoMerge (oneNotMerged)
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework
   ( Test,
     TestOptions' (topt_timeout),
@@ -31,7 +32,6 @@ import Test.Framework
     testGroup,
   )
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
 
 traversableFunctionTests :: Test
 traversableFunctionTests =
@@ -76,11 +76,11 @@ traversableFunctionTests =
                             (throwError 2)
                             (mrgIf "d" (return 3) (return 6))
                         mrgSingle [a, b]
-                  actual @?= expected,
+                  actual .@?= expected,
                 testCase "merge intermediate" $ do
                   let actual = func1 (const oneNotMerged) [1 .. 1000]
                   let expected = mrgReturn $ replicate 1000 1
-                  actual @?= expected
+                  actual .@?= expected
               ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testGroup "mrgSequenceA, mrgSequence" $ do
@@ -126,11 +126,11 @@ traversableFunctionTests =
                             (throwError 2)
                             (mrgIf "d" (return 3) (return 6))
                         mrgSingle [a, b]
-                  actual @?= expected,
+                  actual .@?= expected,
                 testCase "merge intermediate" $ do
                   let actual = func1 (replicate 1000 oneNotMerged)
                   let expected = mrgReturn $ replicate 1000 1
-                  actual @?= expected
+                  actual .@?= expected
               ],
       plusTestOptions (mempty {topt_timeout = Just (Just 1000000)}) $
         testGroup "mrgMapAccumM, mrgForAccumM" $ do
@@ -153,7 +153,7 @@ traversableFunctionTests =
                             [(i - 1) * i `div` 2 - i | i <- [1 .. 1000]]
                           ) ::
                           Union (Integer, [Integer])
-                  actual @?= expected,
+                  actual .@?= expected,
                 testCase "merge intermediate" $ do
                   let actual =
                         func1
@@ -168,6 +168,6 @@ traversableFunctionTests =
                   let expected =
                         mrgReturn (1, replicate 1000 1) ::
                           Union (Integer, [Integer])
-                  actual @?= expected
+                  actual .@?= expected
               ]
     ]

--- a/test/Grisette/SymPrim/FPTests.hs
+++ b/test/Grisette/SymPrim/FPTests.hs
@@ -51,6 +51,7 @@ import Grisette
         fpSqrt,
         fpSub
       ),
+    KeyEq (keyEq),
     WordN,
     bitCastOrCanonical,
   )
@@ -282,58 +283,58 @@ fpTests =
         ],
       testGroup
         "SymIEEEFPTraits"
-        [ unaryOpComplianceWithFloat "symFpIsNaN" symFpIsNaN symFpIsNaN (==),
+        [ unaryOpComplianceWithFloat "symFpIsNaN" symFpIsNaN symFpIsNaN keyEq,
           unaryOpComplianceWithFloat
             "symFpIsPositive"
             symFpIsPositive
             symFpIsPositive
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsNegative"
             symFpIsNegative
             symFpIsNegative
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsPositiveInfinite"
             symFpIsPositiveInfinite
             symFpIsPositiveInfinite
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsNegativeInfinite"
             symFpIsNegativeInfinite
             symFpIsNegativeInfinite
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsInfinite"
             symFpIsInfinite
             symFpIsInfinite
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsPositiveZero"
             symFpIsPositiveZero
             symFpIsPositiveZero
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsNegativeZero"
             symFpIsNegativeZero
             symFpIsNegativeZero
-            (==),
-          unaryOpComplianceWithFloat "symFpIsZero" symFpIsZero symFpIsZero (==),
+            keyEq,
+          unaryOpComplianceWithFloat "symFpIsZero" symFpIsZero symFpIsZero keyEq,
           unaryOpComplianceWithFloat
             "symFpIsNormal"
             symFpIsNormal
             symFpIsNormal
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsSubnormal"
             symFpIsSubnormal
             symFpIsSubnormal
-            (==),
+            keyEq,
           unaryOpComplianceWithFloat
             "symFpIsPoint"
             symFpIsPoint
             symFpIsPoint
-            (==)
+            keyEq
         ],
       testGroup
         "IEEEFPConstants"

--- a/test/Grisette/SymPrim/QuantifierTests.hs
+++ b/test/Grisette/SymPrim/QuantifierTests.hs
@@ -6,7 +6,8 @@
 module Grisette.SymPrim.QuantifierTests (quantifierTests) where
 
 import Grisette
-  ( Function ((#)),
+  ( AsKey (AsKey),
+    Function ((#)),
     GenSymSimple (simpleFresh),
     LogicalOp (symImplies),
     ModelOps (isEmptyModel),
@@ -73,5 +74,5 @@ quantifierTests =
                 l :: [SymInteger] <- simpleFresh (SimpleListSpec 2 ())
                 r <- simpleFresh (SimpleListSpec 2 ())
                 return $ forallSym l $ existsSym r $ l .== r
-          x @?= r
+          AsKey x @?= AsKey r
       ]

--- a/test/Grisette/SymPrim/SymPrimTests.hs
+++ b/test/Grisette/SymPrim/SymPrimTests.hs
@@ -41,6 +41,7 @@ import Data.Word (Word8)
 import Grisette
   ( AlgReal,
     Apply (apply),
+    AsKey (AsKey),
     BV (bv),
     EvalSym (evalSym),
     ExtractSym (extractSym),
@@ -184,10 +185,11 @@ import Grisette.SymPrim
     type (-~>),
     type (=~>),
   )
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, TestName, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
-import Test.HUnit (Assertion, assertFailure, (@=?), (@?=))
+import Test.HUnit (Assertion, assertFailure, (@?=))
 import Test.QuickCheck (Arbitrary, ioProperty)
 
 newtype AEWrapper = AEWrapper ArithException deriving (Eq)
@@ -201,7 +203,8 @@ instance NFData AEWrapper where
 sameSafeDiv ::
   forall c s.
   ( Show s,
-    Eq s,
+    SymEq s,
+    EvalSym s,
     Mergeable s,
     NFData c,
     Solvable c s
@@ -214,13 +217,14 @@ sameSafeDiv ::
 sameSafeDiv i j f cf = do
   xc <- evaluate (force $ Right $ cf i j) `catch` \(e :: ArithException) -> return $ Left $ AEWrapper e
   case xc of
-    Left (AEWrapper e) -> f (con i :: s) (con j) @=? tryMerge (throwError e)
-    Right c -> f (con i :: s) (con j) @=? mrgSingle (con c)
+    Left (AEWrapper e) -> f (con i :: s) (con j) .@?= tryMerge (throwError e)
+    Right c -> f (con i :: s) (con j) .@?= mrgSingle (con c)
 
 sameSafeDivMod ::
   forall c s.
   ( Show s,
-    Eq s,
+    SymEq s,
+    EvalSym s,
     Mergeable s,
     NFData c,
     Solvable c s
@@ -233,12 +237,12 @@ sameSafeDivMod ::
 sameSafeDivMod i j f cf = do
   xc <- evaluate (force $ Right $ cf i j) `catch` \(e :: ArithException) -> return $ Left $ AEWrapper e
   case xc of
-    Left (AEWrapper e) -> f (con i :: s) (con j) @=? tryMerge (throwError e)
-    Right (c1, c2) -> f (con i :: s) (con j) @=? mrgSingle (con c1, con c2)
+    Left (AEWrapper e) -> f (con i :: s) (con j) .@?= tryMerge (throwError e)
+    Right (c1, c2) -> f (con i :: s) (con j) .@?= mrgSingle (con c1, con c2)
 
 safeDivisionBoundedOnlyTests ::
   forall c s.
-  (LinkedRep c s, Bounded c, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Bounded c, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   (s -> s -> ExceptT ArithException Union s) ->
   (c -> c -> c) ->
   (Term c -> Term c -> Term c) ->
@@ -248,33 +252,33 @@ safeDivisionBoundedOnlyTests f cf pf =
       sameSafeDiv minBound (-1) f cf,
     testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
-        @=? ( mrgIf
-                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
-                (throwError DivideByZero)
-                ( mrgIf
-                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
-                    (throwError Overflow)
-                    (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b"))
-                ) ::
-                ExceptT ArithException Union s
-            )
+        .@?= ( mrgIf
+                 ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
+                 (throwError DivideByZero)
+                 ( mrgIf
+                     ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
+                     (throwError Overflow)
+                     (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b"))
+                 ) ::
+                 ExceptT ArithException Union s
+             )
   ]
 
 safeDivisionUnboundedOnlyTests ::
   forall c s.
-  (LinkedRep c s, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   (s -> s -> ExceptT ArithException Union s) ->
   (Term c -> Term c -> Term c) ->
   [Test]
 safeDivisionUnboundedOnlyTests f pf =
   [ testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
-        @=? ( mrgIf
-                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
-                (throwError DivideByZero)
-                (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b")) ::
-                ExceptT ArithException Union s
-            )
+        .@?= ( mrgIf
+                 ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
+                 (throwError DivideByZero)
+                 (mrgSingle $ wrapTerm $ pf (ssymTerm "a") (ssymTerm "b")) ::
+                 ExceptT ArithException Union s
+             )
   ]
 
 safeDivisionGeneralTests ::
@@ -283,10 +287,11 @@ safeDivisionGeneralTests ::
     Arbitrary c0,
     Show c0,
     Solvable c s,
-    Eq s,
     Num c,
     Show s,
-    Mergeable s
+    Mergeable s,
+    SymEq s,
+    EvalSym s
   ) =>
   (c0 -> c) ->
   (s -> s -> ExceptT ArithException Union s) ->
@@ -304,12 +309,12 @@ safeDivisionGeneralTests transform f cf =
         sameSafeDiv i 0 f cf,
     testCase "when divided by zero" $ do
       f (ssym "a" :: s) (con 0)
-        @=? (tryMerge $ throwError DivideByZero :: ExceptT ArithException Union s)
+        .@?= (tryMerge $ throwError DivideByZero :: ExceptT ArithException Union s)
   ]
 
 safeDivisionBoundedTests ::
   forall c c0 s.
-  (LinkedRep c s, Arbitrary c0, Show c0, Bounded c, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Arbitrary c0, Show c0, Bounded c, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   TestName ->
   (c0 -> c) ->
   (s -> s -> ExceptT ArithException Union s) ->
@@ -323,7 +328,7 @@ safeDivisionBoundedTests name transform f cf pf =
 
 safeDivisionUnboundedTests ::
   forall c c0 s.
-  (LinkedRep c s, Arbitrary c0, Show c0, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Arbitrary c0, Show c0, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   TestName ->
   (c0 -> c) ->
   (s -> s -> ExceptT ArithException Union s) ->
@@ -337,7 +342,7 @@ safeDivisionUnboundedTests name transform f cf pf =
 
 safeDivModBoundedOnlyTests ::
   forall c s.
-  (LinkedRep c s, Bounded c, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Bounded c, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   ( s ->
     s ->
     ExceptT ArithException Union (s, s)
@@ -351,25 +356,25 @@ safeDivModBoundedOnlyTests f cf pf1 pf2 =
       sameSafeDivMod minBound (-1) f cf,
     testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
-        @=? ( mrgIf
-                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
-                (throwError DivideByZero)
-                ( mrgIf
-                    ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
-                    (throwError Overflow)
-                    ( mrgSingle
-                        ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
-                          wrapTerm $ pf2 (ssymTerm "a") (ssymTerm "b")
-                        )
-                    )
-                ) ::
-                ExceptT ArithException Union (s, s)
-            )
+        .@?= ( mrgIf
+                 ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
+                 (throwError DivideByZero)
+                 ( mrgIf
+                     ((ssym "b" :: s) .== con (-1) .&& (ssym "a" :: s) .== con (minBound :: c) :: SymBool)
+                     (throwError Overflow)
+                     ( mrgSingle
+                         ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
+                           wrapTerm $ pf2 (ssymTerm "a") (ssymTerm "b")
+                         )
+                     )
+                 ) ::
+                 ExceptT ArithException Union (s, s)
+             )
   ]
 
 safeDivModUnboundedOnlyTests ::
   forall c s.
-  (LinkedRep c s, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   ( s ->
     s ->
     ExceptT ArithException Union (s, s)
@@ -380,16 +385,16 @@ safeDivModUnboundedOnlyTests ::
 safeDivModUnboundedOnlyTests f pf1 pf2 =
   [ testCase "on symbolic" $ do
       f (ssym "a" :: s) (ssym "b")
-        @=? ( mrgIf
-                ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
-                (throwError DivideByZero)
-                ( mrgSingle
-                    ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
-                      wrapTerm $ pf2 (ssymTerm "a") (ssymTerm "b")
-                    )
-                ) ::
-                ExceptT ArithException Union (s, s)
-            )
+        .@?= ( mrgIf
+                 ((ssym "b" :: s) .== con (0 :: c) :: SymBool)
+                 (throwError DivideByZero)
+                 ( mrgSingle
+                     ( wrapTerm $ pf1 (ssymTerm "a") (ssymTerm "b"),
+                       wrapTerm $ pf2 (ssymTerm "a") (ssymTerm "b")
+                     )
+                 ) ::
+                 ExceptT ArithException Union (s, s)
+             )
   ]
 
 safeDivModGeneralTests ::
@@ -398,10 +403,11 @@ safeDivModGeneralTests ::
     Arbitrary c0,
     Show c0,
     Solvable c s,
-    Eq s,
     Num c,
     Show s,
-    Mergeable s
+    Mergeable s,
+    SymEq s,
+    EvalSym s
   ) =>
   (c0 -> c) ->
   ( s ->
@@ -422,12 +428,12 @@ safeDivModGeneralTests transform f cf =
         sameSafeDivMod i 0 f cf,
     testCase "when divided by zero" $ do
       f (ssym "a" :: s) (con 0)
-        @=? (tryMerge $ throwError DivideByZero :: ExceptT ArithException Union (s, s))
+        .@?= (tryMerge $ throwError DivideByZero :: ExceptT ArithException Union (s, s))
   ]
 
 safeDivModBoundedTests ::
   forall c c0 s.
-  (LinkedRep c s, Arbitrary c0, Show c0, Bounded c, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Arbitrary c0, Show c0, Bounded c, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   TestName ->
   (c0 -> c) ->
   ( s ->
@@ -445,7 +451,7 @@ safeDivModBoundedTests name transform f cf pf1 pf2 =
 
 safeDivModUnboundedTests ::
   forall c c0 s.
-  (LinkedRep c s, Arbitrary c0, Show c0, Solvable c s, Eq s, Num c, Show s, Mergeable s, SymEq s) =>
+  (LinkedRep c s, Arbitrary c0, Show c0, Solvable c s, Num c, Show s, Mergeable s, SymEq s, EvalSym s) =>
   TestName ->
   (c0 -> c) ->
   ( s ->
@@ -469,12 +475,12 @@ symPrimTests =
         "General SymPrim"
         [ testGroup
             "Solvable"
-            [ testCase "con" $ (con 1 :: SymInteger) @=? SymInteger (conTerm 1),
-              testCase "ssym" $ (ssym "a" :: SymInteger) @=? SymInteger (ssymTerm "a"),
-              testCase "isym" $ (isym "a" 1 :: SymInteger) @=? SymInteger (isymTerm "a" 1),
+            [ testCase "con" $ (con 1 :: SymInteger) .@?= SymInteger (conTerm 1),
+              testCase "ssym" $ (ssym "a" :: SymInteger) .@?= SymInteger (ssymTerm "a"),
+              testCase "isym" $ (isym "a" 1 :: SymInteger) .@?= SymInteger (isymTerm "a" 1),
               testCase "conView" $ do
-                conView (con 1 :: SymInteger) @=? Just 1
-                conView (ssym "a" :: SymInteger) @=? Nothing
+                conView (con 1 :: SymInteger) .@?= Just 1
+                conView (ssym "a" :: SymInteger) .@?= Nothing
                 case con 1 :: SymInteger of
                   Con 1 -> return ()
                   _ -> assertFailure "Bad match"
@@ -486,36 +492,36 @@ symPrimTests =
             "ITEOp"
             [ testCase "symIte" $
                 symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c")
-                  @=? SymInteger (pevalITETerm (ssymTerm "a") (ssymTerm "b") (ssymTerm "c"))
+                  .@?= SymInteger (pevalITETerm (ssymTerm "a") (ssymTerm "b") (ssymTerm "c"))
             ],
           testCase "Mergeable" $ do
             let SimpleStrategy s = rootStrategy :: MergingStrategy SymInteger
             s (ssym "a") (ssym "b") (ssym "c")
-              @=? symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
+              .@?= symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
           testCase "SimpleMergeable" $
             mrgIte (ssym "a" :: SymBool) (ssym "b") (ssym "c")
-              @=? symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
-          testCase "IsString" $ ("a" :: SymBool) @=? SymBool (ssymTerm "a"),
+              .@?= symIte (ssym "a" :: SymBool) (ssym "b" :: SymInteger) (ssym "c"),
+          testCase "IsString" $ ("a" :: SymBool) .@?= SymBool (ssymTerm "a"),
           testGroup
             "ToSym"
-            [ testCase "From self" $ toSym (ssym "a" :: SymBool) @=? (ssym "a" :: SymBool),
-              testCase "From concrete" $ toSym True @=? (con True :: SymBool)
+            [ testCase "From self" $ toSym (ssym "a" :: SymBool) .@?= (ssym "a" :: SymBool),
+              testCase "From concrete" $ toSym True .@?= (con True :: SymBool)
             ],
           testGroup
             "ToCon"
-            [ testCase "To self" $ toCon (ssym "a" :: SymBool) @=? (Nothing :: Maybe Bool),
-              testCase "To concrete" $ toCon True @=? Just True
+            [ testCase "To self" $ toCon (ssym "a" :: SymBool) .@?= (Nothing :: Maybe Bool),
+              testCase "To concrete" $ toCon True .@?= Just True
             ],
           testCase "EvalSym" $ do
             let m1 = emptyModel :: Model
             let m2 = insertValue "a" (1 :: Integer) m1
             let m3 = insertValue "b" True m2
             evalSym False m3 (symIte ("c" :: SymBool) "a" ("a" + "a" :: SymInteger))
-              @=? symIte ("c" :: SymBool) 1 2
-            evalSym True m3 (symIte ("c" :: SymBool) "a" ("a" + "a" :: SymInteger)) @=? 2,
+              .@?= symIte ("c" :: SymBool) 1 2
+            evalSym True m3 (symIte ("c" :: SymBool) "a" ("a" + "a" :: SymInteger)) .@?= 2,
           testCase "ExtractSym" $
             extractSym (symIte ("c" :: SymBool) ("a" :: SymInteger) ("b" :: SymInteger))
-              @=? SymbolSet
+              @?= SymbolSet
                 ( S.fromList
                     [ someTypedSymbol ("c" :: TypedAnySymbol Bool),
                       someTypedSymbol ("a" :: TypedAnySymbol Integer),
@@ -523,42 +529,42 @@ symPrimTests =
                     ]
                 ),
           testCase "GenSym" $ do
-            (genSym () "a" :: Union SymBool) @=? mrgSingle (isym "a" 0)
-            (genSymSimple () "a" :: SymBool) @=? isym "a" 0
-            (genSym (ssym "a" :: SymBool) "a" :: Union SymBool) @=? mrgSingle (isym "a" 0)
-            (genSymSimple (ssym "a" :: SymBool) "a" :: SymBool) @=? isym "a" 0,
+            (genSym () "a" :: Union SymBool) .@?= mrgSingle (isym "a" 0)
+            (genSymSimple () "a" :: SymBool) .@?= isym "a" 0
+            (genSym (ssym "a" :: SymBool) "a" :: Union SymBool) .@?= mrgSingle (isym "a" 0)
+            (genSymSimple (ssym "a" :: SymBool) "a" :: SymBool) .@?= isym "a" 0,
           testCase "SymEq" $ do
-            (ssym "a" :: SymBool) .== ssym "b" @=? SymBool (pevalEqTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
-            (ssym "a" :: SymBool) ./= ssym "b" @=? SymBool (pevalNotTerm $ pevalEqTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
+            (ssym "a" :: SymBool) .== ssym "b" .@?= SymBool (pevalEqTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
+            (ssym "a" :: SymBool) ./= ssym "b" .@?= SymBool (pevalNotTerm $ pevalEqTerm (ssymTerm "a" :: Term Bool) (ssymTerm "b"))
         ],
       testGroup
         "SymBool"
         [ testGroup
             "LogicalOp"
-            [ testCase ".||" $ ssym "a" .|| ssym "b" @=? SymBool (pevalOrTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase ".|| short circuit" $ con True .|| undefined @=? (con True :: SymBool),
-              testCase ".&&" $ ssym "a" .&& ssym "b" @=? SymBool (pevalAndTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase ".&& short circuit" $ con False .&& undefined @=? (con False :: SymBool),
-              testCase "symNot" $ symNot (ssym "a") @=? SymBool (pevalNotTerm (ssymTerm "a")),
-              testCase "symXor" $ symXor (ssym "a") (ssym "b") @=? SymBool (pevalXorTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "symImplies" $ symImplies (ssym "a") (ssym "b") @=? SymBool (pevalImplyTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "symImplies short circuit" $ symImplies (con False) (ssym "b") @=? (con True :: SymBool),
+            [ testCase ".||" $ ssym "a" .|| ssym "b" .@?= SymBool (pevalOrTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase ".|| short circuit" $ con True .|| undefined .@?= (con True :: SymBool),
+              testCase ".&&" $ ssym "a" .&& ssym "b" .@?= SymBool (pevalAndTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase ".&& short circuit" $ con False .&& undefined .@?= (con False :: SymBool),
+              testCase "symNot" $ symNot (ssym "a") .@?= SymBool (pevalNotTerm (ssymTerm "a")),
+              testCase "symXor" $ symXor (ssym "a") (ssym "b") .@?= SymBool (pevalXorTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "symImplies" $ symImplies (ssym "a") (ssym "b") .@?= SymBool (pevalImplyTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "symImplies short circuit" $ symImplies (con False) (ssym "b") .@?= (con True :: SymBool),
               testCase "symIte short circuit" $ do
-                symIte (con True) (ssym "a") undefined @=? (ssym "a" :: SymBool)
-                symIte (con False) undefined (ssym "a") @=? (ssym "a" :: SymBool)
+                symIte (con True) (ssym "a") undefined .@?= (ssym "a" :: SymBool)
+                symIte (con False) undefined (ssym "a") .@?= (ssym "a" :: SymBool)
             ]
         ],
       testGroup
         "SymInteger"
         [ testGroup
             "Num"
-            [ testCase "fromInteger" $ (1 :: SymInteger) @=? SymInteger (conTerm 1),
-              testCase "(+)" $ (ssym "a" :: SymInteger) + ssym "b" @=? SymInteger (pevalAddNumTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "(-)" $ (ssym "a" :: SymInteger) - ssym "b" @=? SymInteger (pevalSubNumTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "(*)" $ (ssym "a" :: SymInteger) * ssym "b" @=? SymInteger (pevalMulNumTerm (ssymTerm "a") (ssymTerm "b")),
-              testCase "negate" $ negate (ssym "a" :: SymInteger) @=? SymInteger (pevalNegNumTerm (ssymTerm "a")),
-              testCase "abs" $ abs (ssym "a" :: SymInteger) @=? SymInteger (pevalAbsNumTerm (ssymTerm "a")),
-              testCase "signum" $ signum (ssym "a" :: SymInteger) @=? SymInteger (pevalSignumNumTerm (ssymTerm "a"))
+            [ testCase "fromInteger" $ (1 :: SymInteger) .@?= SymInteger (conTerm 1),
+              testCase "(+)" $ (ssym "a" :: SymInteger) + ssym "b" .@?= SymInteger (pevalAddNumTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "(-)" $ (ssym "a" :: SymInteger) - ssym "b" .@?= SymInteger (pevalSubNumTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "(*)" $ (ssym "a" :: SymInteger) * ssym "b" .@?= SymInteger (pevalMulNumTerm (ssymTerm "a") (ssymTerm "b")),
+              testCase "negate" $ negate (ssym "a" :: SymInteger) .@?= SymInteger (pevalNegNumTerm (ssymTerm "a")),
+              testCase "abs" $ abs (ssym "a" :: SymInteger) .@?= SymInteger (pevalAbsNumTerm (ssymTerm "a")),
+              testCase "signum" $ signum (ssym "a" :: SymInteger) .@?= SymInteger (pevalSignumNumTerm (ssymTerm "a"))
             ],
           testGroup
             "SafeDiv"
@@ -574,46 +580,46 @@ symPrimTests =
             [ testProperty "safeAdd on concrete" $ \(i :: Integer, j :: Integer) ->
                 ioProperty $ do
                   safeAdd (con i :: SymInteger) (con j)
-                    @=? (mrgSingle $ con $ i + j :: ExceptT ArithException Union SymInteger),
+                    .@?= (mrgSingle $ con $ i + j :: ExceptT ArithException Union SymInteger),
               testCase "safeAdd on symbolic" $ do
                 safeAdd (ssym "a" :: SymInteger) (ssym "b")
-                  @=? (mrgSingle $ SymInteger $ pevalAddNumTerm (ssymTerm "a") (ssymTerm "b") :: ExceptT ArithException Union SymInteger),
+                  .@?= (mrgSingle $ SymInteger $ pevalAddNumTerm (ssymTerm "a") (ssymTerm "b") :: ExceptT ArithException Union SymInteger),
               testProperty "safeNeg on concrete" $ \(i :: Integer) ->
                 ioProperty $ do
                   safeNeg (con i :: SymInteger)
-                    @=? (mrgSingle $ con $ -i :: ExceptT ArithException Union SymInteger),
+                    .@?= (mrgSingle $ con $ -i :: ExceptT ArithException Union SymInteger),
               testCase "safeNeg on symbolic" $ do
                 safeNeg (ssym "a" :: SymInteger)
-                  @=? (mrgSingle $ SymInteger $ pevalNegNumTerm (ssymTerm "a") :: ExceptT ArithException Union SymInteger),
+                  .@?= (mrgSingle $ SymInteger $ pevalNegNumTerm (ssymTerm "a") :: ExceptT ArithException Union SymInteger),
               testProperty "safeSub on concrete" $ \(i :: Integer, j :: Integer) ->
                 ioProperty $ do
                   safeSub (con i :: SymInteger) (con j)
-                    @=? (mrgSingle $ con $ i - j :: ExceptT ArithException Union SymInteger),
+                    .@?= (mrgSingle $ con $ i - j :: ExceptT ArithException Union SymInteger),
               testCase "safeSub on symbolic" $ do
                 safeSub (ssym "a" :: SymInteger) (ssym "b")
-                  @=? (mrgSingle $ SymInteger $ pevalSubNumTerm (ssymTerm "a") (ssymTerm "b") :: ExceptT ArithException Union SymInteger)
+                  .@?= (mrgSingle $ SymInteger $ pevalSubNumTerm (ssymTerm "a") (ssymTerm "b") :: ExceptT ArithException Union SymInteger)
             ],
           testGroup
             "SymOrd"
             [ testProperty "SymOrd on concrete" $ \(i :: Integer, j :: Integer) -> ioProperty $ do
-                (con i :: SymInteger) .<= con j @=? (con (i <= j) :: SymBool)
-                (con i :: SymInteger) .< con j @=? (con (i < j) :: SymBool)
-                (con i :: SymInteger) .>= con j @=? (con (i >= j) :: SymBool)
-                (con i :: SymInteger) .> con j @=? (con (i > j) :: SymBool)
+                (con i :: SymInteger) .<= con j .@?= (con (i <= j) :: SymBool)
+                (con i :: SymInteger) .< con j .@?= (con (i < j) :: SymBool)
+                (con i :: SymInteger) .>= con j .@?= (con (i >= j) :: SymBool)
+                (con i :: SymInteger) .> con j .@?= (con (i > j) :: SymBool)
                 (con i :: SymInteger)
                   `symCompare` con j
-                  @=? (i `symCompare` j :: Union Ordering),
+                  .@?= (i `symCompare` j :: Union Ordering),
               testCase "SymOrd on symbolic" $ do
                 let a :: SymInteger = ssym "a"
                 let b :: SymInteger = ssym "b"
                 let at :: Term Integer = ssymTerm "a"
                 let bt :: Term Integer = ssymTerm "b"
-                a .<= b @=? SymBool (pevalLeOrdTerm at bt)
-                a .< b @=? SymBool (pevalLtOrdTerm at bt)
-                a .>= b @=? SymBool (pevalGeOrdTerm at bt)
-                a .> b @=? SymBool (pevalGtOrdTerm at bt)
+                a .<= b .@?= SymBool (pevalLeOrdTerm at bt)
+                a .< b .@?= SymBool (pevalLtOrdTerm at bt)
+                a .>= b .@?= SymBool (pevalGeOrdTerm at bt)
+                a .> b .@?= SymBool (pevalGtOrdTerm at bt)
                 (a `symCompare` ssym "b" :: Union Ordering)
-                  @=? mrgIf (a .< b) (mrgSingle LT) (mrgIf (a .== b) (mrgSingle EQ) (mrgSingle GT))
+                  .@?= mrgIf (a .< b) (mrgSingle LT) (mrgIf (a .== b) (mrgSingle EQ) (mrgSingle GT))
             ]
         ],
       let au :: SymWordN 4 = ssym "a"
@@ -629,26 +635,26 @@ symPrimTests =
             [ testGroup
                 "Num"
                 [ testCase "fromInteger" $ do
-                    (1 :: SymWordN 4) @=? SymWordN (conTerm 1)
-                    (1 :: SymIntN 4) @=? SymIntN (conTerm 1),
+                    (1 :: SymWordN 4) .@?= SymWordN (conTerm 1)
+                    (1 :: SymIntN 4) .@?= SymIntN (conTerm 1),
                   testCase "(+)" $ do
-                    au + bu @=? SymWordN (pevalAddNumTerm aut but)
-                    as + bs @=? SymIntN (pevalAddNumTerm ast bst),
+                    au + bu .@?= SymWordN (pevalAddNumTerm aut but)
+                    as + bs .@?= SymIntN (pevalAddNumTerm ast bst),
                   testCase "(-)" $ do
-                    au - bu @=? SymWordN (pevalSubNumTerm aut but)
-                    as - bs @=? SymIntN (pevalSubNumTerm ast bst),
+                    au - bu .@?= SymWordN (pevalSubNumTerm aut but)
+                    as - bs .@?= SymIntN (pevalSubNumTerm ast bst),
                   testCase "(*)" $ do
-                    au * bu @=? SymWordN (pevalMulNumTerm aut but)
-                    as * bs @=? SymIntN (pevalMulNumTerm ast bst),
+                    au * bu .@?= SymWordN (pevalMulNumTerm aut but)
+                    as * bs .@?= SymIntN (pevalMulNumTerm ast bst),
                   testCase "negate" $ do
-                    negate au @=? SymWordN (pevalNegNumTerm aut)
-                    negate as @=? SymIntN (pevalNegNumTerm ast),
+                    negate au .@?= SymWordN (pevalNegNumTerm aut)
+                    negate as .@?= SymIntN (pevalNegNumTerm ast),
                   testCase "abs" $ do
-                    abs au @=? SymWordN (pevalAbsNumTerm aut)
-                    abs as @=? SymIntN (pevalAbsNumTerm ast),
+                    abs au .@?= SymWordN (pevalAbsNumTerm aut)
+                    abs as .@?= SymIntN (pevalAbsNumTerm ast),
                   testCase "signum" $ do
-                    signum au @=? SymWordN (pevalSignumNumTerm aut)
-                    signum as @=? SymIntN (pevalSignumNumTerm ast)
+                    signum au .@?= SymWordN (pevalSignumNumTerm aut)
+                    signum as .@?= SymIntN (pevalSignumNumTerm ast)
                 ],
               testGroup
                 "SafeDiv"
@@ -680,7 +686,7 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                               jint = fromIntegral j
                            in safeAdd (toSym i :: SymIntN 8) (toSym j)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   (iint + jint .< fromIntegral (i + j))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -693,7 +699,7 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                               jint = fromIntegral j
                            in safeSub (toSym i :: SymIntN 8) (toSym j)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   (iint - jint .< fromIntegral (i - j))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -705,7 +711,7 @@ symPrimTests =
                         ioProperty $
                           let iint = fromIntegral i :: Integer
                            in safeNeg (toSym i :: SymIntN 8)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   ((-iint) .< fromIntegral (-i))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -721,7 +727,7 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                               jint = fromIntegral j
                            in safeAdd (toSym i :: SymWordN 8) (toSym j)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   (iint + jint .< fromIntegral (i + j))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -734,7 +740,7 @@ symPrimTests =
                           let iint = fromIntegral i :: Integer
                               jint = fromIntegral j
                            in safeSub (toSym i :: SymWordN 8) (toSym j)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   (iint - jint .< fromIntegral (i - j))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -746,7 +752,7 @@ symPrimTests =
                         ioProperty $
                           let iint = fromIntegral i :: Integer
                            in safeNeg (toSym i :: SymWordN 8)
-                                @=? mrgIf
+                                .@?= mrgIf
                                   ((-iint) .< fromIntegral (-i))
                                   (throwError Underflow)
                                   ( mrgIf
@@ -765,78 +771,78 @@ symPrimTests =
                     let js :: IntN 4 = fromInteger j
                     let normalizeu k = k - k `div` 16 * 16
                     let normalizes k = if normalizeu k >= 8 then normalizeu k - 16 else normalizeu k
-                    (con iu :: SymWordN 4) .<= con ju @=? (con (normalizeu i <= normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) .< con ju @=? (con (normalizeu i < normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) .>= con ju @=? (con (normalizeu i >= normalizeu j) :: SymBool)
-                    (con iu :: SymWordN 4) .> con ju @=? (con (normalizeu i > normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .<= con ju .@?= (con (normalizeu i <= normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .< con ju .@?= (con (normalizeu i < normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .>= con ju .@?= (con (normalizeu i >= normalizeu j) :: SymBool)
+                    (con iu :: SymWordN 4) .> con ju .@?= (con (normalizeu i > normalizeu j) :: SymBool)
                     (con iu :: SymWordN 4)
                       `symCompare` con ju
-                      @=? (normalizeu i `symCompare` normalizeu j :: Union Ordering)
-                    (con is :: SymIntN 4) .<= con js @=? (con (normalizes i <= normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) .< con js @=? (con (normalizes i < normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) .>= con js @=? (con (normalizes i >= normalizes j) :: SymBool)
-                    (con is :: SymIntN 4) .> con js @=? (con (normalizes i > normalizes j) :: SymBool)
+                      .@?= (normalizeu i `symCompare` normalizeu j :: Union Ordering)
+                    (con is :: SymIntN 4) .<= con js .@?= (con (normalizes i <= normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .< con js .@?= (con (normalizes i < normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .>= con js .@?= (con (normalizes i >= normalizes j) :: SymBool)
+                    (con is :: SymIntN 4) .> con js .@?= (con (normalizes i > normalizes j) :: SymBool)
                     (con is :: SymIntN 4)
                       `symCompare` con js
-                      @=? (normalizes i `symCompare` normalizes j :: Union Ordering),
+                      .@?= (normalizes i `symCompare` normalizes j :: Union Ordering),
                   testCase "SymOrd on symbolic" $ do
-                    au .<= bu @=? SymBool (pevalLeOrdTerm aut but)
-                    au .< bu @=? SymBool (pevalLtOrdTerm aut but)
-                    au .>= bu @=? SymBool (pevalGeOrdTerm aut but)
-                    au .> bu @=? SymBool (pevalGtOrdTerm aut but)
+                    au .<= bu .@?= SymBool (pevalLeOrdTerm aut but)
+                    au .< bu .@?= SymBool (pevalLtOrdTerm aut but)
+                    au .>= bu .@?= SymBool (pevalGeOrdTerm aut but)
+                    au .> bu .@?= SymBool (pevalGtOrdTerm aut but)
                     (au `symCompare` bu :: Union Ordering)
-                      @=? mrgIf (au .< bu) (mrgSingle LT) (mrgIf (au .== bu) (mrgSingle EQ) (mrgSingle GT))
+                      .@?= mrgIf (au .< bu) (mrgSingle LT) (mrgIf (au .== bu) (mrgSingle EQ) (mrgSingle GT))
 
-                    as .<= bs @=? SymBool (pevalLeOrdTerm ast bst)
-                    as .< bs @=? SymBool (pevalLtOrdTerm ast bst)
-                    as .>= bs @=? SymBool (pevalGeOrdTerm ast bst)
-                    as .> bs @=? SymBool (pevalGtOrdTerm ast bst)
+                    as .<= bs .@?= SymBool (pevalLeOrdTerm ast bst)
+                    as .< bs .@?= SymBool (pevalLtOrdTerm ast bst)
+                    as .>= bs .@?= SymBool (pevalGeOrdTerm ast bst)
+                    as .> bs .@?= SymBool (pevalGtOrdTerm ast bst)
                     (as `symCompare` bs :: Union Ordering)
-                      @=? mrgIf (as .< bs) (mrgSingle LT) (mrgIf (as .== bs) (mrgSingle EQ) (mrgSingle GT))
+                      .@?= mrgIf (as .< bs) (mrgSingle LT) (mrgIf (as .== bs) (mrgSingle EQ) (mrgSingle GT))
                 ],
               testGroup
                 "Bits"
                 [ testCase ".&." $ do
-                    au .&. bu @=? SymWordN (pevalAndBitsTerm aut but)
-                    as .&. bs @=? SymIntN (pevalAndBitsTerm ast bst),
+                    au .&. bu .@?= SymWordN (pevalAndBitsTerm aut but)
+                    as .&. bs .@?= SymIntN (pevalAndBitsTerm ast bst),
                   testCase ".|." $ do
-                    au .|. bu @=? SymWordN (pevalOrBitsTerm aut but)
-                    as .|. bs @=? SymIntN (pevalOrBitsTerm ast bst),
+                    au .|. bu .@?= SymWordN (pevalOrBitsTerm aut but)
+                    as .|. bs .@?= SymIntN (pevalOrBitsTerm ast bst),
                   testCase "xor" $ do
-                    au `xor` bu @=? SymWordN (pevalXorBitsTerm aut but)
-                    as `xor` bs @=? SymIntN (pevalXorBitsTerm ast bst),
+                    au `xor` bu .@?= SymWordN (pevalXorBitsTerm aut but)
+                    as `xor` bs .@?= SymIntN (pevalXorBitsTerm ast bst),
                   testCase "complement" $ do
-                    complement au @=? SymWordN (pevalComplementBitsTerm aut)
-                    complement as @=? SymIntN (pevalComplementBitsTerm ast),
+                    complement au .@?= SymWordN (pevalComplementBitsTerm aut)
+                    complement as .@?= SymIntN (pevalComplementBitsTerm ast),
                   testCase "shift" $ do
-                    shift au 1 @=? SymWordN (pevalShiftLeftTerm aut $ conTerm 1)
-                    shift as 1 @=? SymIntN (pevalShiftLeftTerm ast $ conTerm 1)
-                    shift au (-1) @=? SymWordN (pevalShiftRightTerm aut $ conTerm 1)
-                    shift as (-1) @=? SymIntN (pevalShiftRightTerm ast $ conTerm 1),
+                    shift au 1 .@?= SymWordN (pevalShiftLeftTerm aut $ conTerm 1)
+                    shift as 1 .@?= SymIntN (pevalShiftLeftTerm ast $ conTerm 1)
+                    shift au (-1) .@?= SymWordN (pevalShiftRightTerm aut $ conTerm 1)
+                    shift as (-1) .@?= SymIntN (pevalShiftRightTerm ast $ conTerm 1),
                   testCase "rotate" $ do
-                    rotate au 1 @=? SymWordN (pevalRotateLeftTerm aut $ conTerm 1)
-                    rotate as 1 @=? SymIntN (pevalRotateLeftTerm ast $ conTerm 1)
-                    rotate au (-1) @=? SymWordN (pevalRotateRightTerm aut $ conTerm 1)
-                    rotate as (-1) @=? SymIntN (pevalRotateRightTerm ast $ conTerm 1),
+                    rotate au 1 .@?= SymWordN (pevalRotateLeftTerm aut $ conTerm 1)
+                    rotate as 1 .@?= SymIntN (pevalRotateLeftTerm ast $ conTerm 1)
+                    rotate au (-1) .@?= SymWordN (pevalRotateRightTerm aut $ conTerm 1)
+                    rotate as (-1) .@?= SymIntN (pevalRotateRightTerm ast $ conTerm 1),
                   testCase "bitSize" $ do
-                    bitSizeMaybe au @=? Just 4
-                    bitSizeMaybe as @=? Just 4,
+                    bitSizeMaybe au .@?= Just 4
+                    bitSizeMaybe as .@?= Just 4,
                   testCase "isSigned" $ do
-                    isSigned au @=? False
-                    isSigned as @=? True,
+                    isSigned au .@?= False
+                    isSigned as .@?= True,
                   testCase "testBit would only work on concrete ones" $ do
-                    testBit (con 3 :: SymWordN 4) 1 @=? True
-                    testBit (con 3 :: SymWordN 4) 2 @=? False
-                    testBit (con 3 :: SymIntN 4) 1 @=? True
-                    testBit (con 3 :: SymIntN 4) 2 @=? False,
+                    testBit (con 3 :: SymWordN 4) 1 .@?= True
+                    testBit (con 3 :: SymWordN 4) 2 .@?= False
+                    testBit (con 3 :: SymIntN 4) 1 .@?= True
+                    testBit (con 3 :: SymIntN 4) 2 .@?= False,
                   testCase "bit would work" $ do
-                    bit 1 @=? (con 2 :: SymWordN 4)
-                    bit 1 @=? (con 2 :: SymIntN 4),
+                    bit 1 .@?= (con 2 :: SymWordN 4)
+                    bit 1 .@?= (con 2 :: SymIntN 4),
                   testCase "popCount would only work on concrete ones" $ do
-                    popCount (con 3 :: SymWordN 4) @=? 2
-                    popCount (con 3 :: SymWordN 4) @=? 2
-                    popCount (con 3 :: SymIntN 4) @=? 2
-                    popCount (con 3 :: SymIntN 4) @=? 2
+                    popCount (con 3 :: SymWordN 4) .@?= 2
+                    popCount (con 3 :: SymWordN 4) .@?= 2
+                    popCount (con 3 :: SymIntN 4) .@?= 2
+                    popCount (con 3 :: SymIntN 4) .@?= 2
                 ],
               testGroup
                 "sizedBVConcat"
@@ -844,7 +850,7 @@ symPrimTests =
                     sizedBVConcat
                       (ssym "a" :: SymWordN 4)
                       (ssym "b" :: SymWordN 3)
-                      @=? SymWordN
+                      .@?= SymWordN
                         ( pevalBVConcatTerm
                             (ssymTerm "a" :: Term (WordN 4))
                             (ssymTerm "b" :: Term (WordN 3))
@@ -853,46 +859,46 @@ symPrimTests =
               testGroup
                 "sizedBVExt for Sym BV"
                 [ testCase "sizedBVZext" $ do
-                    sizedBVZext (Proxy @6) au @=? SymWordN (pevalBVExtendTerm False (Proxy @6) aut)
-                    sizedBVZext (Proxy @6) as @=? SymIntN (pevalBVExtendTerm False (Proxy @6) ast),
+                    sizedBVZext (Proxy @6) au .@?= SymWordN (pevalBVExtendTerm False (Proxy @6) aut)
+                    sizedBVZext (Proxy @6) as .@?= SymIntN (pevalBVExtendTerm False (Proxy @6) ast),
                   testCase "sizedBVSext" $ do
-                    sizedBVSext (Proxy @6) au @=? SymWordN (pevalBVExtendTerm True (Proxy @6) aut)
-                    sizedBVSext (Proxy @6) as @=? SymIntN (pevalBVExtendTerm True (Proxy @6) ast),
+                    sizedBVSext (Proxy @6) au .@?= SymWordN (pevalBVExtendTerm True (Proxy @6) aut)
+                    sizedBVSext (Proxy @6) as .@?= SymIntN (pevalBVExtendTerm True (Proxy @6) ast),
                   testCase "sizedBVExt" $ do
-                    sizedBVExt (Proxy @6) au @=? SymWordN (pevalBVExtendTerm False (Proxy @6) aut)
-                    sizedBVExt (Proxy @6) as @=? SymIntN (pevalBVExtendTerm True (Proxy @6) ast)
+                    sizedBVExt (Proxy @6) au .@?= SymWordN (pevalBVExtendTerm False (Proxy @6) aut)
+                    sizedBVExt (Proxy @6) as .@?= SymIntN (pevalBVExtendTerm True (Proxy @6) ast)
                 ],
               testGroup
                 "sizedBVSelect for Sym BV"
                 [ testCase "sizedBVSelect" $ do
                     sizedBVSelect (Proxy @2) (Proxy @1) au
-                      @=? SymWordN (pevalBVSelectTerm (Proxy @2) (Proxy @1) aut)
+                      .@?= SymWordN (pevalBVSelectTerm (Proxy @2) (Proxy @1) aut)
                     sizedBVSelect (Proxy @2) (Proxy @1) as
-                      @=? SymIntN (pevalBVSelectTerm (Proxy @2) (Proxy @1) ast)
+                      .@?= SymIntN (pevalBVSelectTerm (Proxy @2) (Proxy @1) ast)
                 ],
               testGroup
                 "conversion between Int8 and Sym BV"
                 [ testCase "toSym" $ do
-                    toSym (0 :: Int8) @=? (con 0 :: SymIntN 8)
-                    toSym (-127 :: Int8) @=? (con $ -127 :: SymIntN 8)
-                    toSym (-128 :: Int8) @=? (con $ -128 :: SymIntN 8)
-                    toSym (127 :: Int8) @=? (con 127 :: SymIntN 8),
+                    toSym (0 :: Int8) .@?= (con 0 :: SymIntN 8)
+                    toSym (-127 :: Int8) .@?= (con $ -127 :: SymIntN 8)
+                    toSym (-128 :: Int8) .@?= (con $ -128 :: SymIntN 8)
+                    toSym (127 :: Int8) .@?= (con 127 :: SymIntN 8),
                   testCase "toCon" $ do
-                    toCon (con 0 :: SymIntN 8) @=? Just (0 :: Int8)
-                    toCon (con $ -127 :: SymIntN 8) @=? Just (-127 :: Int8)
-                    toCon (con $ -128 :: SymIntN 8) @=? Just (-128 :: Int8)
-                    toCon (con 127 :: SymIntN 8) @=? Just (127 :: Int8)
+                    toCon (con 0 :: SymIntN 8) .@?= Just (0 :: Int8)
+                    toCon (con $ -127 :: SymIntN 8) .@?= Just (-127 :: Int8)
+                    toCon (con $ -128 :: SymIntN 8) .@?= Just (-128 :: Int8)
+                    toCon (con 127 :: SymIntN 8) .@?= Just (127 :: Int8)
                 ],
               testGroup
                 "conversion between Word8 and Sym BV"
                 [ testCase "toSym" $ do
-                    toSym (0 :: Word8) @=? (con 0 :: SymWordN 8)
-                    toSym (1 :: Word8) @=? (con 1 :: SymWordN 8)
-                    toSym (255 :: Word8) @=? (con 255 :: SymWordN 8),
+                    toSym (0 :: Word8) .@?= (con 0 :: SymWordN 8)
+                    toSym (1 :: Word8) .@?= (con 1 :: SymWordN 8)
+                    toSym (255 :: Word8) .@?= (con 255 :: SymWordN 8),
                   testCase "toCon" $ do
-                    toCon (con 0 :: SymWordN 8) @=? Just (0 :: Word8)
-                    toCon (con 1 :: SymWordN 8) @=? Just (1 :: Word8)
-                    toCon (con 255 :: SymWordN 8) @=? Just (255 :: Word8)
+                    toCon (con 0 :: SymWordN 8) .@?= Just (0 :: Word8)
+                    toCon (con 1 :: SymWordN 8) .@?= Just (1 :: Word8)
+                    toCon (con 255 :: SymWordN 8) .@?= Just (255 :: Word8)
                 ]
             ],
       testGroup
@@ -972,8 +978,8 @@ symPrimTests =
         [ testGroup
             "BV"
             [ testCase "bv" $ do
-                (bv 12 21 :: SomeSymWordN) @?= SomeSymWordN (21 :: SymWordN 12)
-                (bv 12 21 :: SomeSymIntN) @?= SomeSymIntN (21 :: SymIntN 12)
+                AsKey (bv 12 21 :: SomeSymWordN) @?= AsKey (SomeSymWordN (21 :: SymWordN 12))
+                AsKey (bv 12 21 :: SomeSymIntN) @?= AsKey (SomeSymIntN (21 :: SymIntN 12))
             ]
         ],
       testGroup
@@ -981,13 +987,13 @@ symPrimTests =
         [ testCase "#" $
             (ssym "a" :: SymInteger =~> SymInteger)
               # ssym "b"
-              @=? SymInteger (pevalApplyTerm (ssymTerm "a" :: Term (Integer =-> Integer)) (ssymTerm "b")),
+              .@?= SymInteger (pevalApplyTerm (ssymTerm "a" :: Term (Integer =-> Integer)) (ssymTerm "b")),
           testCase "apply" $
             apply
               (ssym "f" :: SymInteger =~> SymInteger =~> SymInteger)
               (ssym "a")
               (ssym "b")
-              @=? SymInteger
+              .@?= SymInteger
                 ( pevalApplyTerm
                     ( pevalApplyTerm
                         (ssymTerm "f" :: Term (Integer =-> Integer =-> Integer))
@@ -999,35 +1005,39 @@ symPrimTests =
       testGroup
         "GeneralFun"
         [ testCase "evaluate" $ do
-            evalSym
-              False
-              (buildModel ("a" := (1 :: Integer), "b" := (2 :: Integer)))
-              (con ("a" --> "a" + "b") :: SymInteger -~> SymInteger)
-              @=? (con ("a" --> "a" + 2) :: SymInteger -~> SymInteger)
-            evalSym
-              False
-              (buildModel ("a" := (1 :: Integer), "b" := (2 :: Integer), "c" := (3 :: Integer)))
-              (con ("a" --> con ("b" --> "a" + "b" + "c")) :: SymInteger -~> SymInteger -~> SymInteger)
-              @=? con ("a" --> con ("b" --> "a" + "b" + 3) :: Integer --> Integer --> Integer),
+            AsKey
+              ( evalSym
+                  False
+                  (buildModel ("a" := (1 :: Integer), "b" := (2 :: Integer)))
+                  (con ("a" --> "a" + "b") :: SymInteger -~> SymInteger)
+              )
+              @?= AsKey (con ("a" --> "a" + 2) :: SymInteger -~> SymInteger)
+            AsKey
+              ( evalSym
+                  False
+                  (buildModel ("a" := (1 :: Integer), "b" := (2 :: Integer), "c" := (3 :: Integer)))
+                  (con ("a" --> con ("b" --> "a" + "b" + "c")) :: SymInteger -~> SymInteger -~> SymInteger)
+              )
+              @?= AsKey (con ("a" --> con ("b" --> "a" + "b" + 3) :: Integer --> Integer --> Integer)),
           testCase "#" $ do
             let f :: SymInteger -~> SymInteger -~> SymInteger =
                   con ("a" --> con ("b" --> "a" + "b"))
-            f # ssym "x" @=? con ("b" --> "x" + "b"),
+            AsKey (f # ssym "x") @?= AsKey (con ("b" --> "x" + "b")),
           testCase "apply" $ do
             let f :: SymInteger -~> SymInteger -~> SymInteger =
                   con ("a" --> con ("b" --> "a" + "b"))
-            apply f "x" "y" @=? "x" + "y"
+            AsKey (apply f "x" "y") @?= AsKey ("x" + "y")
         ],
       testGroup
         "Symbolic size"
         [ testCase "symSize" $ do
-            symSize (ssym "a" :: SymInteger) @=? 1
-            symSize (con 1 :: SymInteger) @=? 1
-            symSize (con 1 + ssym "a" :: SymInteger) @=? 3
-            symSize (ssym "a" + ssym "a" :: SymInteger) @=? 2
-            symSize (-(ssym "a") :: SymInteger) @=? 2
-            symSize (symIte (ssym "a" :: SymBool) (ssym "b") (ssym "c") :: SymInteger) @=? 4,
-          testCase "symsSize" $ symsSize [ssym "a" :: SymInteger, ssym "a" + ssym "a"] @=? 2
+            symSize (ssym "a" :: SymInteger) .@?= 1
+            symSize (con 1 :: SymInteger) .@?= 1
+            symSize (con 1 + ssym "a" :: SymInteger) .@?= 3
+            symSize (ssym "a" + ssym "a" :: SymInteger) .@?= 2
+            symSize (-(ssym "a") :: SymInteger) .@?= 2
+            symSize (symIte (ssym "a" :: SymBool) (ssym "b") (ssym "c") :: SymInteger) .@?= 4,
+          testCase "symsSize" $ symsSize [ssym "a" :: SymInteger, ssym "a" + ssym "a"] .@?= 2
         ],
       let asymbol :: TypedAnySymbol Integer = "a"
           bsymbol :: TypedAnySymbol Bool = "b"
@@ -1046,9 +1056,9 @@ symPrimTests =
        in testCase
             "construting Model from ModelSymPair"
             $ do
-              buildModel ("a" := va) @=? Model (M.singleton (someTypedSymbol asymbol) (toModelValue va))
+              buildModel ("a" := va) @?= Model (M.singleton (someTypedSymbol asymbol) (toModelValue va))
               buildModel ("a" := va, "b" := True)
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True)
@@ -1059,7 +1069,7 @@ symPrimTests =
                   "b" := True,
                   "c" := vc
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),
@@ -1072,7 +1082,7 @@ symPrimTests =
                   "c" := vc,
                   "d" := False
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),
@@ -1087,7 +1097,7 @@ symPrimTests =
                   "d" := False,
                   "e" := ve
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),
@@ -1104,7 +1114,7 @@ symPrimTests =
                   "e" := ve,
                   "f" := vf
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),
@@ -1123,7 +1133,7 @@ symPrimTests =
                   "f" := vf,
                   "g" := vg
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),
@@ -1144,7 +1154,7 @@ symPrimTests =
                   "g" := vg,
                   "h" := vh
                 )
-                @=? Model
+                @?= Model
                   ( M.fromList
                       [ (someTypedSymbol asymbol, toModelValue va),
                         (someTypedSymbol bsymbol, toModelValue True),

--- a/test/Grisette/TestUtil/NoMerge.hs
+++ b/test/Grisette/TestUtil/NoMerge.hs
@@ -10,7 +10,8 @@ where
 
 import GHC.Generics (Generic)
 import Grisette
-  ( Mergeable (rootStrategy),
+  ( AsKey1,
+    Mergeable (rootStrategy),
     MergingStrategy (NoStrategy),
     SymBranching (mrgIfPropagatedStrategy),
     Union,
@@ -22,8 +23,8 @@ data NoMerge = NoMerge
 instance Mergeable NoMerge where
   rootStrategy = NoStrategy
 
-oneNotMerged :: Union Int
+oneNotMerged :: AsKey1 Union Int
 oneNotMerged = mrgIfPropagatedStrategy "a" (return 1) (return 1)
 
-noMergeNotMerged :: Union NoMerge
+noMergeNotMerged :: AsKey1 Union NoMerge
 noMergeNotMerged = mrgIfPropagatedStrategy "a" (return NoMerge) (return NoMerge)

--- a/test/Grisette/Unified/UnifiedClassesTest.hs
+++ b/test/Grisette/Unified/UnifiedClassesTest.hs
@@ -45,6 +45,7 @@ import Grisette.Internal.TH.Derivation.Common
       ),
     EvalModeConfig (EvalModeConstraints),
   )
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Grisette.Unified
   ( BaseMonad,
     EvalModeBV,
@@ -141,19 +142,19 @@ unifiedClassesTest =
                     (a Grisette..== 1)
                     (return a)
                     (throwError "err")
-            testBranchingBase a @?= expected,
+            testBranchingBase a .@?= expected,
           testCase "branching 'Con" $
             testBranching 1 @?= (return 1 :: Either T.Text Integer),
           testCase "branching 'Sym" $
-            testBranching 1 @?= (return 1 :: ExceptT T.Text Union SymInteger)
+            testBranching 1 .@?= (return 1 :: ExceptT T.Text Union SymInteger)
         ],
       testGroup
         "UnifiedSEq"
         [ testCase "testSEq 'Con" $ do
             let x1 = X True [1 :: WordN 8] (Identity XNil) [Identity XNil] (1 :: Integer) [1]
             let x2 = X False [1 :: WordN 8] (Identity XNil) [Identity XNil] (1 :: Integer) [2]
-            testSEq x1 x1 @?= True
-            testSEq x1 x2 @?= False,
+            testSEq x1 x1 .@?= True
+            testSEq x1 x2 .@?= False,
           testCase "testSEq 'Sym" $ do
             let x1 =
                   X
@@ -172,7 +173,7 @@ unifiedClassesTest =
                     ("y" :: SymInteger)
                     ["z"]
             testSEq x1 x2
-              @?= symAnd
+              .@?= symAnd
                 [ (("a" :: SymBool) .== "b"),
                   (("x" :: SymInteger) .== "y"),
                   (("w" :: SymInteger) .== "z")

--- a/test/Grisette/Unified/UnifiedConstructorTest.hs
+++ b/test/Grisette/Unified/UnifiedConstructorTest.hs
@@ -51,9 +51,9 @@ import Grisette.Internal.TH.Derivation.Common
     EvalModeConfig (EvalModeConstraints),
   )
 import Grisette.TH (makeNamedUnifiedCtor, makePrefixedUnifiedCtor)
+import Grisette.TestUtil.SymbolicAssertion ((.@?=))
 import Test.Framework (Test, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
-import Test.HUnit ((@?=))
 
 data T mode a
   = T (GetBool mode) a (GetData mode (T mode a))
@@ -98,9 +98,9 @@ makePrefixedUnifiedCtor [] "mk" ''TNoArg
 unifiedConstructorExtraTest :: [Test]
 unifiedConstructorExtraTest =
   [ testCase "mkUnifiedConstructor" $ do
-      f @?= Identity (T True 10 (Identity T1))
+      f .@?= Identity (T True 10 (Identity T1))
       f
-        @?= ( mrgReturn (T (con True) 10 (mrgReturn T1)) ::
+        .@?= ( mrgReturn (T (con True) 10 (mrgReturn T1)) ::
                 Union (T 'S SymInteger)
             )
   ]
@@ -114,10 +114,10 @@ unifiedConstructorTest =
   testGroup "UnifiedConstructor" $
     [ testCase "NoMode" $ do
         tNoMode0 True (10 :: Int) TNoMode1
-          @?= Identity (TNoMode0 True 10 TNoMode1)
-        tNoMode1 @?= (mrgReturn TNoMode1 :: Union (TNoMode Int)),
+          .@?= Identity (TNoMode0 True 10 TNoMode1)
+        tNoMode1 .@?= (mrgReturn TNoMode1 :: Union (TNoMode Int)),
       testCase "NoArg" $ do
-        mkTNoArg @?= Identity TNoArg
-        mkTNoArg @?= (mrgReturn TNoArg :: Union TNoArg)
+        mkTNoArg .@?= Identity TNoArg
+        mkTNoArg .@?= (mrgReturn TNoArg :: Union TNoArg)
     ]
       ++ unifiedConstructorExtraTest


### PR DESCRIPTION
This pull request removed `Hashable` instances on symbolic types as they have confusing semantics (term identity semantics).
This pull request also makes `Eq` throw runtime error to avoid the confusion brought by the term identity semantics.

To use the term identity semantics, a user should now use `AsKey` to explicit specify that the term identity semantics should be used.