### PR TITLE
Refactor Union

### DIFF
--- a/src/Grisette/Core.hs
+++ b/src/Grisette/Core.hs
@@ -836,11 +836,10 @@ module Grisette.Core
     KeyOrd1 (..),
 
     -- ** Union Monad
-    Union,
+    Union (unionMergingStrategy),
     unionUnaryOp,
     unionBinOp,
     liftUnion,
-    unionMergingStrategy,
     liftToMonadUnion,
     unionSize,
 
@@ -1452,11 +1451,10 @@ import Grisette.Internal.Core.Control.Monad.CBMCExcept
   )
 import Grisette.Internal.Core.Control.Monad.Class.Union (MonadUnion)
 import Grisette.Internal.Core.Control.Monad.Union
-  ( Union,
+  ( Union (unionMergingStrategy),
     liftToMonadUnion,
     liftUnion,
     unionBinOp,
-    unionMergingStrategy,
     unionSize,
     unionUnaryOp,
   )

--- a/src/Grisette/Internal/Core/Control/Monad/Union.hs
+++ b/src/Grisette/Internal/Core/Control/Monad/Union.hs
@@ -15,8 +15,6 @@ module Grisette.Internal.Core.Control.Monad.Union
     unionBinOp,
     liftUnion,
     liftToMonadUnion,
-    unionBase,
-    unionMergingStrategy,
     isMerged,
     unionSize,
   )

--- a/test/Grisette/Core/Control/Monad/UnionTests.hs
+++ b/test/Grisette/Core/Control/Monad/UnionTests.hs
@@ -45,7 +45,7 @@ import Grisette
     unionToCon,
   )
 import Grisette.Internal.Core.Control.Monad.Union
-  ( Union (UAny, UMrg),
+  ( Union (Union),
     isMerged,
     liftToMonadUnion,
     liftUnion,
@@ -83,7 +83,7 @@ unionBase12Merged =
     (UnionSingle (Right (symIte "u12c" "u1b" "u2b")))
 
 union12Merged :: AsKey1 Union (Either (AsKey SymBool) (AsKey SymInteger))
-union12Merged = AsKey1 $ UMrg rootStrategy unionBase12Merged
+union12Merged = AsKey1 $ Union (Just rootStrategy) unionBase12Merged
 
 unionSimple1 :: AsKey1 Union (AsKey SymInteger)
 unionSimple1 = mrgIfPropagatedStrategy "u1c" (return "u1a") (return "u1b")
@@ -101,8 +101,8 @@ unionSimple2 = AsKey1 $ mrgIfPropagatedStrategy "u2c" (return "u2a") (return "u2
 unionSimple12Merged :: AsKey1 Union (AsKey SymInteger)
 unionSimple12Merged =
   AsKey1 $
-    UMrg
-      rootStrategy
+    Union
+      (Just rootStrategy)
       ( UnionSingle
           (symIte "u12c" (symIte "u1c" "u1a" "u1b") (symIte "u2c" "u2a" "u2b"))
       )
@@ -217,14 +217,14 @@ unionTests =
       testGroup
         "Applicative"
         [ testCase "pure should work" $
-            (pure 1 :: AsKey1 Union Int) @?= AsKey1 (UAny (UnionSingle 1)),
+            (pure 1 :: AsKey1 Union Int) @?= AsKey1 (Union Nothing (UnionSingle 1)),
           testCase "<*> should work" $
             pure (+ 1) <*> unionSimple1 @?= unionSimple1Plus1
         ],
       testGroup
         "Monad"
         [ testCase "return should work" $
-            (return 1 :: AsKey1 Union Int) @?= AsKey1 (UAny (UnionSingle 1)),
+            (return 1 :: AsKey1 Union Int) @?= AsKey1 (Union Nothing (UnionSingle 1)),
           testCase ">>= should work" $
             (unionSimple1 >>= (\i -> return (i + 1))) @?= unionSimple1Plus1,
           testCase ">>= should propagate merge strategy" $ do

--- a/test/Grisette/Core/Data/Class/TryMergeTests.hs
+++ b/test/Grisette/Core/Data/Class/TryMergeTests.hs
@@ -17,7 +17,8 @@ import Control.Monad.Trans.Maybe (MaybeT (MaybeT))
 import qualified Control.Monad.Writer.Lazy as WriterLazy
 import qualified Control.Monad.Writer.Strict as WriterStrict
 import Grisette
-  ( EvalSym,
+  ( AsKey1 (AsKey1),
+    EvalSym,
     ITEOp (symIte),
     Mergeable (rootStrategy),
     SymBranching (mrgIfPropagatedStrategy),
@@ -26,7 +27,7 @@ import Grisette
     mrgSingle,
     tryMerge,
   )
-import Grisette.Internal.Core.Control.Monad.Union (Union (UMrg))
+import Grisette.Internal.Core.Control.Monad.Union (Union (Union))
 import Grisette.Internal.Core.Data.UnionBase (UnionBase (UnionSingle))
 import Grisette.Internal.SymPrim.SymInteger (SymInteger)
 import Grisette.TestUtil.SymbolicAssertion ((.@?=))
@@ -55,14 +56,14 @@ tryMergeTests =
   testGroup
     "TryMerge"
     [ testCase "mrgSingle" $ do
-        let actual = mrgSingle 1 :: Union Integer
-        actual .@?= (UMrg rootStrategy (UnionSingle 1)),
+        let actual = mrgSingle 1 :: AsKey1 Union Integer
+        actual .@?= AsKey1 (Union (Just rootStrategy) (UnionSingle 1)),
       testCase "mrgSingle" $ do
-        let actual = mrgSingle 1 :: Union Integer
-        actual .@?= (UMrg rootStrategy (UnionSingle 1)),
+        let actual = mrgSingle 1 :: AsKey1 Union Integer
+        actual .@?= AsKey1 (Union (Just rootStrategy) (UnionSingle 1)),
       testCase "tryMerge" $ do
-        let actual = tryMerge $ return 1 :: Union Integer
-        actual .@?= (UMrg rootStrategy (UnionSingle 1)),
+        let actual = tryMerge $ return 1 :: AsKey1 Union Integer
+        actual .@?= AsKey1 (Union (Just rootStrategy) (UnionSingle 1)),
       testGroup "Instances" $ do
         test <-
           [ TryMergeInstanceTest

--- a/test/Grisette/SymPrim/SomeBVTests.hs
+++ b/test/Grisette/SymPrim/SomeBVTests.hs
@@ -50,7 +50,7 @@ import Grisette
     mrgReturn,
     mrgSingle,
   )
-import Grisette.Internal.Core.Control.Monad.Union (Union (UMrg))
+import Grisette.Internal.Core.Control.Monad.Union (Union (Union))
 import Grisette.Internal.Core.Data.UnionBase
   ( UnionBase (UnionSingle),
     ifWithLeftMost,
@@ -490,7 +490,7 @@ someBVTests =
             return $ testCase name $ do
               let actual =
                     mrgIf "cond" (return l) (return r) :: Union SomeIntN
-              let expected = UMrg rootStrategy merged
+              let expected = Union (Just rootStrategy) merged
               AsKey actual @?= AsKey expected,
           testGroup "SomeSymIntN" $ do
             (name, l, r, merged) <-
@@ -525,7 +525,7 @@ someBVTests =
                       (return $ AsKey l)
                       (return $ AsKey r) ::
                       Union (AsKey SomeSymIntN)
-              let expected = UMrg rootStrategy merged
+              let expected = Union (Just rootStrategy) merged
               AsKey1 actual @?= AsKey1 expected
         ],
       testGroup


### PR DESCRIPTION
Refactor `Union` to drop `UMrg` and `UAny` constructors but instead use `Maybe (MergingStrategy a)`.