### PR TITLE
Initial version of theory of array support!

### DIFF
--- a/examples/grisette-examples.cabal
+++ b/examples/grisette-examples.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.38.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:               grisette-examples
-version:            0.13.0.0
+version:            0.13.0.1
 synopsis:           Examples for Grisette
 description:        More examples are available in the
                     [tutorials](https://github.com/lsrcz/grisette/tree/main/tutorials) of

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
@@ -116,6 +116,7 @@ library
       Grisette.Internal.Core.Data.UnionBase
       Grisette.Internal.SymPrim.AlgReal
       Grisette.Internal.SymPrim.AllSyms
+      Grisette.Internal.SymPrim.Array
       Grisette.Internal.SymPrim.BV
       Grisette.Internal.SymPrim.FP
       Grisette.Internal.SymPrim.FunInstanceGen
@@ -147,6 +148,7 @@ library
       Grisette.Internal.SymPrim.Quantifier
       Grisette.Internal.SymPrim.SomeBV
       Grisette.Internal.SymPrim.SymAlgReal
+      Grisette.Internal.SymPrim.SymArray
       Grisette.Internal.SymPrim.SymBool
       Grisette.Internal.SymPrim.SymBV
       Grisette.Internal.SymPrim.SymFP

--- a/grisette.cabal
+++ b/grisette.cabal
@@ -331,7 +331,7 @@ library
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <13
+    , sbv >=13.4
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.24
     , text >=1.2.4.1 && <2.2
@@ -380,7 +380,7 @@ test-suite doctest
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <13
+    , sbv >=13.4
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.24
     , text >=1.2.4.1 && <2.2
@@ -501,7 +501,7 @@ test-suite spec
     , mtl >=2.2.2 && <2.4
     , parallel >=3.2.2 && <3.3
     , prettyprinter >=1.5.0 && <1.8
-    , sbv >=8.17 && <13
+    , sbv >=13.4
     , stm ==2.5.*
     , template-haskell >=2.16 && <2.24
     , test-framework >=0.8.2 && <0.9

--- a/package.yaml
+++ b/package.yaml
@@ -36,7 +36,7 @@ dependencies:
   - th-compat >= 0.1.2 && < 0.2
   - th-abstraction >= 0.4 && < 0.8
   - array >= 0.5.4 && < 0.6
-  - sbv >= 8.17 && < 13
+  - sbv >= 13.4
   - parallel >= 3.2.2 && < 3.3
   - text >= 1.2.4.1 && < 2.2
   - QuickCheck >= 2.14 && < 2.17

--- a/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
+++ b/src/Grisette/Internal/Core/Data/Class/ITEOp.hs
@@ -33,10 +33,13 @@ import Grisette.Internal.SymPrim.GeneralFun
 import Grisette.Internal.SymPrim.Prim.SomeTerm (SomeTerm (SomeTerm))
 import Grisette.Internal.SymPrim.Prim.Term
   ( SupportedPrim (pevalITETerm),
+    SupportedNonFuncPrim,
+    LinkedRep,
     TypedConstantSymbol,
     symTerm,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
+import Grisette.Internal.SymPrim.SymArray (SymArray (SymArray))
 import Grisette.Internal.SymPrim.SymBV
   ( SymIntN (SymIntN),
     SymWordN (SymWordN),
@@ -92,6 +95,15 @@ ITEOP_BV(SymWordN)
 ITEOP_FUN((=->), (=~>), SymTabularFun)
 ITEOP_FUN((-->), (-~>), SymGeneralFun)
 #endif
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  ITEOp (SymArray sk sv) where
+  symIte (SymBool c) (SymArray t) (SymArray f) = SymArray $ pevalITETerm c t f
 
 instance ITEOp (a --> b) where
   symIte

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/EvalSym.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/EvalSym.hs
@@ -75,6 +75,7 @@ import Grisette.Internal.Internal.Decl.Core.Data.Class.EvalSym
     evalSym1,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal)
+import Grisette.Internal.SymPrim.Array (Array)
 import Grisette.Internal.SymPrim.BV (IntN, WordN)
 import Grisette.Internal.SymPrim.FP
   ( FP,
@@ -86,9 +87,12 @@ import Grisette.Internal.SymPrim.GeneralFun (type (-->) (GeneralFun))
 import Grisette.Internal.SymPrim.Prim.Model (evalTerm)
 import Grisette.Internal.SymPrim.Prim.Term
   ( SymRep (SymType),
+    SupportedNonFuncPrim,
+    LinkedRep,
     someTypedSymbol,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
+import Grisette.Internal.SymPrim.SymArray (SymArray (SymArray))
 import Grisette.Internal.SymPrim.SymBV
   ( SymIntN (SymIntN),
     SymWordN (SymWordN),
@@ -137,6 +141,7 @@ CONCRETE_EVALUATESYM(Ordering)
 CONCRETE_EVALUATESYM_BV(IntN)
 CONCRETE_EVALUATESYM_BV(WordN)
 CONCRETE_EVALUATESYM(AlgReal)
+CONCRETE_EVALUATESYM((Array k v))
 #endif
 
 instance EvalSym (Proxy a) where
@@ -185,6 +190,15 @@ EVALUATE_SYM_FUN((-->), (-~>), SymGeneralFun)
 instance (ValidFP eb sb) => EvalSym (SymFP eb sb) where
   evalSym fillDefault model (SymFP t) =
     SymFP $ evalTerm fillDefault model HS.empty t
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  EvalSym (SymArray sk sv) where
+  evalSym fill model (SymArray t) = SymArray $ evalTerm fill model HS.empty t
 
 derive
   [ ''(),

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/Mergeable.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/Mergeable.hs
@@ -90,6 +90,7 @@ import Grisette.Internal.Internal.Decl.Core.Data.Class.Mergeable
     wrapStrategy,
   )
 import Grisette.Internal.SymPrim.AlgReal (AlgReal, AlgRealPoly, RealPoint)
+import Grisette.Internal.SymPrim.Array (Array)
 import Grisette.Internal.SymPrim.BV
   ( IntN,
     WordN,
@@ -103,6 +104,7 @@ import Grisette.Internal.SymPrim.FP
   )
 import Grisette.Internal.SymPrim.GeneralFun (type (-->))
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal)
+import Grisette.Internal.SymPrim.SymArray (SymArray)
 import Grisette.Internal.SymPrim.SymBV (SymIntN, SymWordN)
 import Grisette.Internal.SymPrim.SymFP (SymFP, SymFPRoundingMode)
 import Grisette.Internal.SymPrim.SymGeneralFun (type (-~>))
@@ -111,6 +113,7 @@ import Grisette.Internal.SymPrim.SymTabularFun (type (=~>))
 import Grisette.Internal.SymPrim.TabularFun (type (=->))
 import Grisette.Internal.TH.Derivation.Derive (derive)
 import Unsafe.Coerce (unsafeCoerce)
+import Grisette.Internal.SymPrim.Prim.Internal.Term (SupportedNonFuncPrim, LinkedRep)
 
 #define CONCRETE_ORD_MERGEABLE(type) \
 instance Mergeable type where \
@@ -175,6 +178,9 @@ instance Mergeable (a =-> b) where
 instance Mergeable (a --> b) where
   rootStrategy = SimpleStrategy symIte
 
+instance Mergeable (Array k v) where
+  rootStrategy = NoStrategy
+
 #define MERGEABLE_SIMPLE(symtype) \
 instance Mergeable symtype where \
   rootStrategy = SimpleStrategy symIte
@@ -196,6 +202,15 @@ MERGEABLE_BV(SymWordN)
 MERGEABLE_FUN((=->), (=~>), SymTabularFun)
 MERGEABLE_FUN((-->), (-~>), SymGeneralFun)
 #endif
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  Mergeable (SymArray sk sv) where
+  rootStrategy = SimpleStrategy $ symIte
 
 instance (ValidFP eb sb) => Mergeable (SymFP eb sb) where
   rootStrategy = SimpleStrategy symIte

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SimpleMergeable.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SimpleMergeable.hs
@@ -78,10 +78,11 @@ import Grisette.Internal.Internal.Decl.Core.Data.Class.SimpleMergeable
 import Grisette.Internal.Internal.Impl.Core.Data.Class.TryMerge ()
 import Grisette.Internal.SymPrim.FP (ValidFP)
 import Grisette.Internal.SymPrim.GeneralFun (freshArgSymbol, substTerm, type (-->) (GeneralFun))
-import Grisette.Internal.SymPrim.Prim.Internal.Term (SupportedPrim (pevalITETerm), symTerm)
+import Grisette.Internal.SymPrim.Prim.Internal.Term (SupportedPrim (pevalITETerm), LinkedRep, symTerm)
 import Grisette.Internal.SymPrim.Prim.SomeTerm (SomeTerm (SomeTerm))
-import Grisette.Internal.SymPrim.Prim.Term (TypedConstantSymbol)
+import Grisette.Internal.SymPrim.Prim.Term (TypedConstantSymbol, SupportedNonFuncPrim)
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
+import Grisette.Internal.SymPrim.SymArray (SymArray (SymArray))
 import Grisette.Internal.SymPrim.SymBV
   ( SymIntN (SymIntN),
     SymWordN (SymWordN),
@@ -558,6 +559,15 @@ SIMPLE_MERGEABLE_BV(SymWordN)
 SIMPLE_MERGEABLE_FUN((=->), (=~>), SymTabularFun)
 SIMPLE_MERGEABLE_FUN((-->), (-~>), SymGeneralFun)
 #endif
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  SimpleMergeable (SymArray sk sv) where
+  mrgIte (SymBool c) (SymArray t) (SymArray f) = SymArray $ pevalITETerm c t f
 
 instance SimpleMergeable (a --> b) where
   mrgIte

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymEq.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymEq.hs
@@ -80,8 +80,9 @@ import Grisette.Internal.SymPrim.FP
   )
 import Grisette.Internal.SymPrim.Prim.Term
   ( SupportedPrim (pevalDistinctTerm),
+    LinkedRep (underlyingTerm, wrapTerm),
+    SupportedNonFuncPrim,
     pevalEqTerm,
-    underlyingTerm,
   )
 import Grisette.Internal.SymPrim.SymAlgReal (SymAlgReal (SymAlgReal))
 import Grisette.Internal.SymPrim.SymBV
@@ -95,6 +96,7 @@ import Grisette.Internal.SymPrim.SymFP
   )
 import Grisette.Internal.SymPrim.SymInteger (SymInteger (SymInteger))
 import Grisette.Internal.TH.Derivation.Derive (derive)
+import Grisette.Internal.SymPrim.SymArray (SymArray)
 
 #define CONCRETE_SEQ(type) \
 instance SymEq type where \
@@ -184,6 +186,15 @@ SEQ_BV(SymWordN)
 instance (ValidFP eb sb) => SymEq (SymFP eb sb) where
   (SymFP l) .== (SymFP r) = SymBool $ pevalEqTerm l r
   {-# INLINE (.==) #-}
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  SymEq (SymArray sk sv) where
+  lhs .== rhs = wrapTerm $ pevalEqTerm (underlyingTerm lhs) (underlyingTerm rhs)
 
 derive
   [ ''(),

--- a/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymOrd.hs
+++ b/src/Grisette/Internal/Internal/Impl/Core/Data/Class/SymOrd.hs
@@ -100,10 +100,7 @@ import Grisette.Internal.SymPrim.SymBV
     SymWordN (SymWordN),
   )
 import Grisette.Internal.SymPrim.SymBool (SymBool (SymBool))
-import Grisette.Internal.SymPrim.SymFP
-  ( SymFP (SymFP),
-    SymFPRoundingMode (SymFPRoundingMode),
-  )
+import Grisette.Internal.SymPrim.SymFP (SymFP (SymFP))
 import Grisette.Internal.SymPrim.SymInteger (SymInteger (SymInteger))
 import Grisette.Internal.TH.Derivation.Derive (derive)
 
@@ -254,7 +251,6 @@ instance SymOrd SymBool where
 #if 1
 SORD_SIMPLE(SymInteger)
 SORD_SIMPLE(SymAlgReal)
-SORD_SIMPLE(SymFPRoundingMode)
 SORD_BV(SymIntN)
 SORD_BV(SymWordN)
 #endif

--- a/src/Grisette/Internal/SymPrim/Array.hs
+++ b/src/Grisette/Internal/SymPrim/Array.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+
+-- |
+-- Module      :   Grisette.Internal.SymPrim.Array
+-- Copyright   :   (c) Sirui Lu 2021-2023
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Internal.SymPrim.Array
+  ( Array (..)
+  , const
+  , select
+  , store
+  ) where
+
+import Control.DeepSeq (NFData)
+import Data.Binary qualified as Binary
+import Data.Bytes.Serial (Serial (serialize, deserialize))
+import Data.Hashable (Hashable)
+import Data.HashMap.Strict qualified as HM
+import Data.Serialize qualified as Cereal
+import GHC.Generics (Generic)
+import Language.Haskell.TH.Syntax (Lift)
+import Prelude (Show, Eq, Ord)
+
+-- TODO: The equality of this array model is incorrect. The easy solution is
+-- to disallow it entirely. Alternatively, I already have a version with a
+-- working equality check. It works by canonicalising the array.
+--
+-- Canonicalisation will not happen for keys with an infinite domain and
+-- realistically also not for keys with a sufficiently large domain. In fact,
+-- we avoid tracking information for canonicalisation in these cases altogether!
+-- The main gripe with this is that at that point is that insertions do require
+-- keys for which we know both their cardinality and can enumerate their domain.
+-- The latter we could restrict to only enumerable domains given a finite
+-- cardinality with type-level shenanigans, but still.
+--
+-- Yet another alternative would be to simply accept that we cannot conclude
+-- inequality if one of the arrays would require canonicalisation? Then we don't
+-- need the additional typeclass constraints. This way, we could still perform
+-- normalisation of most terms.
+data Array k v = Array (HM.HashMap k v) v
+  deriving (Show, Eq, Ord, Generic, Lift, Hashable, NFData)
+
+instance (Hashable k, Serial k, Serial v) => Serial (Array k v)
+
+instance (Hashable k, Serial k, Serial v) => Cereal.Serialize (Array k v) where
+  put = serialize
+  get = deserialize
+
+instance (Hashable k, Serial k, Serial v) => Binary.Binary (Array k v) where
+  put = serialize
+  get = deserialize
+
+-- TODO: Perhaps it is nice to make this a typeclass and give it names that do
+-- not require qualified imports? I don't necessarily mind the qualified import,
+-- but we'll see what the library author thinks.
+const :: forall k v. v -> Array k v
+const = Array HM.empty
+
+select :: forall k v. Hashable k => Array k v -> k -> v
+select (Array entries root) key = HM.lookupDefault root key entries
+
+store :: forall k v. Hashable k => Array k v -> k -> v -> Array k v
+store (Array entries root) key value = do
+  let entries' = HM.insert key value entries
+  Array entries' root

--- a/src/Grisette/Internal/SymPrim/GeneralFun.hs
+++ b/src/Grisette/Internal/SymPrim/GeneralFun.hs
@@ -100,6 +100,9 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
     PEvalOrdTerm (pevalLeOrdTerm, pevalLtOrdTerm),
     PEvalRotateTerm (pevalRotateRightTerm),
     PEvalShiftTerm (pevalShiftLeftTerm, pevalShiftRightTerm),
+    pevalSelectTerm,
+    pevalStoreTerm,
+    pevalConstArrayTerm,
     SBVRep (SBVType),
     SomeTypedAnySymbol,
     SomeTypedConstantSymbol,
@@ -189,6 +192,9 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
     pattern SymTerm,
     pattern ToFPTerm,
     pattern XorBitsTerm,
+    pattern SelectTerm,
+    pattern StoreTerm,
+    pattern ConstArrayTerm,
   )
 import Grisette.Internal.SymPrim.Prim.Pattern (pattern SubTerms)
 import Grisette.Internal.SymPrim.Prim.SomeTerm (SomeTerm (SomeTerm), someTerm)
@@ -542,6 +548,12 @@ generalSubstSomeTerm subst initialBoundedSymbols = go initialMemo
       _
       (SomeTerm (ToFPTerm mode (arg :: Term a) (_ :: p eb) (_ :: q sb))) =
         goBinary memo (pevalToFPTerm @a @eb @sb) mode arg
+    goSome  memo _ (SomeTerm (SelectTerm arr key)) =
+      goBinary memo pevalSelectTerm arr key
+    goSome  memo _ (SomeTerm (StoreTerm arr key val)) =
+      goTernary memo pevalStoreTerm arr key val
+    goSome  memo _ (SomeTerm (ConstArrayTerm pkey val)) =
+      goUnary memo (pevalConstArrayTerm pkey) val
     goUnary memo f a = SomeTerm $ f (go memo a)
     goBinary memo f a b = SomeTerm $ f (go memo a) (go memo b)
     goTernary memo f a b c =

--- a/src/Grisette/Internal/SymPrim/Prim/Pattern.hs
+++ b/src/Grisette/Internal/SymPrim/Prim/Pattern.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 -- |
@@ -19,6 +21,7 @@ where
 import Data.Foldable (Foldable (toList))
 import Grisette.Internal.SymPrim.Prim.Internal.Term
   ( Term,
+    SupportedPrim (withPrim),
     pattern AbsNumTerm,
     pattern AddNumTerm,
     pattern AndBitsTerm,
@@ -67,10 +70,13 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
     pattern SymTerm,
     pattern ToFPTerm,
     pattern XorBitsTerm,
+    pattern SelectTerm,
+    pattern StoreTerm,
+    pattern ConstArrayTerm,
   )
 import Grisette.Internal.SymPrim.Prim.SomeTerm (SomeTerm (SomeTerm))
 
-subTermsViewPattern :: Term a -> Maybe [SomeTerm]
+subTermsViewPattern :: forall a. Term a -> Maybe [SomeTerm]
 subTermsViewPattern (ConTerm _) = return []
 subTermsViewPattern (SymTerm _) = return []
 subTermsViewPattern (ForallTerm _ t) = return [SomeTerm t]
@@ -121,6 +127,9 @@ subTermsViewPattern (FPFMATerm rd t1 t2 t3) =
 subTermsViewPattern (FromIntegralTerm t) = return [SomeTerm t]
 subTermsViewPattern (FromFPOrTerm t1 rd t2) = return [SomeTerm t1, SomeTerm rd, SomeTerm t2]
 subTermsViewPattern (ToFPTerm rd t1 _ _) = return [SomeTerm rd, SomeTerm t1]
+subTermsViewPattern (SelectTerm (t1 :: Term arr) t2) = withPrim @arr $ return [SomeTerm t1, SomeTerm t2]
+subTermsViewPattern (StoreTerm t1 t2 t3) = withPrim @a $ return [SomeTerm t1, SomeTerm t2, SomeTerm t3]
+subTermsViewPattern (ConstArrayTerm _ t1) = withPrim @a $ return [SomeTerm t1]
 
 -- | Extract all the subterms of a term.
 pattern SubTerms :: [SomeTerm] -> Term a

--- a/src/Grisette/Internal/SymPrim/SymArray.hs
+++ b/src/Grisette/Internal/SymPrim/SymArray.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- |
+-- Module      :   Grisette.Internal.SymPrim.Array
+-- Copyright   :   (c) Sirui Lu 2021-2023
+-- License     :   BSD-3-Clause (see the LICENSE file)
+--
+-- Maintainer  :   siruilu@cs.washington.edu
+-- Stability   :   Experimental
+-- Portability :   GHC only
+module Grisette.Internal.SymPrim.SymArray 
+  ( SymArray (..)
+  , const
+  , select
+  , store
+  ) where
+
+import Control.DeepSeq (NFData)
+import Data.Binary qualified as Binary
+import Data.Bytes.Serial (Serial (deserialize, serialize))
+import Data.Data (Proxy(Proxy))
+import Data.Serialize qualified as Cereal
+import Data.String (IsString (fromString))
+import Grisette.Internal.SymPrim.Array (Array)
+import Grisette.Internal.SymPrim.Prim.Internal.Term
+  ( Term
+  , SupportedNonFuncPrim
+  , ConRep (ConType)
+  , SymRep (SymType)
+  , LinkedRep (underlyingTerm, wrapTerm)
+  , conTerm
+  , typedConstantSymbol
+  , symTerm
+  , pattern ConTerm
+  , pattern SelectTerm
+  , pattern StoreTerm
+  , pattern ConstArrayTerm
+  )
+import Grisette.Internal.SymPrim.Prim.Internal.Serialize ()
+import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con, sym, conView), ssym)
+import GHC.Generics (Generic)
+import Language.Haskell.TH.Syntax (Lift)
+import Prelude (Maybe (Just, Nothing), (<$>), ($), (.))
+
+newtype SymArray k v = SymArray { underlyingArrayTerm :: Term (Array (ConType k) (ConType v)) }
+  deriving (Lift, NFData, Generic)
+
+instance ConRep (SymArray k v) where
+  type ConType (SymArray k v) = Array (ConType k) (ConType v)
+
+instance (SupportedNonFuncPrim k, SupportedNonFuncPrim v) => SymRep (Array k v) where
+  type SymType (Array k v) = SymArray (SymType k) (SymType v)
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  LinkedRep (Array ck cv) (SymArray sk sv) where
+  underlyingTerm = underlyingArrayTerm
+  wrapTerm = SymArray
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  Solvable (Array ck cv) (SymArray sk sv) where
+  con = wrapTerm . conTerm
+  sym = wrapTerm . symTerm . typedConstantSymbol
+  conView v = case underlyingTerm v of
+    ConTerm t -> Just t
+    _ -> Nothing
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  IsString (SymArray sk sv) where
+  fromString = ssym . fromString
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  Serial (SymArray sk sv) where
+  serialize = serialize . underlyingArrayTerm
+  deserialize = SymArray <$> deserialize
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  Cereal.Serialize (SymArray sk sv) where
+  put = serialize
+  get = deserialize
+
+instance
+  ( SupportedNonFuncPrim ck,
+    SupportedNonFuncPrim cv,
+    LinkedRep ck sk,
+    LinkedRep cv sv
+  ) =>
+  Binary.Binary (SymArray sk sv) where
+  put = serialize
+  get = deserialize
+
+const
+  :: forall k v
+   . SupportedNonFuncPrim (ConType k)
+  => SupportedNonFuncPrim (ConType v)
+  => LinkedRep (ConType k) k
+  => LinkedRep (ConType v) v
+  => v
+  -> SymArray k v
+const val = wrapTerm $ ConstArrayTerm Proxy (underlyingTerm val)
+
+select
+  :: forall k v
+   . SupportedNonFuncPrim (ConType k)
+  => SupportedNonFuncPrim (ConType v)
+  => LinkedRep (ConType k) k
+  => LinkedRep (ConType v) v
+  => SymArray k v
+  -> k
+  -> v
+select arr key = wrapTerm $ SelectTerm (underlyingTerm arr) (underlyingTerm key)
+
+store
+  :: forall k v
+   . SupportedNonFuncPrim (ConType k)
+  => SupportedNonFuncPrim (ConType v)
+  => LinkedRep (ConType k) k
+  => LinkedRep (ConType v) v
+  => SymArray k v
+  -> k
+  -> v
+  -> SymArray k v
+store arr key val = do
+  wrapTerm $ StoreTerm (underlyingTerm arr) (underlyingTerm key) (underlyingTerm val)

--- a/src/Grisette/Internal/SymPrim/SymArray.hs
+++ b/src/Grisette/Internal/SymPrim/SymArray.hs
@@ -42,6 +42,7 @@ import Grisette.Internal.SymPrim.Prim.Internal.Term
   , conTerm
   , typedConstantSymbol
   , symTerm
+  , pformatTerm
   , pattern ConTerm
   , pattern SelectTerm
   , pattern StoreTerm
@@ -51,7 +52,7 @@ import Grisette.Internal.SymPrim.Prim.Internal.Serialize ()
 import Grisette.Internal.Core.Data.Class.Solvable (Solvable (con, sym, conView), ssym)
 import GHC.Generics (Generic)
 import Language.Haskell.TH.Syntax (Lift)
-import Prelude (Maybe (Just, Nothing), (<$>), ($), (.))
+import Prelude (Show (show), Maybe (Just, Nothing), (<$>), ($), (.))
 
 newtype SymArray k v = SymArray { underlyingArrayTerm :: Term (Array (ConType k) (ConType v)) }
   deriving (Lift, NFData, Generic)
@@ -94,6 +95,9 @@ instance
   IsString (SymArray sk sv) where
   fromString = ssym . fromString
 
+instance Show (SymArray sk sv) where
+  show = pformatTerm . underlyingArrayTerm
+
 instance
   ( SupportedNonFuncPrim ck,
     SupportedNonFuncPrim cv,
@@ -101,8 +105,8 @@ instance
     LinkedRep cv sv
   ) =>
   Serial (SymArray sk sv) where
-  serialize = serialize . underlyingArrayTerm
-  deserialize = SymArray <$> deserialize
+  serialize = serialize . underlyingTerm
+  deserialize = wrapTerm <$> deserialize
 
 instance
   ( SupportedNonFuncPrim ck,

--- a/src/Grisette/SymPrim.hs
+++ b/src/Grisette/SymPrim.hs
@@ -290,6 +290,9 @@ module Grisette.SymPrim
     pattern FromIntegralTerm,
     pattern FromFPOrTerm,
     pattern ToFPTerm,
+    pattern SelectTerm,
+    pattern StoreTerm,
+    pattern ConstArrayTerm,
     pattern SubTerms,
   )
 where
@@ -416,6 +419,9 @@ import Grisette.Internal.SymPrim.Prim.Term
     pattern SupportedTypedSymbol,
     pattern SymTerm,
     pattern ToFPTerm,
+    pattern SelectTerm,
+    pattern StoreTerm,
+    pattern ConstArrayTerm,
     pattern XorBitsTerm,
   )
 import Grisette.Internal.SymPrim.Prim.TermUtils

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -33,13 +33,11 @@ packages:
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
 #
-# extra-deps:
-# - acme-missiles-0.3
-# - git: https://github.com/commercialhaskell/stack.git
-#   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 #
 # Override default flag values for local packages and extra-deps
 # flags: {}
+extra-deps:
+- sbv-13.5
 
 # Extra package databases containing global packages
 # extra-package-dbs: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/topics/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: sbv-13.5@sha256:00aea86ad09dcefb5d5286dd68bfb894709d2874052bcdadf80af3add9596af7,26690
+    pantry-tree:
+      sha256: 65d23f68088ce549e8aa8ae77a35f2ec7c6491facbc4aeae8c2317101d9ddcda
+      size: 93933
+  original:
+    hackage: sbv-13.5
 snapshots:
 - completed:
     sha256: 7a26eba54b469fc72b1e37b881dfec480a2c1cb0636136f96aec7d81be6c762f


### PR DESCRIPTION
Hey!

I wanted to use the theory of arrays within `Grisette`, so I added support for it. It works from beginning to end (i.e. I can use `SymArray` and read a counterexample back from the `SMT` solver). It still is a bit rough though in some places, so maybe it is best to **not merge immediately**!

Here are the caveats:
1. It requires a version of `SBV` that is not yet on stackage. I needed to extend `SBV` in order to properly support this, I'm still waiting for some of the changes to be merged on the `SBV` side of things. Additionally, this will not support any previous version of `SBV` as it indeed only compiles with these changes. I'm not sure how to go about this breakage.
2. There are no partial evaluation optimisations (yet). There are plenty of things one could do here and it is my intent to actually implement them as I need the arrays to be performant.
3. I have not tested the code-paths for serialisation and deserialisation. I think I implemented them (mostly) correct, but very likely I made a mistake there somewhere!
4. The concrete array equivalence is incorrect. I wrote some possible solutions as annotation to this, but we'll have to see how to best handle this.
5. Anything else that I may have missed (e.g. maybe some typeclass instances for `Array` and `SymArray`)

As an aside, I had to remove the instance for `SymOrd` for `RoundingMode` as `SBV` stopped supporting `OrdSymbolic` for it. This is in fact fine, because the SMT solvers do not even support the ordering relation.

I also rewrote some of the functions that involved `Typeable`: I needed to extend them anyway and I feel like the current rewrite is a lot more intuitive.